### PR TITLE
Switch to username for globus authentication

### DIFF
--- a/academy/exchange/cloud/app.py
+++ b/academy/exchange/cloud/app.py
@@ -24,7 +24,6 @@ import enum
 import logging
 import ssl
 import sys
-import uuid
 from collections.abc import Awaitable
 from collections.abc import Sequence
 from typing import Any
@@ -302,7 +301,7 @@ def authenticate_factory(
         handler: Callable[[Request], Awaitable[Response]],
     ) -> Response:
         try:
-            client_uuid: uuid.UUID = await authenticator.authenticate_user(
+            client_id: str = await authenticator.authenticate_user(
                 request.headers,
             )
         except ForbiddenError:
@@ -317,7 +316,7 @@ def authenticate_factory(
             )
 
         headers = request.headers.copy()
-        headers['client_id'] = str(client_uuid)
+        headers['client_id'] = client_id
 
         # Handle early client-side disconnect in Issue #142
         # This is somewhat hard to reproduce in tests:

--- a/tests/unit/exchange/cloud/app_test.py
+++ b/tests/unit/exchange/cloud/app_test.py
@@ -240,8 +240,8 @@ async def auth_client() -> AsyncGenerator[TestClient[Request, Application]]:
     )
     user_1: dict[str, Any] = {
         'active': True,
-        'username': 'username',
-        'client_id': str(uuid.uuid4()),
+        'username': 'user1',
+        'client_id': '1624cf3f-45ee-4f54-9de4-2d5d79191346',
         'email': 'username@example.com',
         'name': 'User Name',
         'aud': [AcademyExchangeScopes.resource_server],
@@ -249,8 +249,8 @@ async def auth_client() -> AsyncGenerator[TestClient[Request, Application]]:
 
     user_2: dict[str, Any] = {
         'active': True,
-        'username': 'username',
-        'client_id': str(uuid.uuid4()),
+        'username': 'user2',
+        'client_id': '1624cf3f-45ee-4f54-9de4-2d5d79191346',
         'email': 'username@example.com',
         'name': 'User Name',
         'aud': [AcademyExchangeScopes.resource_server],

--- a/tests/unit/exchange/cloud/authenticate_test.py
+++ b/tests/unit/exchange/cloud/authenticate_test.py
@@ -34,7 +34,7 @@ async def test_authenticate_user_with_token() -> None:
         'aud': [authenticator.audience],
         'sub': authenticator.auth_client.client_id,
         'username': 'username',
-        'client_id': str(uuid.uuid4()),
+        'client_id': '1624cf3f-45ee-4f54-9de4-2d5d79191346',
         'email': 'username@example.com',
         'name': 'User Name',
     }
@@ -48,7 +48,7 @@ async def test_authenticate_user_with_token() -> None:
             {'Authorization': 'Bearer <TOKEN>'},
         )
 
-    assert user == uuid.UUID(token_meta['client_id'])
+    assert user == token_meta['username']
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
Currently we use the client_id to check if a user has the correct permissions. This is always going to be the ACADEMY_CLIENT auth id, so every user is being mapped to the same identity. To address this issue, we switch to using the username field returned by token introspect instead.


## Changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Testing
Revised tests to reflect that client id does not change.

## Pull Request Checklist

Please confirm the PR meets the following requirements.
- [x] Relevant tags are added based on the types of changes.
- [x] Code changes pass `pre-commit` (e.g., ruff, mypy, etc.).
- [x] Tests have been added to show the fix is effective or that the new feature works.
- [x] New and existing unit tests pass locally with the changes.
- [x] Docs have been updated and reviewed if relevant.
