### PR TITLE
Fix client ID logging

### DIFF
--- a/academy/handle.py
+++ b/academy/handle.py
@@ -252,11 +252,11 @@ class Handle(Generic[AgentT]):
         await self.exchange.send(request)
         logger.debug(
             'Sent action request from %s to %s (action=%r)',
-            self.client_id,
+            exchange.client_id,
             self.agent_id,
             action,
             extra={
-                'academy.action_src': self.client_id,
+                'academy.action_src': exchange.client_id,
                 'academy.action_dest': self.agent_id,
                 'academy.action': action,
             },
@@ -297,10 +297,10 @@ class Handle(Generic[AgentT]):
         await self.exchange.send(request)
         logger.debug(
             'Sent ping from %s to %s',
-            self.client_id,
+            exchange.client_id,
             self.agent_id,
             extra={
-                'academy.ping_src': self.client_id,
+                'academy.ping_src': exchange.client_id,
                 'academy.ping_dest': self.agent_id,
             },
         )


### PR DESCRIPTION
## Summary

self.client_id does not exist, but as it is invoked on a handle, it turns into an unevaluated RPC stub, which is never compared against the remote agent to generate an error. The repr that was logged was the repr of that RPC stub:

> Sent ping from <function Handle.__getattr__.<locals>.remote_method_call at 0x7f26330a5080> to AgentId<599f4732>

This PR makes logs look like this:

> Sent ping from UserId<381c0daa> to AgentId<642794a7>

## Changes

- [ ] Breaking (backwards incompatible changes to public interfaces)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (non-breaking change or feature addition)
- [ ] Refactor (internal code or design clean up)
- [ ] Documentation (no changes to the code)
- [ ] Test (changes or additions to testing)
- [ ] Build (change to CI workflows or build processes)
- [ ] Package (changes to package metadata or dependency versions)

## Testing
visual inspection as pasted into the description above

## Pull Request Checklist

Please confirm the PR meets the following requirements.
- [x] Relevant tags are added based on the types of changes.
- [ x Code changes pass `pre-commit` (e.g., ruff, mypy, etc.).
- [ ] Tests have been added to show the fix is effective or that the new feature works.
- [x] New and existing unit tests pass locally with the changes.
- [ ] Docs have been updated and reviewed if relevant.
