### PR TITLE
Join killed process in HTTP exchange context manager

### DIFF
--- a/academy/exchange/cloud/client.py
+++ b/academy/exchange/cloud/client.py
@@ -354,6 +354,7 @@ def spawn_http_exchange(
                 wait,
             )
             exchange_process.kill()
+            exchange_process.join()
         else:
             logger.info('Terminated exchange server!')
         exchange_process.close()


### PR DESCRIPTION
## Summary
After calling `process.kill()` we still need to call `process.join()` before calling `process.close()` otherwise we get this error:
```
ValueError: Cannot close a process while it is still running. You should first call join() or terminate().
```

Not covered in testing, but for some reason when spawning a process with the [`academy-extensions`](https://github.com/academy-agents/academy-extensions), process clean-up does not always happen smoothly.

## Changes
<!--- Check which of the following changes were made --->

- [ ] Breaking (backwards incompatible changes to public interfaces)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (non-breaking change or feature addition)
- [ ] Refactor (internal code or design clean up)
- [ ] Documentation (no changes to the code)
- [ ] Test (changes or additions to testing)
- [ ] Build (change to CI workflows or build processes)
- [ ] Package (changes to package metadata or dependency versions)

## Testing
Test suite for [`academy-extensions`](https://github.com/academy-agents/academy-extensions) now passes without raising the ValueError. I could not find a way to create a MRE to add to the Academy test suite.

## Pull Request Checklist

Please confirm the PR meets the following requirements.
- [x] Relevant tags are added based on the types of changes.
- [x] Code changes pass `pre-commit` (e.g., ruff, mypy, etc.).
- [ ] Tests have been added to show the fix is effective or that the new feature works.
- [x] New and existing unit tests pass locally with the changes.
- [x] Docs have been updated and reviewed if relevant.
