### PR TITLE
Change minimum supported version to Python 3.10

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,9 +16,6 @@ jobs:
       matrix:
         include:
         - os: ubuntu-latest
-          python: '3.9'
-          toxenv: py39
-        - os: ubuntu-latest
           python: '3.10'
           toxenv: py310
         - os: ubuntu-latest
@@ -70,9 +67,6 @@ jobs:
       fail-fast: false
       matrix:
         include:
-        - os: ubuntu-latest
-          python: '3.9'
-          toxenv: py39
         - os: ubuntu-latest
           python: '3.10'
           toxenv: py310

--- a/academy/agent.py
+++ b/academy/agent.py
@@ -6,32 +6,27 @@ import inspect
 import logging
 import sys
 import warnings
+from collections.abc import Callable
 from collections.abc import Coroutine
 from collections.abc import Generator
 from datetime import timedelta
 from typing import Any
-from typing import Callable
 from typing import Generic
 from typing import get_type_hints
 from typing import Literal
 from typing import overload
+from typing import ParamSpec
 from typing import Protocol
 from typing import TYPE_CHECKING
+from typing import TypeAlias
 from typing import TypeVar
-
-from pydantic import BaseModel
-
-if sys.version_info >= (3, 10):  # pragma: >=3.10 cover
-    from typing import ParamSpec
-    from typing import TypeAlias
-else:  # pragma: <3.10 cover
-    from typing_extensions import ParamSpec
-    from typing_extensions import TypeAlias
 
 if sys.version_info >= (3, 11):  # pragma: >=3.11 cover
     from typing import Self
 else:  # pragma: <3.11 cover
     from typing_extensions import Self
+
+from pydantic import BaseModel
 
 from academy.event import wait_event_async
 from academy.exception import AgentNotInitializedError
