### PR TITLE
Test `JSONHandler` without `force=True` so pytest logger is not replaced

### DIFF
--- a/academy/logging.py
+++ b/academy/logging.py
@@ -183,8 +183,8 @@ class JSONHandler(logging.Handler):
         for k, v in record.__dict__.items():
             try:
                 d[k] = str(v)
-            except Exception:  # pragma: no cover
-                d[k] = 'Unrepresentable: {e!r}'
+            except Exception as e:
+                d[k] = f'Unrepresentable: {e!r}'
 
         json.dump(d, fp=self.f)
         print('', file=self.f)

--- a/tests/unit/logging_test.py
+++ b/tests/unit/logging_test.py
@@ -1,11 +1,13 @@
 from __future__ import annotations
 
+import json
 import logging
 import pathlib
 
 import pytest
 
 from academy.logging import init_logging
+from academy.logging import JSONHandler
 
 # Note: these tests are just for coverage to make sure the code is functional.
 # It does not test the agent of init_logging because pytest captures
@@ -14,7 +16,7 @@ from academy.logging import init_logging
 
 @pytest.mark.parametrize(('color', 'extra'), ((True, True), (False, False)))
 def test_logging_no_file(color: bool, extra: bool) -> None:
-    init_logging(color=color, extra=extra, force=True)
+    init_logging(color=color, extra=extra)
 
     logger = logging.getLogger()
     logger.info('Test logging')
@@ -30,7 +32,70 @@ def test_logging_with_file(
     tmp_path: pathlib.Path,
 ) -> None:
     filepath = tmp_path / 'log.txt'
-    init_logging(logfile=filepath, color=color, extra=extra, force=True)
+    init_logging(logfile=filepath, color=color, extra=extra)
 
     logger = logging.getLogger()
     logger.info('Test logging')
+
+
+def test_json_handler_emit(tmp_path: pathlib.Path) -> None:
+    log_file = tmp_path / 'test.jsonl'
+    handler = JSONHandler(log_file)
+
+    record = logging.LogRecord(
+        name='test_logger',
+        level=logging.INFO,
+        pathname=__file__,
+        lineno=42,
+        msg='Hello, world!',
+        args=(),
+        exc_info=None,
+    )
+    # Options passed to extra= are added to the __dict__ of LogRecord
+    record.foo = 'bar'
+
+    # Attach a formatter for the `formatted` attribute
+    formatter = logging.Formatter('%(levelname)s: %(message)s')
+    handler.setFormatter(formatter)
+
+    handler.emit(record)
+
+    contents = log_file.read_text().strip().splitlines()
+    assert len(contents) == 1
+    data = json.loads(contents[0])
+    assert isinstance(data, dict)
+    assert data['formatted'] == 'INFO: Hello, world!'
+    assert data['msg'] == 'Hello, world!'
+    assert data['levelname'] == 'INFO'
+    assert data['lineno'] == '42'
+    assert data['name'] == 'test_logger'
+    assert data['foo'] == 'bar'
+
+    handler.f.close()
+
+
+def test_json_handler_emit_unrepresentable(tmp_path: pathlib.Path) -> None:
+    log_file = tmp_path / 'test_bad.jsonl'
+    handler = JSONHandler(log_file)
+
+    class Bad:
+        def __str__(self):
+            raise ValueError('Cannot be converted to a str.')
+
+    record = logging.LogRecord(
+        name='test_logger',
+        level=logging.WARNING,
+        pathname=__file__,
+        lineno=99,
+        msg='This will break',
+        args=(),
+        exc_info=None,
+    )
+    record.bad = Bad()
+
+    handler.emit(record)
+    data = json.loads(log_file.read_text().strip())
+    assert 'bad' in data
+    assert 'Unrepresentable' in data['bad']
+
+    handler.f.close()


### PR DESCRIPTION
## Summary
<!--- Provide a summary of the changes --->

#247 set the logging tests to use `force=True` so that the `JSONHandler` added in #248 would get properly covered. `force=True` replaced the pytest logger used for capturing, so the logging tests would inadvertently remove logging for all later test (described in more detail in #257).

Since the change to `force=True` was just about coverage, I added some unit tests for the `JSONHandler` and removed `force=True`. There was also an exception handle that was `#pragma: no cover` that I think was supposed to f-string format the exception but was missing the `f"` so I added a test for that.

## Related Issues
<!--- List any issue numbers above that this PR addresses --->

- Closes #257 

## Changes
<!--- Check which of the following changes were made --->

*Not marking this as "bug" since it's just related to the tests and doesn't need to distract from the real bugs in the release notes.*

- [ ] Breaking (backwards incompatible changes to public interfaces)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (non-breaking change or feature addition)
- [ ] Refactor (internal code or design clean up)
- [ ] Documentation (no changes to the code)
- [x] Test (changes or additions to testing)
- [ ] Build (change to CI workflows or build processes)
- [ ] Package (changes to package metadata or dependency versions)

## Testing
<!--- Please describe the test ran to verify changes --->

Added new tests and confirmed logging works in pytest again.

## Pull Request Checklist

Please confirm the PR meets the following requirements.
- [x] Relevant tags are added based on the types of changes.
- [x] Code changes pass `pre-commit` (e.g., ruff, mypy, etc.).
- [x] Tests have been added to show the fix is effective or that the new feature works.
- [x] New and existing unit tests pass locally with the changes.
- [x] Docs have been updated and reviewed if relevant.
