### PR TITLE
Add Logging Options to Agent Launch

### DIFF
--- a/tests/unit/manager_test.py
+++ b/tests/unit/manager_test.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import asyncio
+import os
+import pathlib
 from concurrent.futures import ThreadPoolExecutor
 
 import pytest
@@ -276,3 +278,30 @@ async def test_warn_executor_overload(
         with pytest.warns(RuntimeWarning, match='Executor overload:'):
             await manager.launch(agent)
         assert len(manager.running()) == 2  # noqa: PLR2004
+
+
+# Note: these tests are just for coverage to make sure the code is functional.
+# It does not test the agent of init_logging because pytest captures
+# logging already.
+
+
+@pytest.mark.asyncio
+async def test_worker_init_logging_no_logfile(
+    manager: Manager[LocalExchangeTransport],
+) -> None:
+    agent = SleepAgent(TEST_SLEEP_INTERVAL)
+    handle = await manager.launch(agent, init_logging=True)
+    await handle.shutdown()
+    await manager.wait({handle})
+
+
+@pytest.mark.asyncio
+async def test_worker_init_logging_logfile(
+    manager: Manager[LocalExchangeTransport],
+    tmp_path: pathlib.Path,
+) -> None:
+    filepath = os.path.join(tmp_path, '{agent_id}-log.txt')
+    agent = SleepAgent(TEST_SLEEP_INTERVAL)
+    handle = await manager.launch(agent, init_logging=True, logfile=filepath)
+    await handle.shutdown()
+    await manager.wait({handle})


### PR DESCRIPTION
## Summary
Writing some experiments with Globus Compute I had lots of trouble debugging agents on remote systems. This is partly because I had a hard time configuring logging. In the repository examples, we configure logging with the initializer function of the process pool executor. This isn't possible with Globus Compute. This PR just introduces the ability to initialize logging within the remote function before calling the agent runner.

I think this is probably just a start to how we want to consider doing remote logging. We probably want a mechanism to capture remote logs and send them back to the client (or at least make them retrievable). 

## Changes
<!--- Check which of the following changes were made --->

- [ ] Breaking (backwards incompatible changes to public interfaces)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Enhancement (non-breaking change or feature addition)
- [ ] Refactor (internal code or design clean up)
- [ ] Documentation (no changes to the code)
- [ ] Test (changes or additions to testing)
- [ ] Build (change to CI workflows or build processes)
- [ ] Package (changes to package metadata or dependency versions)

## Pull Request Checklist

Please confirm the PR meets the following requirements.
- [x] Relevant tags are added based on the types of changes.
- [x] Code changes pass `pre-commit` (e.g., ruff, mypy, etc.).
- [x] Tests have been added to show the fix is effective or that the new feature works.
- [x] New and existing unit tests pass locally with the changes.
- [x] Docs have been updated and reviewed if relevant.
