### PR TITLE
Make cachetools required dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,7 @@ dependencies = [
     "redis",
     "tomli ; python_version<'3.11'",
     "typing-extensions>=4.3.0 ; python_version<'3.11'",
+    "cachetools",
 ]
 
 [project.urls]
@@ -66,9 +67,6 @@ docs = [
     "mkdocstrings==0.29.1",
     "mkdocstrings-python==1.16.10",
     "mike==2.1.3",
-]
-server = [
-    "cachetools"
 ]
 
 [tool.codespell]


### PR DESCRIPTION
## Summary
Cachetools is required for server authentication, but is automatically imported no matter what. This optional dependency means that without `pip install academy[server]` things won't run. It does not seem like there is good reason to keep this as an optional dependency given that (1) it is alone, and (2) it is very light-weight, and (3) it is a well-maintained package that we have confidence in.


## Changes
- [ ] Breaking (backwards incompatible changes to public interfaces)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (non-breaking change or feature addition)
- [ ] Refactor (internal code or design clean up)
- [ ] Documentation (no changes to the code)
- [ ] Test (changes or additions to testing)
- [ ] Build (change to CI workflows or build processes)
- [x] Package (changes to package metadata or dependency versions)

## Testing
<!--- Please describe the test ran to verify changes --->

N/A

## Pull Request Checklist

Please confirm the PR meets the following requirements.
- [x] Relevant tags are added based on the types of changes.
- [x] Code changes pass `pre-commit` (e.g., ruff, mypy, etc.).
- [ ] Tests have been added to show the fix is effective or that the new feature works.
- [ ] New and existing unit tests pass locally with the changes.
- [ ] Docs have been updated and reviewed if relevant.
