### PR TITLE
Change default docs version from latest to stable

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -73,4 +73,4 @@ jobs:
         if: startsWith(github.ref, 'refs/tags/')
         run: |
           pip install .[docs]
-          mike deploy --push --update-aliases "${{ env.PACKAGE_VERSION }}" latest
+          mike deploy --push --update-aliases "${{ env.PACKAGE_VERSION }}" stable

--- a/docs/css/extra.css
+++ b/docs/css/extra.css
@@ -54,3 +54,14 @@
     /* Reset alignment for table cells */
     text-align: initial;
 }
+
+/* Add parentheses around version aliases in docs */
+/* https://github.com/squidfunk/mkdocs-material/issues/6436 */
+.md-version__alias::before {
+  display: inherit;
+  content: "(";
+}
+.md-version__alias::after {
+  display: inherit;
+  content: ")";
+}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -56,7 +56,8 @@ watch:
 
 extra:
   version:
-    default: latest
+    alias: true
+    default: stable
     provider: mike
 
 extra_css:
@@ -124,7 +125,7 @@ nav:
 plugins:
   - mike:
       alias_type: symlink
-      canonical_version: latest
+      canonical_version: stable
   - gen-files:
       scripts:
         - docs/generate_api.py


### PR DESCRIPTION
## Summary
<!--- Provide a summary of the changes --->

The version aliases were a little messed up as all PRs and releases pushed to the latest tag. Now PRs push to latest and releases push to stable. The default redirects users to stable.

## Related Issues
<!--- List any issue numbers above that this PR addresses --->

N/A

## Changes
<!--- Check which of the following changes were made --->

- [ ] Breaking (backwards incompatible changes to public interfaces)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (non-breaking change or feature addition)
- [ ] Refactor (internal code or design clean up)
- [x] Documentation (no changes to the code)
- [ ] Test (changes or additions to testing)
- [x] Build (change to CI workflows or build processes)
- [ ] Package (changes to package metadata or dependency versions)

## Testing
<!--- Please describe the test ran to verify changes --->

N/A

## Pull Request Checklist

Please confirm the PR meets the following requirements.
- [x] Relevant tags are added based on the types of changes.
- [x] Code changes pass `pre-commit` (e.g., ruff, mypy, etc.).
- [x] Tests have been added to show the fix is effective or that the new feature works.
- [x] New and existing unit tests pass locally with the changes.
- [x] Docs have been updated and reviewed if relevant.
