### PR TITLE
Update Pydantic BaseModel type annotations

### DIFF
--- a/academy/exchange/cloud/config.py
+++ b/academy/exchange/cloud/config.py
@@ -8,12 +8,9 @@ import pathlib
 import sys
 from typing import Any
 from typing import BinaryIO
-from typing import Dict  # noqa: UP035
 from typing import Literal
-from typing import Optional
 from typing import Protocol
 from typing import TypeVar
-from typing import Union
 
 if sys.version_info >= (3, 11):  # pragma: >=3.11 cover
     from typing import Self
@@ -49,11 +46,8 @@ class ExchangeAuthConfig(BaseModel):
 
     model_config = ConfigDict(extra='forbid')
 
-    method: Optional[Literal['globus']] = None  # noqa: UP045
-    kwargs: Dict[str, Any] = Field(  # noqa: UP006
-        default_factory=dict,
-        repr=False,
-    )
+    method: Literal['globus'] | None = None
+    kwargs: dict[str, Any] = Field(default_factory=dict, repr=False)
 
 
 class BackendConfig(Protocol):
@@ -94,10 +88,7 @@ class RedisBackendConfig(BaseModel):
     message_size_limit_kb: int = Field(default=1024, gt=0, le=1024 * 512)
     mailbox_expiration_d: float = Field(default=7, gt=0)
     gravestone_expiration_d: float = Field(default=365, gt=0)
-    kwargs: Dict[str, Any] = Field(  # noqa: UP006
-        default_factory=dict,
-        repr=False,
-    )
+    kwargs: dict[str, Any] = Field(default_factory=dict, repr=False)
     kind: Literal['redis'] = Field(default='redis', repr=False)
 
     def get_backend(self) -> MailboxBackend:
@@ -114,7 +105,7 @@ class RedisBackendConfig(BaseModel):
         )
 
 
-BackendConfigT = Union[PythonBackendConfig, RedisBackendConfig]  # noqa: UP007
+BackendConfigT = PythonBackendConfig | RedisBackendConfig
 
 
 class ExchangeServingConfig(BaseModel):
@@ -133,12 +124,12 @@ class ExchangeServingConfig(BaseModel):
 
     host: str = 'localhost'
     port: int = 8700
-    certfile: Optional[str] = None  # noqa: UP045
-    keyfile: Optional[str] = None  # noqa: UP045
+    certfile: str | None = None
+    keyfile: str | None = None
     auth: ExchangeAuthConfig = Field(default_factory=ExchangeAuthConfig)
     backend: BackendConfigT = Field(default_factory=PythonBackendConfig)
-    log_file: Optional[str] = None  # noqa: UP045
-    log_level: Union[int, str] = logging.INFO  # noqa: UP007
+    log_file: str | None = None
+    log_level: int | str = logging.INFO
 
     @classmethod
     def from_toml(cls, filepath: str | pathlib.Path) -> Self:

--- a/academy/identifier.py
+++ b/academy/identifier.py
@@ -5,10 +5,8 @@ import uuid
 from typing import Any
 from typing import Generic
 from typing import Literal
-from typing import Optional
 from typing import TYPE_CHECKING
 from typing import TypeVar
-from typing import Union
 
 if sys.version_info >= (3, 11):  # pragma: >=3.11 cover
     from typing import Self
@@ -28,7 +26,7 @@ class AgentId(BaseModel, Generic[AgentT]):
     """Unique identifier for an agent entity in a multi-agent system."""
 
     uid: uuid.UUID = Field()
