### PR TITLE
Refactor `Exchange` protocol to support stateful `Mailbox` clients

### DIFF
--- a/aeris/multiplex.py
+++ b/aeris/multiplex.py
@@ -66,6 +66,7 @@ class MailboxMultiplexer:
         self.exchange = exchange
         self.request_handler = request_handler
         self.bound_handles: dict[uuid.UUID, BoundRemoteHandle[Any]] = {}
+        self._mailbox = self.exchange.get_mailbox(mailbox_id)
 
     def __enter__(self) -> Self:
         return self
@@ -132,6 +133,7 @@ class MailboxMultiplexer:
 
         Closes all handles bound to this mailbox and then closes the mailbox.
         """
+        self._mailbox.close()
         self.close_bound_handles()
         self.close_mailbox()
 
@@ -166,7 +168,7 @@ class MailboxMultiplexer:
 
         while True:
             try:
-                message = self.exchange.recv(self.mailbox_id)
+                message = self._mailbox.recv()
             except MailboxClosedError:
                 break
             else:

--- a/tests/exchange/queue_test.py
+++ b/tests/exchange/queue_test.py
@@ -34,6 +34,9 @@ def test_queue() -> None:
     received = queue.get()
     assert message == received
 
+    with pytest.raises(TimeoutError):
+        queue.get(timeout=0.001)
+
     queue.close()
     queue.close()  # Idempotent check
 

--- a/tests/manager_test.py
+++ b/tests/manager_test.py
@@ -44,9 +44,11 @@ def test_reply_to_requests_with_error() -> None:
         client_id = manager.exchange.create_client()
         request = PingRequest(src=client_id, dest=manager.mailbox_id)
         manager.exchange.send(request.dest, request)
-        response = manager.exchange.recv(client_id)
+        mailbox = manager.exchange.get_mailbox(client_id)
+        response = mailbox.recv()
         assert isinstance(response, PingResponse)
         assert isinstance(response.exception, TypeError)
+        mailbox.close()
 
 
 def test_wait_bad_identifier(exchange: ThreadExchange) -> None:


### PR DESCRIPTION
# Description
<!--- Describe your changes in detail --->

This change was motivated by the desire to enable peer-to-peer messaging between entities. To achieve this, entities need to "bind" themselves to a mailbox and listen for messages sent to that mailbox. The current `Exchange` protocol had no mechanism to say "I am the destination for any messages sent a specific address." Rather, it just had a "check if there's a new message in a mailbox that lives elsewhere" mechanism.

Now, `Exchange.recv(uid)` has been removed and replaced by `Exchange.get_mailbox(uid)` which returns a `Mailbox` instance with a `recv()` method. This means that by initializing a `Mailbox`, an entity can initialize mechanisms to listen for incoming messages.

### Fixes N/A
<!--- List any issue numbers above that this PR addresses --->

### Type of Change
<!--- Check which off the following types describe this PR --->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (internal implementation changes)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (no changes to the code)
- [ ] CI change (changes to CI workflows, packages, templates, etc.)
- [ ] Version changes (changes to the package or dependency versions)

## Testing
<!--- Please describe the test ran to verify changes --->

N/A

## Pull Request Checklist

Please confirm the PR meets the following requirements.
- [x] Relevant tags are added (breaking, bug, dependencies, documentation, enhancement, refactor).
- [x] Code changes pass `pre-commit` (e.g., ruff, mypy, etc.).
- [x] Tests have been added to show the fix is effective or that the new feature works.
- [x] New and existing unit tests pass locally with the changes.
- [x] Docs have been updated and reviewed if relevant.
