### PR TITLE
Adding mechanism to discover all agents

### DIFF
--- a/academy/agent.py
+++ b/academy/agent.py
@@ -570,7 +570,7 @@ class Agent:
         """
         mro = cls.mro()
         base_index = mro.index(Agent)
-        mro = mro[:base_index]
+        mro = mro[: base_index + 1]
         return tuple(f'{t.__module__}.{t.__qualname__}' for t in mro)
 
     async def agent_on_startup(self) -> None:

--- a/tests/unit/agent_test.py
+++ b/tests/unit/agent_test.py
@@ -322,14 +322,19 @@ class D(A, B): ...
 
 
 def test_agent_mro() -> None:
-    assert Agent._agent_mro() == ()
-    assert A._agent_mro() == (f'{__name__}.A',)
-    assert B._agent_mro() == (f'{__name__}.B',)
-    assert C._agent_mro() == (f'{__name__}.C', f'{__name__}.A')
+    assert Agent._agent_mro() == ('academy.agent.Agent',)
+    assert A._agent_mro() == (f'{__name__}.A', 'academy.agent.Agent')
+    assert B._agent_mro() == (f'{__name__}.B', 'academy.agent.Agent')
+    assert C._agent_mro() == (
+        f'{__name__}.C',
+        f'{__name__}.A',
+        'academy.agent.Agent',
+    )
     assert D._agent_mro() == (
         f'{__name__}.D',
         f'{__name__}.A',
         f'{__name__}.B',
+        'academy.agent.Agent',
     )
 
 

--- a/tests/unit/exchange/transport_test.py
+++ b/tests/unit/exchange/transport_test.py
@@ -222,3 +222,7 @@ async def test_transport_discover(
     assert found == (bid,)
     found = await transport.discover(B, allow_subclasses=True)
     assert found == (bid, cid)
+
+    aid = (await transport.register_agent(A)).agent_id
+    found = await transport.discover(Agent)
+    assert set(found) == {bid, cid, aid}


### PR DESCRIPTION
## Summary
I need a mechanism to discover all agents that are registered to a user. This is necessary to the MCP server, but I imagine also for other UI/UX stuff (i.e. any monitoring or web-interface). 

The actual change here is quite small --- adding the agent class to the `agent_mro`. This gives the desired functionality at the cost of a few more bytes of storage. There may have been alternatives that saved that storage, but this seemed like the simplest, understandable technique that didn't involve a special case.


## Related Issues
- Related to #178 

## Changes
- [ ] Breaking (backwards incompatible changes to public interfaces)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Enhancement (non-breaking change or feature addition)
- [ ] Refactor (internal code or design clean up)
- [ ] Documentation (no changes to the code)
- [ ] Test (changes or additions to testing)
- [ ] Build (change to CI workflows or build processes)
- [ ] Package (changes to package metadata or dependency versions)

## Pull Request Checklist

Please confirm the PR meets the following requirements.
- [x] Relevant tags are added based on the types of changes.
- [x] Code changes pass `pre-commit` (e.g., ruff, mypy, etc.).
- [x] Tests have been added to show the fix is effective or that the new feature works.
- [x] New and existing unit tests pass locally with the changes.
- [x] Docs have been updated and reviewed if relevant.