-    name: Optional[str] = Field(None)  # noqa: UP045
+    name: str | None = Field(None)
     role: Literal['agent'] = Field('agent', repr=False)
 
     model_config = ConfigDict(
@@ -61,7 +59,7 @@ class UserId(BaseModel):
     """Unique identifier for a user entity in a multi-agent system."""
 
     uid: uuid.UUID = Field()
-    name: Optional[str] = Field(None)  # noqa: UP045
+    name: str | None = Field(None)
     role: Literal['user'] = Field('user', repr=False)
 
     model_config = ConfigDict(
@@ -91,7 +89,7 @@ class UserId(BaseModel):
 
 
 if TYPE_CHECKING:
-    EntityId = Union[AgentId[Any], UserId]  # noqa: UP007
+    EntityId = AgentId[Any] | UserId
     """EntityId union type for type annotations."""
 else:
     # Pydantic produces validation errors with Agent[Any] in versions
@@ -100,4 +98,4 @@ else:
     # stricter requirements.
     # Issue: https://github.com/pydantic/pydantic/issues/9414
     # Fix: https://github.com/pydantic/pydantic/pull/10666
-    EntityId = Union[AgentId, UserId]  # noqa: UP007
+    EntityId = AgentId | UserId

--- a/academy/message.py
+++ b/academy/message.py
@@ -8,9 +8,7 @@ from typing import Any
 from typing import Generic
 from typing import get_args
 from typing import Literal
-from typing import Optional
 from typing import TypeVar
-from typing import Union
 
 if sys.version_info >= (3, 11):  # pragma: >=3.11 cover
     from typing import Self
@@ -109,7 +107,7 @@ class PingRequest(BaseModel):
 class ShutdownRequest(BaseModel):
     """Agent shutdown request message."""
 
-    terminate: Optional[bool] = Field(  # noqa: UP045
+    terminate: bool | None = Field(
         None,
         description='Override the termination behavior of the agent.',
     )
@@ -135,7 +133,7 @@ class ActionResponse(BaseModel):
     model_config = DEFAULT_MUTABLE_CONFIG
 
     @field_serializer('result', when_used='json')
-    def _pickle_and_encode_result(self, obj: Any) -> Optional[list[Any]]:  # noqa: UP045
+    def _pickle_and_encode_result(self, obj: Any) -> list[Any] | None:
         if (
             isinstance(obj, list)
             and len(obj) == 2  # noqa PLR2004
@@ -182,7 +180,7 @@ class ErrorResponse(BaseModel):
     model_config = DEFAULT_MUTABLE_CONFIG
 
     @field_serializer('exception', when_used='json')
-    def _pickle_and_encode_obj(self, obj: Any) -> Optional[str]:  # noqa: UP045
+    def _pickle_and_encode_obj(self, obj: Any) -> str | None:
         raw = pickle.dumps(obj)
         return base64.b64encode(raw).decode('utf-8')
 
@@ -208,9 +206,9 @@ class SuccessResponse(BaseModel):
     model_config = DEFAULT_FROZEN_CONFIG
 
 
-Request = Union[ActionRequest, PingRequest, ShutdownRequest]  # noqa: UP007
-Response = Union[ActionResponse, ErrorResponse, SuccessResponse]  # noqa: UP007
-Body = Union[Request, Response]  # noqa: UP007
+Request = ActionRequest | PingRequest | ShutdownRequest
+Response = ActionResponse | ErrorResponse | SuccessResponse
+Body = Request | Response
 
 BodyT = TypeVar('BodyT', bound=Body)
 RequestT = TypeVar('RequestT', bound=Request)
@@ -231,7 +229,7 @@ class Header(BaseModel):
         default_factory=uuid.uuid4,
         description='Unique message tag used to match requests and responses.',
     )
-    label: Optional[uuid.UUID] = Field(  # noqa: UP045
+    label: uuid.UUID | None = Field(
         None,
         description=(
             'Optional label used to disambiguate response messages when '


### PR DESCRIPTION
## Summary
<!--- Provide a summary of the changes --->

Now that the min python version is 3.10 we no longer need to use `Optional`, `Union`, `Dict`, etc for pydantic model type annotations.

This does not change any logic---just removes a bunch of `# noqa: UPXXX` and simplifies annotations/imports.

## Related Issues
<!--- List any issue numbers above that this PR addresses --->

N/A

## Changes
<!--- Check which of the following changes were made --->

- [ ] Breaking (backwards incompatible changes to public interfaces)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (non-breaking change or feature addition)
- [x] Refactor (internal code or design clean up)
- [ ] Documentation (no changes to the code)
- [ ] Test (changes or additions to testing)
- [ ] Build (change to CI workflows or build processes)
- [ ] Package (changes to package metadata or dependency versions)

## Testing
<!--- Please describe the test ran to verify changes --->

N/A

## Pull Request Checklist

Please confirm the PR meets the following requirements.
- [x] Relevant tags are added based on the types of changes.
- [x] Code changes pass `pre-commit` (e.g., ruff, mypy, etc.).
- [x] Tests have been added to show the fix is effective or that the new feature works.
- [x] New and existing unit tests pass locally with the changes.
- [x] Docs have been updated and reviewed if relevant.
