### PR TITLE
Make all custom exception types pickleable

### DIFF
--- a/academy/exception.py
+++ b/academy/exception.py
@@ -18,6 +18,10 @@ class ActionCancelledError(Exception):
 
     def __init__(self, name: str) -> None:
         super().__init__(f'Action "{name}" was cancelled by the agent.')
+        self.name = name
+
+    def __reduce__(self) -> Any:
+        return type(self), (self.name,)
 
 
 class AgentNotInitializedError(Exception):
@@ -33,6 +37,9 @@ class AgentNotInitializedError(Exception):
             'Has the agent been started?',
         )
 
+    def __reduce__(self) -> Any:
+        return type(self), ()
+
 
 class ExchangeError(Exception):
     """Base type for exchange related errors."""
@@ -45,6 +52,10 @@ class BadEntityIdError(ExchangeError):
 
     def __init__(self, uid: EntityId) -> None:
         super().__init__(f'Unknown identifier {uid}.')
+        self.uid = uid
+
+    def __reduce__(self) -> Any:
+        return type(self), (self.uid,)
 
 
 class ForbiddenError(ExchangeError):
@@ -68,6 +79,9 @@ class MessageTooLargeError(ExchangeError):
         super().__init__(
             f'Message of size {size} bytes is larger than limit {limit}.',
         )
+
+    def __reduce__(self) -> Any:
+        return type(self), (self.size, self.limit)
 
 
 class MailboxTerminatedError(ExchangeError):
@@ -135,6 +149,10 @@ class ExchangeClientNotFoundError(Exception):
             f'Handle to {aid} can not find an exchange client to use. See the '
             'exception docstring for troubleshooting.',
         )
+        self.aid = aid
+
+    def __reduce__(self) -> Any:
+        return type(self), (self.aid,)
 
 
 def raise_exceptions(

--- a/tests/unit/exception_test.py
+++ b/tests/unit/exception_test.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+import pickle
+
+import pytest
+
+from academy.exception import ActionCancelledError
+from academy.exception import AgentNotInitializedError
+from academy.exception import AgentTerminatedError
+from academy.exception import BadEntityIdError
+from academy.exception import ExchangeClientNotFoundError
+from academy.exception import ExchangeError
+from academy.exception import ForbiddenError
+from academy.exception import MailboxTerminatedError
+from academy.exception import MessageTooLargeError
+from academy.exception import UnauthorizedError
+from academy.exception import UserTerminatedError
+from academy.identifier import AgentId
+from academy.identifier import UserId
+
+
+@pytest.mark.parametrize(
+    'exc',
+    (
+        ActionCancelledError('test'),
+        AgentNotInitializedError(),
+        ExchangeError(),
+        BadEntityIdError(AgentId.new()),
+        ForbiddenError(),
+        MessageTooLargeError(2, 1),
+        MailboxTerminatedError(AgentId.new()),
+        AgentTerminatedError(AgentId.new()),
+        UserTerminatedError(UserId.new()),
+        UnauthorizedError(),
+        ExchangeClientNotFoundError(AgentId.new()),
+    ),
+)
+def test_pickle_exception(exc: Exception) -> None:
+    pkl = pickle.dumps(exc)
+    reconstructed = pickle.loads(pkl)
+    # Exception types cannot be tested for equality using == so use the
+    # repr as a proxy for equality.
+    assert repr(exc) == repr(reconstructed)


### PR DESCRIPTION
## Summary
<!--- Provide a summary of the changes --->

Address a broader problem raised in #245 that some of our custom exception types are pickleable and some are not. I'm of the opinion that all should be pickleable so that exceptions can be correctly propagated back from remote agents.

## Related Issues
<!--- List any issue numbers above that this PR addresses --->

- Closes #245

## Changes
<!--- Check which of the following changes were made --->

- [ ] Breaking (backwards incompatible changes to public interfaces)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (non-breaking change or feature addition)
- [ ] Refactor (internal code or design clean up)
- [ ] Documentation (no changes to the code)
- [ ] Test (changes or additions to testing)
- [ ] Build (change to CI workflows or build processes)
- [ ] Package (changes to package metadata or dependency versions)

## Testing
<!--- Please describe the test ran to verify changes --->

Added new tests.

## Pull Request Checklist

Please confirm the PR meets the following requirements.
- [x] Relevant tags are added based on the types of changes.
- [x] Code changes pass `pre-commit` (e.g., ruff, mypy, etc.).
- [x] Tests have been added to show the fix is effective or that the new feature works.
- [x] New and existing unit tests pass locally with the changes.
- [x] Docs have been updated and reviewed if relevant.
