### PR TITLE
Fix `EntityId` validation error in pydantic<2.10

### DIFF
--- a/academy/identifier.py
+++ b/academy/identifier.py
@@ -6,6 +6,7 @@ from typing import Any
 from typing import Generic
 from typing import Literal
 from typing import Optional
+from typing import TYPE_CHECKING
 from typing import TypeVar
 from typing import Union
 
@@ -89,5 +90,14 @@ class UserId(BaseModel):
         return cls(uid=uuid.uuid4(), name=name)
 
 
-EntityId = Union[AgentId[Any], UserId]
-"""EntityId union type for type annotations."""
+if TYPE_CHECKING:
+    EntityId = Union[AgentId[Any], UserId]
+    """EntityId union type for type annotations."""
+else:
+    # Pydantic produces validation errors with Agent[Any] in versions
+    # prior to 2.10.0. We could require academy to use newer versions of
+    # pydantic but this could be a headache for third-party apps with
+    # stricter requirements.
+    # Issue: https://github.com/pydantic/pydantic/issues/9414
+    # Fix: https://github.com/pydantic/pydantic/pull/10666
+    EntityId = Union[AgentId, UserId]


### PR DESCRIPTION
# Description
<!--- Describe your changes in detail --->

Using Academy with pydantic 2.9.2 and older produces a `ValidationError` on all message types where the src/dest is an `AgentId`. 
```
pydantic_core._pydantic_core.ValidationError: 2 validation errors for ShutdownRequest
dest.AgentId[Any]
  Input should be a valid dictionary or instance of AgentId[Any] [type=model_type, input_value=AgentId(uid=UUID('c087cfc...0ebfb72218'), name=None), input_type=AgentId]
    For further information visit https://errors.pydantic.dev/2.9/v/model_type
dest.UserId
  Input should be a valid dictionary or instance of UserId [type=model_type, input_value=AgentId(uid=UUID('c087cfc...0ebfb72218'), name=None), input_type=AgentId]
    For further information visit https://errors.pydantic.dev/2.9/v/model_type
```

The suggested fix to maintain backwards compatibility with older pydantic versions is described here: https://github.com/pydantic/pydantic/issues/9414#issuecomment-2140808897

### Fixes N/A
<!--- List any issue numbers above that this PR addresses --->

### Type of Change
<!--- Check which off the following types describe this PR --->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (internal implementation changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (no changes to the code)
- [ ] CI change (changes to CI workflows, packages, templates, etc.)
- [ ] Version changes (changes to the package or dependency versions)

## Testing
<!--- Please describe the test ran to verify changes --->

Replicated the issue with the examples and checked they work after the change.

## Pull Request Checklist

Please confirm the PR meets the following requirements.
- [x] Relevant tags are added (breaking, bug, dependencies, documentation, enhancement, refactor).
- [x] Code changes pass `pre-commit` (e.g., ruff, mypy, etc.).
- [x] Tests have been added to show the fix is effective or that the new feature works.
- [x] New and existing unit tests pass locally with the changes.
- [x] Docs have been updated and reviewed if relevant.
