### PR TITLE
Raise error when action-decorated method is not a coroutine

### DIFF
--- a/academy/agent.py
+++ b/academy/agent.py
@@ -172,6 +172,7 @@ def action(
             The `context` will be provided at runtime as a keyword argument.
 
     Raises:
+        TypeError: If the decorated function is not a coroutine.
         TypeError: If `context=True` and the method does not have a parameter
             named `context` or if `context` is a positional only argument.
     """
@@ -189,6 +190,13 @@ def action(
                 UserWarning,
                 stacklevel=3,
             )
+
+        if not inspect.iscoroutinefunction(method_):
+            raise TypeError(
+                f'Action method "{method_.__name__}" is not a coroutine. '
+                'Did you forget an "async" in the method declaration?',
+            )
+
         # Typing the requirement that if context=True then params P should
         # contain a keyword argument named "context" is not easily annotated
         # for mypy so instead we check at runtime.

--- a/tests/unit/agent_test.py
+++ b/tests/unit/agent_test.py
@@ -277,6 +277,17 @@ def test_agent_action_decorator_usage_error() -> None:
         action(context=True)(_TestAgent.pos_only)
 
 
+def test_agent_action_decorator_sync_method_error() -> None:
+    with pytest.raises(
+        TypeError,
+        match='Action method "not_async" is not a coroutine',
+    ):
+
+        class _TestAgent(Agent):
+            @action  # type: ignore[arg-type]
+            def not_async(self) -> None: ...
+
+
 def test_agent_action_decorator_name_clash_ok() -> None:
     class _TestAgent(Agent):
         async def ping(self) -> None: ...


### PR DESCRIPTION
## Summary
<!--- Provide a summary of the changes --->

Now using `@action` on a non-coroutine raises a more helpful error with a hint.

```python
>>> from academy.agent import Agent, action
>>> class Test(Agent):
...     @action
...     def foo(self) -> None:
...         return None
...
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "<stdin>", line 2, in Test
  File "/home/jgpaul/workspace/academy/academy/agent.py", line 227, in action
    return decorator(method)
           ^^^^^^^^^^^^^^^^^
  File "/home/jgpaul/workspace/academy/academy/agent.py", line 195, in decorator
    raise TypeError(
TypeError: Action method "foo" is not a coroutine. Did you forget an "async" in the method declaration?
```

## Related Issues
<!--- List any issue numbers above that this PR addresses --->

- Closes #243

## Changes
<!--- Check which of the following changes were made --->

- [ ] Breaking (backwards incompatible changes to public interfaces)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (non-breaking change or feature addition)
- [ ] Refactor (internal code or design clean up)
- [ ] Documentation (no changes to the code)
- [ ] Test (changes or additions to testing)
- [ ] Build (change to CI workflows or build processes)
- [ ] Package (changes to package metadata or dependency versions)

## Testing
<!--- Please describe the test ran to verify changes --->

Added a new test.

## Pull Request Checklist

Please confirm the PR meets the following requirements.
- [x] Relevant tags are added based on the types of changes.
- [x] Code changes pass `pre-commit` (e.g., ruff, mypy, etc.).
- [x] Tests have been added to show the fix is effective or that the new feature works.
- [x] New and existing unit tests pass locally with the changes.
- [x] Docs have been updated and reviewed if relevant.
