### PR TITLE
Add restart on failures to `ExecutorLauncher` and separate shutdown from termination

### DIFF
--- a/aeris/launcher/executor.py
+++ b/aeris/launcher/executor.py
@@ -17,6 +17,7 @@ else:  # pragma: <3.11 cover
     from typing_extensions import Self
 
 from aeris.agent import Agent
+from aeris.agent import AgentRunConfig
 from aeris.behavior import Behavior
 from aeris.exception import BadIdentifierError
 from aeris.exchange import Exchange
@@ -128,7 +129,10 @@ class ExecutorLauncher:
             acb.behavior,
             agent_id=acb.agent_id,
             exchange=acb.exchange,
-            close_exchange=self._close_exchange,
+            config=AgentRunConfig(
+                close_exchange_on_exit=self._close_exchange,
+                terminate_on_error=acb.launch_count + 1 >= self._max_restarts,
+            ),
         )
         future = self._executor.submit(_run_agent_on_worker, agent)
         acb.launch_count += 1

--- a/aeris/launcher/thread.py
+++ b/aeris/launcher/thread.py
@@ -15,6 +15,7 @@ else:  # pragma: <3.11 cover
     from typing_extensions import Self
 
 from aeris.agent import Agent
+from aeris.agent import AgentRunConfig
 from aeris.behavior import Behavior
 from aeris.exception import BadIdentifierError
 from aeris.exchange import Exchange
@@ -93,7 +94,7 @@ class ThreadLauncher:
             behavior,
             agent_id=agent_id,
             exchange=exchange,
-            close_exchange=False,
+            config=AgentRunConfig(close_exchange_on_exit=False),
         )
         thread = threading.Thread(target=agent, name=f'{self}-{agent_id}')
         thread.start()

--- a/tests/agent_test.py
+++ b/tests/agent_test.py
@@ -7,6 +7,7 @@ from concurrent.futures import Future
 import pytest
 
 from aeris.agent import Agent
+from aeris.agent import AgentRunConfig
 from aeris.behavior import action
 from aeris.behavior import Behavior
 from aeris.behavior import loop
@@ -63,6 +64,23 @@ def test_agent_start_shutdown(exchange: Exchange) -> None:
 
     assert agent.behavior.setup_event.is_set()
     assert agent.behavior.shutdown_event.is_set()
+
+
+def test_agent_shutdown_without_terminate(exchange: Exchange) -> None:
+    agent_id = exchange.create_agent()
+    agent = Agent(
+        SignalingBehavior(),
+        agent_id=agent_id,
+        exchange=exchange,
+        config=AgentRunConfig(
+            close_exchange_on_exit=False,
+            terminate_on_exit=False,
+        ),
+    )
+    agent.start()
+    agent.shutdown()
+    # Verify mailbox is open
+    exchange.send(agent_id, PingRequest(src=agent_id, dest=agent_id))
 
 
 def test_agent_shutdown_without_start(exchange: Exchange) -> None:


### PR DESCRIPTION
# Description
<!--- Describe your changes in detail --->

`ExecutorLauncher` supports a `max_restarts` parameter (defaults to 0) for auto-restarting agents. This requires ensuring the agents mailbox is not closed, so we also had to add support for handling shutdown from termination differently.

### Fixes
<!--- List any issue numbers above that this PR addresses --->

- Fixes: #47
- Fixes: #48
- Fixes: #50

### Type of Change
<!--- Check which off the following types describe this PR --->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (internal implementation changes)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (no changes to the code)
- [ ] CI change (changes to CI workflows, packages, templates, etc.)
- [ ] Version changes (changes to the package or dependency versions)

## Testing
<!--- Please describe the test ran to verify changes --->

Added more unit tests.

## Pull Request Checklist

Please confirm the PR meets the following requirements.
- [x] Relevant tags are added (breaking, bug, dependencies, documentation, enhancement, refactor).
- [x] Code changes pass `pre-commit` (e.g., ruff, mypy, etc.).
- [x] Tests have been added to show the fix is effective or that the new feature works.
- [x] New and existing unit tests pass locally with the changes.
- [x] Docs have been updated and reviewed if relevant.
