### PR TITLE
Improve ordering of agent setup and shutdown processes

### DIFF
--- a/academy/behavior.py
+++ b/academy/behavior.py
@@ -242,16 +242,18 @@ class Behavior:
         return tuple(f'{t.__module__}.{t.__qualname__}' for t in mro)
 
     async def on_setup(self) -> None:
-        """Setup up resources needed for the agents execution.
+        """Callback invoked at the end of an agent's setup sequence.
 
-        This is called before any control loop threads are started.
+        See [`Agent.run()`][academy.agent.Agent.run] for more details on the
+        setup sequence.
         """
         pass
 
     async def on_shutdown(self) -> None:
-        """Shutdown resources after the agents execution.
+        """Callback invoked at the beginning of an agent's shutdown sequence.
 
-        This is called after control loop threads have exited.
+        See [`Agent.run()`][academy.agent.Agent.run] for more details on the
+        shutdown sequence.
         """
         pass
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -35,5 +35,11 @@ This section highlights common best practices for developing applications in Aca
 
 ### Avoid communication operations during behavior initialization
 
-The `__init__` and [`on_setup()`][academy.behavior.Behavior.on_setup] methods of a [`Behavior`][academy.behavior.Behavior] are called during the setup process of an agent but before the agent is in a running state.
-Thus, communication operations, such as invoking an action on a remote agent, can cause setup to hang.
+The `__init__` method of a [`Behavior`][academy.behavior.Behavior] is called in one of two places:
+
+1. On the client when submitting an instantiated behavior to be executed.
+1. On the agent at the start of the setup sequence when the behavior instantiation is deferred.
+
+In both scenarios, it is unsafe to perform communication operations (i.e., invoking an action on a remote agent) in `__init__` because connection resources and background tasks have not yet been initialized.
+
+The [`Behavior.on_setup()`][academy.behavior.Behavior.on_setup] callback can be used instead to perform communication once the agent is in a running state.

--- a/testing/behavior.py
+++ b/testing/behavior.py
@@ -62,9 +62,6 @@ class SleepBehavior(Behavior):
         self.loop_sleep = loop_sleep
         self.steps = 0
 
-    async def on_shutdown(self) -> None:
-        assert self.steps > 0
-
     @action
     async def sleep(self, sleep: float) -> None:
         await asyncio.sleep(sleep)


### PR DESCRIPTION
# Description
<!--- Describe your changes in detail --->

Improves the ordering of agent setup and shutdown to achieve two goals:
* `on_setup()` and `on_shutdown()` are called when the agent is still in a running/valid state of agent operations.
* Agent shutdown is the reverse of agent setup.

To achieve these goals:
* `on_setup()` is called at the end of agent setup
* `on_shutdown()` remains called at the start of shutdown
* Mailbox listener task is started before starting control loop tasks in setup
* Mailbox listener task is stopped after stopping control loop tasks in shutdown

This ensures that `on_setup`/`on_shutdown` callbacks do not error if they perform some communication, and that control loops don't end up in an invalid state by trying to perform some communication after the mailbox listener task has been stopped.

### Fixes N/A
<!--- List any issue numbers above that this PR addresses --->

### Type of Change
<!--- Check which off the following types describe this PR --->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (internal implementation changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (no changes to the code)
- [ ] CI change (changes to CI workflows, packages, templates, etc.)
- [ ] Version changes (changes to the package or dependency versions)

## Testing
<!--- Please describe the test ran to verify changes --->

N/A

## Pull Request Checklist

Please confirm the PR meets the following requirements.
- [x] Relevant tags are added (breaking, bug, dependencies, documentation, enhancement, refactor).
- [x] Code changes pass `pre-commit` (e.g., ruff, mypy, etc.).
- [x] Tests have been added to show the fix is effective or that the new feature works.
- [x] New and existing unit tests pass locally with the changes.
- [x] Docs have been updated and reviewed if relevant.
