### PR TITLE
Improve attribute discovery on derived `Agent` types

### DIFF
--- a/academy/agent.py
+++ b/academy/agent.py
@@ -141,11 +141,24 @@ class Agent:
         return self.agent_context.exchange_client
 
     def _agent_attributes(self) -> Generator[tuple[str, Any]]:
-        for name in dir(self):
-            if name in Agent.__dict__:
-                # Skip checking attributes of the base Agent. Checking
-                # the type of properties that access agent_context may
-                # raise an AgentNotInitializedError.
+        """Returns a generator that yields attributes of the agent.
+
+        The following attributes are ignored:
+
+        * Attributes defined on the parent/base Agent class
+        * @property methods of the derived type
+        """
+        all_attrs = set(dir(self))
+        base_attrs = set(dir(Agent))
+        derived_attrs = all_attrs - base_attrs
+
+        for name in derived_attrs:
+            if name.startswith('_Agent__'):
+                # Skip '__'-prefixed attributes of Agent whose names
+                # were mangled in the derived type
+                continue
+            if isinstance(getattr(type(self), name, None), property):
+                # Skip checking properties defined on the derived type.
                 continue
             attr = getattr(self, name)
             yield name, attr

--- a/tests/unit/agent_test.py
+++ b/tests/unit/agent_test.py
@@ -91,6 +91,18 @@ async def test_agent_empty() -> None:
 
 
 @pytest.mark.asyncio
+async def test_agent_ignore_property_attributes() -> None:
+    class Example(Agent):
+        @property
+        def bad(self) -> str:  # pragma: no cover
+            raise RuntimeError('Property was accessed!')
+
+    agent = Example()
+    attributes = set(agent._agent_attributes())
+    assert len(attributes) == 0
+
+
+@pytest.mark.asyncio
 async def test_agent_actions() -> None:
     agent = IdentityAgent()
     await agent.agent_on_startup()


### PR DESCRIPTION
## Summary
<!--- Provide a summary of the changes --->

The attribute discovery helper for `Agent`, used when binding handles on an agent during agent startup, would return property types causing the properties to be executed to check the type.

This makes lazy attribute initialization with properties impossible. For example, this would always raise an error during agent startup:
```
class Example(Agent):
    @property
    def bad(self) -> str:
        raise RuntimeError('Property was accessed!')
```

The attribute discovery logic is changed to (1) only look at attributes defined on the derived type and not the base `Agent` type and (2) to ignore attributes whose type is a property.

## Related Issue
<!--- List any issue numbers above that this PR addresses --->

N/A

## Changes
<!--- Check which of the following changes were made --->

- [ ] Breaking (backwards incompatible changes to public interfaces)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (non-breaking change or feature addition)
- [ ] Refactor (internal code or design clean up)
- [ ] Documentation (no changes to the code)
- [ ] Test (changes or additions to testing)
- [ ] Build (change to CI workflows or build processes)
- [ ] Package (changes to package metadata or dependency versions)

## Testing
<!--- Please describe the test ran to verify changes --->

Added a new test to validate the new behavior.

## Pull Request Checklist

Please confirm the PR meets the following requirements.
- [x] Relevant tags are added based on the types of changes.
- [x] Code changes pass `pre-commit` (e.g., ruff, mypy, etc.).
- [x] Tests have been added to show the fix is effective or that the new feature works.
- [x] New and existing unit tests pass locally with the changes.
- [x] Docs have been updated and reviewed if relevant.
