### PR TITLE
fix redis exchange discover

### DIFF
--- a/testing/redis.py
+++ b/testing/redis.py
@@ -21,6 +21,10 @@ class MockRedis:
         self.events: dict[bytes, asyncio.Event] = defaultdict(asyncio.Event)
         self.timeouts: dict[bytes, asyncio.Future[Any]] = {}
 
+        assert (
+            'decode_responses' not in kwargs or not kwargs['decode_responses']
+        ), 'decode_responses is in compatible with the way we use Redis'
+
     def _encode(self, value: bytes | str) -> bytes:
         if isinstance(value, bytes):
             return value


### PR DESCRIPTION
## Summary
<!--- Provide a summary of the changes --->
Redis get() returns bytes, but the code expected a str (e.g., assert isinstance(mro_str, str)).
Adding .decode("utf-8") restores the intended behavior (working with text, not bytes).

## Related Issues
<!--- List any issue numbers above that this PR addresses --->

- Closes #XX
- Related to #XX _(if applicable)_

## Changes
<!--- Check which of the following changes were made --->

- [ ] Breaking (backwards incompatible changes to public interfaces)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (non-breaking change or feature addition)
- [ ] Refactor (internal code or design clean up)
- [ ] Documentation (no changes to the code)
- [ ] Test (changes or additions to testing)
- [ ] Build (change to CI workflows or build processes)
- [ ] Package (changes to package metadata or dependency versions)

## Testing
<!--- Please describe the test ran to verify changes --->

N/A

## Pull Request Checklist

Please confirm the PR meets the following requirements.
- [x] Relevant tags are added based on the types of changes.
- [X] Code changes pass `pre-commit` (e.g., ruff, mypy, etc.).
- [x] Tests have been added to show the fix is effective or that the new feature works.
- [x] New and existing unit tests pass locally with the changes.
- [ ] Docs have been updated and reviewed if relevant.
