### PR TITLE
Add helper data structures for behavior handle binding

### DIFF
--- a/tests/behavior_test.py
+++ b/tests/behavior_test.py
@@ -6,6 +6,9 @@ import pytest
 
 from aeris.behavior import Behavior
 from aeris.behavior import loop
+from aeris.handle import Handle
+from aeris.handle import HandleDict
+from aeris.handle import HandleList
 from aeris.handle import ProxyHandle
 from testing.behavior import EmptyBehavior
 from testing.behavior import HandleBehavior
@@ -67,6 +70,31 @@ def test_behavior_handles() -> None:
 
     handles = behavior.behavior_handles()
     assert set(handles) == {'handle'}
+
+    behavior.on_shutdown()
+
+
+def test_behavior_handles_bind() -> None:
+    class _TestBehavior(Behavior):
+        def __init__(self, handle: Handle[EmptyBehavior]) -> None:
+            self.direct = handle
+            self.sequence = HandleList([handle])
+            self.mapping = HandleDict({'x': handle})
+
+    expected_binds = 3
+    bind_count = 0
+
+    def _bind_handle(handle: Handle[EmptyBehavior]) -> Handle[EmptyBehavior]:
+        nonlocal bind_count
+        bind_count += 1
+        return handle
+
+    handle = ProxyHandle(EmptyBehavior())
+    behavior = _TestBehavior(handle)
+    behavior.on_setup()
+
+    behavior.behavior_handles_bind(_bind_handle)
+    assert bind_count == expected_binds
 
     behavior.on_shutdown()
 


### PR DESCRIPTION
# Description
<!--- Describe your changes in detail --->

When an agent is started and begins executing a `Behavior`, the agent binds all `Handle` instances that are attributes of the `Behavior` to the agent's mailbox. This essentially says that "the return address of all actions requested by this handle is the current agent." However, the binding logic was very trivial and just looked at attributes of the `Behavior`. This meant that lists or dicts of handles would not get bound.

This PR adds a `HandleDict` and `HandleList` class to `aeris.handle` to help the binding logic discover all handles that a behavior has. These classes are simple wrappers around `dict` and `list` respectively. I also moved some of this logic from the `Agent` into the `Behavior`.

Example:
```python
from aeris.behavior import Behavior
from aeris.handle import HandleDict, HandleList

class Example(Behavior):
    def __init__(
        self,
        handle: Handle[Any],
        handle_dict: dict[str, Handle[Any]],
        handle_list: list[Handle[Any]],
    ) -> None:
        self.direct = handle
        self.mapping = HandleDict(handle_dict)
        self.sequence = HandleList(handle_list)
```

### Fixes N/A
<!--- List any issue numbers above that this PR addresses --->

### Type of Change
<!--- Check which off the following types describe this PR --->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (internal implementation changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (no changes to the code)
- [ ] CI change (changes to CI workflows, packages, templates, etc.)
- [ ] Version changes (changes to the package or dependency versions)

## Testing
<!--- Please describe the test ran to verify changes --->

Added a unit test.

## Pull Request Checklist

Please confirm the PR meets the following requirements.
- [x] Relevant tags are added (breaking, bug, dependencies, documentation, enhancement, refactor).
- [x] Code changes pass `pre-commit` (e.g., ruff, mypy, etc.).
- [x] Tests have been added to show the fix is effective or that the new feature works.
- [x] New and existing unit tests pass locally with the changes.
- [x] Docs have been updated and reviewed if relevant.
