### PR TITLE
Avoid setting global multiprocessing start method in `spawn_http_server()`

### DIFF
--- a/academy/exchange/cloud/client.py
+++ b/academy/exchange/cloud/client.py
@@ -327,14 +327,11 @@ def spawn_http_exchange(
     Returns:
         Exchange interface connected to the spawned exchange.
     """
-    # Fork is not safe in multi-threaded context.
-    multiprocessing.set_start_method('spawn')
-
     config = ExchangeServingConfig(host=host, port=port, log_level=level)
-    exchange_process = multiprocessing.Process(
-        target=_run,
-        args=(config,),
-    )
+
+    # Fork is not safe in multi-threaded context.
+    context = multiprocessing.get_context('spawn')
+    exchange_process = context.Process(target=_run, args=(config,))
     exchange_process.start()
 
     logger.info('Starting exchange server...')


### PR DESCRIPTION
## Summary
<!--- Provide a summary of the changes --->

This caused a RuntimeError error when running:
```
pytest tests
```
that the context had already been set. However, the error doesn't occur when running unit and integration tests separately (as in CI):
```
pytest tests/unit
pytest tests/integration
```
This is because the integration tests manually call spawn_http_server and then the unit tests call spawn_http_server once in a fixture. Switching to use a multiprocessing context directly solves this issue of changing the global start method after processes have already been started.

## Related Issues
<!--- List any issue numbers above that this PR addresses --->

N/A

## Changes
<!--- Check which of the following changes were made --->

- [ ] Breaking (backwards incompatible changes to public interfaces)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (non-breaking change or feature addition)
- [ ] Refactor (internal code or design clean up)
- [ ] Documentation (no changes to the code)
- [ ] Test (changes or additions to testing)
- [ ] Build (change to CI workflows or build processes)
- [ ] Package (changes to package metadata or dependency versions)

## Testing
<!--- Please describe the test ran to verify changes --->

`pytest tests` now works as expected.

## Pull Request Checklist

Please confirm the PR meets the following requirements.
- [x] Relevant tags are added based on the types of changes.
- [x] Code changes pass `pre-commit` (e.g., ruff, mypy, etc.).
- [x] Tests have been added to show the fix is effective or that the new feature works.
- [x] New and existing unit tests pass locally with the changes.
- [x] Docs have been updated and reviewed if relevant.
