### PR TITLE
Make logging unit tests force reconfiguration

### DIFF
--- a/tests/unit/logging_test.py
+++ b/tests/unit/logging_test.py
@@ -14,7 +14,7 @@ from academy.logging import init_logging
 
 @pytest.mark.parametrize(('color', 'extra'), ((True, True), (False, False)))
 def test_logging_no_file(color: bool, extra: bool) -> None:
-    init_logging(color=color, extra=extra)
+    init_logging(color=color, extra=extra, force=True)
 
     logger = logging.getLogger()
     logger.info('Test logging')
@@ -27,7 +27,7 @@ def test_logging_with_file(
     tmp_path: pathlib.Path,
 ) -> None:
     filepath = tmp_path / 'log.txt'
-    init_logging(logfile=filepath, color=color, extra=extra)
+    init_logging(logfile=filepath, color=color, extra=extra, force=True)
 
     logger = logging.getLogger()
     logger.info('Test logging')


### PR DESCRIPTION
## Summary

Before this change, part of init_logging behaviour does not happen after the first invocation: logger.basicConfig only has effect the first time it is called.

This does affect any logging tests so far, but in an upcoming PR, I have a new LogHandler that does not get coverage-tested in some test orderings without this.

## Changes

- [ ] Breaking (backwards incompatible changes to public interfaces)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (non-breaking change or feature addition)
- [ ] Refactor (internal code or design clean up)
- [ ] Documentation (no changes to the code)
- [x] Test (changes or additions to testing)
- [ ] Build (change to CI workflows or build processes)
- [ ] Package (changes to package metadata or dependency versions)

## Testing
Tests pass before and after this PR the same. Some in-progress work I have adds a new LogHandler in some situations, and that LogHandler now gets coverage tested.

## Pull Request Checklist

Please confirm the PR meets the following requirements.
- [ ] Relevant tags are added based on the types of changes.
- [x] Code changes pass `pre-commit` (e.g., ruff, mypy, etc.).
- [ ] Tests have been added to show the fix is effective or that the new feature works.
- [x] New and existing unit tests pass locally with the changes.
- [n/a] Docs have been updated and reviewed if relevant.