@@ -253,12 +248,8 @@ def loop(method: LoopMethod[AgentT]) -> LoopMethod[AgentT]:
     """
     method._agent_method_type = 'loop'  # type: ignore[attr-defined]
 
-    if sys.version_info >= (3, 10):  # pragma: >=3.10 cover
-        found_sig = inspect.signature(method, eval_str=True)
-        expected_sig = inspect.signature(ControlLoop.__call__, eval_str=True)
-    else:  # pragma: <3.10 cover
-        found_sig = inspect.signature(method)
-        expected_sig = inspect.signature(ControlLoop.__call__)
+    found_sig = inspect.signature(method, eval_str=True)
+    expected_sig = inspect.signature(ControlLoop.__call__, eval_str=True)
 
     if found_sig != expected_sig:
         raise TypeError(

--- a/academy/exchange/client.py
+++ b/academy/exchange/client.py
@@ -6,18 +6,14 @@ import contextlib
 import logging
 import sys
 import uuid
+from collections.abc import Callable
 from collections.abc import Coroutine
 from types import TracebackType
 from typing import Any
-from typing import Callable
 from typing import Generic
 from typing import TYPE_CHECKING
+from typing import TypeAlias
 from weakref import WeakValueDictionary
-
-if sys.version_info >= (3, 11):  # pragma: >=3.11 cover
-    from typing import TypeAlias
-else:  # pragma: <3.11 cover
-    from typing_extensions import TypeAlias
 
 if sys.version_info >= (3, 11):  # pragma: >=3.11 cover
     from typing import Self

--- a/academy/exchange/cloud/app.py
+++ b/academy/exchange/cloud/app.py
@@ -25,9 +25,9 @@ import logging
 import ssl
 import sys
 from collections.abc import Awaitable
+from collections.abc import Callable
 from collections.abc import Sequence
 from typing import Any
-from typing import Callable
 
 if sys.version_info >= (3, 13):  # pragma: >=3.13 cover
     from asyncio import Queue

--- a/academy/exchange/cloud/config.py
+++ b/academy/exchange/cloud/config.py
@@ -114,7 +114,7 @@ class RedisBackendConfig(BaseModel):
         )
 
 
-BackendConfigT = Union[PythonBackendConfig, RedisBackendConfig]
+BackendConfigT = Union[PythonBackendConfig, RedisBackendConfig]  # noqa: UP007
 
 
 class ExchangeServingConfig(BaseModel):

--- a/academy/exchange/factory.py
+++ b/academy/exchange/factory.py
@@ -2,21 +2,11 @@ from __future__ import annotations
 
 import abc
 import logging
-import sys
+from collections.abc import Callable
 from collections.abc import Coroutine
 from typing import Any
-from typing import Callable
 from typing import Generic
-
-if sys.version_info >= (3, 11):  # pragma: >=3.11 cover
-    from typing import TypeAlias
-else:  # pragma: <3.11 cover
-    from typing_extensions import TypeAlias
-
-if sys.version_info >= (3, 11):  # pragma: >=3.11 cover
-    pass
-else:  # pragma: <3.11 cover
-    pass
+from typing import TypeAlias
 
 from academy.agent import AgentT
 from academy.exception import BadEntityIdError

--- a/academy/exchange/proxystore.py
+++ b/academy/exchange/proxystore.py
@@ -2,10 +2,10 @@
 from __future__ import annotations
 
 import functools
+from collections.abc import Callable
 from collections.abc import Iterable
 from collections.abc import Mapping
 from typing import Any
-from typing import Callable
 from typing import Generic
 
 from proxystore.proxy import Proxy

--- a/academy/handle.py
+++ b/academy/handle.py
@@ -3,21 +3,16 @@ from __future__ import annotations
 import asyncio
 import functools
 import logging
-import sys
 import time
 import uuid
 from contextvars import ContextVar
 from pickle import PicklingError
 from typing import Any
 from typing import Generic
+from typing import ParamSpec
 from typing import TYPE_CHECKING
 from typing import TypeVar
 from weakref import WeakSet
-
-if sys.version_info >= (3, 10):  # pragma: >=3.10 cover
-    from typing import ParamSpec
-else:  # pragma: <3.10 cover
-    from typing_extensions import ParamSpec
 
 from academy.exception import AgentTerminatedError
 from academy.exception import ExchangeClientNotFoundError

--- a/academy/identifier.py
+++ b/academy/identifier.py
@@ -91,7 +91,7 @@ class UserId(BaseModel):
 
 
 if TYPE_CHECKING:
-    EntityId = Union[AgentId[Any], UserId]
+    EntityId = Union[AgentId[Any], UserId]  # noqa: UP007
     """EntityId union type for type annotations."""
 else:
     # Pydantic produces validation errors with Agent[Any] in versions
@@ -100,4 +100,4 @@ else:
     # stricter requirements.
     # Issue: https://github.com/pydantic/pydantic/issues/9414
     # Fix: https://github.com/pydantic/pydantic/pull/10666
-    EntityId = Union[AgentId, UserId]
+    EntityId = Union[AgentId, UserId]  # noqa: UP007

--- a/academy/message.py
+++ b/academy/message.py
@@ -208,9 +208,9 @@ class SuccessResponse(BaseModel):
     model_config = DEFAULT_FROZEN_CONFIG
 
 
-Request = Union[ActionRequest, PingRequest, ShutdownRequest]
-Response = Union[ActionResponse, ErrorResponse, SuccessResponse]
-Body = Union[Request, Response]
+Request = Union[ActionRequest, PingRequest, ShutdownRequest]  # noqa: UP007
+Response = Union[ActionResponse, ErrorResponse, SuccessResponse]  # noqa: UP007
+Body = Union[Request, Response]  # noqa: UP007
 
 BodyT = TypeVar('BodyT', bound=Body)
 RequestT = TypeVar('RequestT', bound=Request)

--- a/academy/mypy_plugin.py
+++ b/academy/mypy_plugin.py
@@ -46,14 +46,9 @@ from __future__ import annotations
 
 import functools
 import re
-import sys
-from typing import Callable
+from collections.abc import Callable
+from typing import ParamSpec
 from typing import TypeVar
-
-if sys.version_info >= (3, 10):  # pragma: >=3.10 cover
-    from typing import ParamSpec
-else:  # pragma: <3.10 cover
-    from typing_extensions import ParamSpec
 
 from mypy.checker import TypeChecker
 from mypy.errorcodes import ATTR_DEFINED

--- a/academy/runtime.py
+++ b/academy/runtime.py
@@ -8,10 +8,10 @@ import logging
 import sys
 import uuid
 from collections.abc import Awaitable
+from collections.abc import Callable
 from concurrent.futures import ThreadPoolExecutor
 from types import TracebackType
 from typing import Any
-from typing import Callable
 from typing import Generic
 from typing import TypeVar
 

--- a/academy/socket.py
+++ b/academy/socket.py
@@ -11,9 +11,9 @@ import sys
 import time
 from collections.abc import AsyncGenerator
 from collections.abc import Awaitable
+from collections.abc import Callable
 from contextlib import asynccontextmanager
 from types import TracebackType
-from typing import Callable
 
 if sys.version_info >= (3, 11):  # pragma: >=3.11 cover
     from typing import Self

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ maintainers = [
 ]
 description = "Build and deploy stateful agents across federated resources."
 readme = "README.md"
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 license = {text = "MIT"}
 classifiers = [
     "License :: OSI Approved :: MIT License",
@@ -127,7 +127,7 @@ markers = [
 
 [tool.ruff]
 line-length = 79
-target-version = "py39"
+target-version = "py310"
 
 [tool.ruff.format]
 indent-style = "space"

--- a/testing/fixture.py
+++ b/testing/fixture.py
@@ -4,8 +4,8 @@ import os
 import pathlib
 import uuid
 from collections.abc import AsyncGenerator
+from collections.abc import Callable
 from typing import Any
-from typing import Callable
 
 import pytest
 import pytest_asyncio

--- a/testing/utils.py
+++ b/testing/utils.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
+from collections.abc import Callable
 from collections.abc import Mapping
 from typing import Any
-from typing import Callable
 from urllib.parse import parse_qsl
 
 from requests import PreparedRequest

--- a/tests/unit/exchange/proxystore_test.py
+++ b/tests/unit/exchange/proxystore_test.py
@@ -1,9 +1,9 @@
 from __future__ import annotations
 
 import pickle
+from collections.abc import Callable
 from collections.abc import Generator
 from typing import Any
-from typing import Callable
 
 import pytest
 from proxystore.connectors.local import LocalConnector
@@ -90,7 +90,11 @@ async def test_wrap_basic_transport_functionality(
         assert isinstance(recv_request, ActionRequest)
         assert sent_request_message.tag == recv_request_message.tag
 
-        for old, new in zip(sent_request.get_args(), recv_request.get_args()):
+        for old, new in zip(
+            sent_request.get_args(),
+            recv_request.get_args(),
+            strict=True,
+        ):
             assert (type(new) is Proxy) == should_proxy(old)
             # will resolve the proxy if it exists
             assert old == new

--- a/tests/unit/manager_test.py
+++ b/tests/unit/manager_test.py
@@ -3,19 +3,12 @@ from __future__ import annotations
 import asyncio
 import multiprocessing
 import pathlib
-import sys
+from collections.abc import Callable
 from concurrent.futures import Future
 from concurrent.futures import ProcessPoolExecutor
 from concurrent.futures import ThreadPoolExecutor
 from typing import Any
-from typing import Callable
-
-from academy.handle import Handle
-
-if sys.version_info >= (3, 10):  # pragma: >=3.10 cover
-    from typing import ParamSpec
-else:  # pragma: <3.10 cover
-    from typing_extensions import ParamSpec
+from typing import ParamSpec
 
 import pytest
 
@@ -27,6 +20,7 @@ from academy.exchange import HttpExchangeFactory
 from academy.exchange import LocalExchangeFactory
 from academy.exchange import LocalExchangeTransport
 from academy.exchange import UserExchangeClient
+from academy.handle import Handle
 from academy.manager import Manager
 from testing.agents import EmptyAgent
 from testing.agents import IdentityAgent

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 envlist =
-    py{39,310,311,312,313,314}
-    py{39,310,311,312,313,314}-integration
+    py{310,311,312,313,314}
+    py{310,311,312,313,314}-integration
     docs
     pre-commit
 
@@ -15,9 +15,9 @@ commands =
     # https://github.com/nedbat/coveragepy/issues/1595
     # We'll rely on the other versions for 100% coverage
     py311: coverage report --omit=tests/integration/* --fail-under 98
-    py{39,310,312,313,314}: coverage report --omit=tests/integration/*
+    py{310,312,313,314}: coverage report --omit=tests/integration/*
 
-[testenv:py{39,310,311,312,313}-integration]
+[testenv:py{310,311,312,313,314}-integration]
 extras = dev
 commands =
     coverage erase


### PR DESCRIPTION
## Summary
<!--- Provide a summary of the changes --->

Changes the minimum supported Python version to 3.10 now that Python 3.9 is EOL. Most of the changes are Ruff's pyupgrade with the change to the min version.

I had to add a couple `# noqa: UP007` since top-level union types can use `X | Y` in 3.10 rather than `Union`. I'm going to fix this in a later PR as we can now remove union/optional from pydantic basemodels as well and I didn't want this PR to be too noisy.

## Related Issues N/A
<!--- List any issue numbers above that this PR addresses --->

## Changes
<!--- Check which of the following changes were made --->

- [ ] Breaking (backwards incompatible changes to public interfaces)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (non-breaking change or feature addition)
- [ ] Refactor (internal code or design clean up)
- [ ] Documentation (no changes to the code)
- [ ] Test (changes or additions to testing)
- [ ] Build (change to CI workflows or build processes)
- [x] Package (changes to package metadata or dependency versions)

## Testing
<!--- Please describe the test ran to verify changes --->

N/A

## Pull Request Checklist

Please confirm the PR meets the following requirements.
- [x] Relevant tags are added based on the types of changes.
- [x] Code changes pass `pre-commit` (e.g., ruff, mypy, etc.).
- [x] Tests have been added to show the fix is effective or that the new feature works.
- [x] New and existing unit tests pass locally with the changes.
- [x] Docs have been updated and reviewed if relevant.
