### PR TITLE
Fix Error When Importing Agent

### DIFF
--- a/academy/exchange/client.py
+++ b/academy/exchange/client.py
@@ -13,6 +13,7 @@ from typing import Any
 from typing import Generic
 from typing import TYPE_CHECKING
 from typing import TypeAlias
+from typing import TypeVar
 from weakref import WeakValueDictionary
 
 if sys.version_info >= (3, 11):  # pragma: >=3.11 cover
@@ -20,7 +21,6 @@ if sys.version_info >= (3, 11):  # pragma: >=3.11 cover
 else:  # pragma: <3.11 cover
     from typing_extensions import Self
 
-import academy.agent as aa
 from academy.exception import MailboxTerminatedError
 from academy.exchange.transport import AgentRegistration
 from academy.exchange.transport import ExchangeTransportT
@@ -36,7 +36,11 @@ from academy.message import RequestT_co
 from academy.task import spawn_guarded_background_task
 
 if TYPE_CHECKING:
+    from academy.agent import Agent
+    from academy.agent import AgentT
     from academy.exchange.factory import ExchangeFactory
+else:
+    AgentT = TypeVar('AgentT')
 
 
 logger = logging.getLogger(__name__)
@@ -103,7 +107,7 @@ class ExchangeClient(abc.ABC, Generic[ExchangeTransportT]):
 
     async def discover(
         self,
-        agent: type[aa.Agent],
+        agent: type[Agent],
         *,
         allow_subclasses: bool = True,
     ) -> tuple[AgentId[Any], ...]:
@@ -126,7 +130,7 @@ class ExchangeClient(abc.ABC, Generic[ExchangeTransportT]):
         """Get an exchange factory."""
         return self._transport.factory()
 
-    def register_handle(self, handle: Handle[aa.AgentT]) -> None:
+    def register_handle(self, handle: Handle[AgentT]) -> None:
         """Register an existing handle to receive messages.
 
         Args:
@@ -136,10 +140,10 @@ class ExchangeClient(abc.ABC, Generic[ExchangeTransportT]):
 
     async def register_agent(
         self,
-        agent: type[aa.AgentT],
+        agent: type[AgentT],
         *,
         name: str | None = None,
-    ) -> AgentRegistration[aa.AgentT]:
+    ) -> AgentRegistration[AgentT]:
         """Register a new agent and associated mailbox with the exchange.
 
         Args:
@@ -221,7 +225,7 @@ class ExchangeClient(abc.ABC, Generic[ExchangeTransportT]):
 
 class AgentExchangeClient(
     ExchangeClient[ExchangeTransportT],
-    Generic[aa.AgentT, ExchangeTransportT],
+    Generic[AgentT, ExchangeTransportT],
 ):
     """Agent exchange client.
 
@@ -239,7 +243,7 @@ class AgentExchangeClient(
 
     def __init__(
         self,
-        agent_id: AgentId[aa.AgentT],
+        agent_id: AgentId[AgentT],
         transport: ExchangeTransportT,
         request_handler: RequestHandler[RequestT_co],
     ) -> None:
@@ -248,7 +252,7 @@ class AgentExchangeClient(
         self._request_handler = request_handler
 
     @property
-    def client_id(self) -> AgentId[aa.AgentT]:
+    def client_id(self) -> AgentId[AgentT]:
         """Agent ID of the client."""
         return self._agent_id
 

--- a/academy/exchange/proxystore.py
+++ b/academy/exchange/proxystore.py
@@ -11,8 +11,6 @@ from typing import Generic
 from typing import TYPE_CHECKING
 from typing import TypeVar
 
-from academy.agent import Agent
-from academy.agent import AgentT
 from academy.exchange.factory import ExchangeFactory
 from academy.exchange.transport import AgentRegistration
 from academy.exchange.transport import AgentRegistrationT


### PR DESCRIPTION
## Summary
From a change in #242, `from academy.agent import Agent` raises an error:
```
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/alokvk2/research/agents/academy/academy/agent.py", line 31, in <module>
    import academy.manager as m
  File "/home/alokvk2/research/agents/academy/academy/manager.py", line 24, in <module>
    import academy.exchange as ae
  File "/home/alokvk2/research/agents/academy/academy/exchange/__init__.py", line 3, in <module>
    from academy.exchange.client import AgentExchangeClient
  File "/home/alokvk2/research/agents/academy/academy/exchange/client.py", line 224, in <module>
    Generic[aa.AgentT, ExchangeTransportT],
            ^^^^^^^^^
AttributeError: partially initialized module 'academy.agent' has no attribute 'AgentT' (most likely due to a circular import)
```
This error is not caught by CI because it is sensitive to the order of imports.

Fixing the imports in `client.py` to follow the same pattern that exists in the other files fixes the issue


## Related Issues
<!--- List any issue numbers above that this PR addresses --->
NA

## Changes
<!--- Check which of the following changes were made --->

- [ ] Breaking (backwards incompatible changes to public interfaces)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (non-breaking change or feature addition)
- [ ] Refactor (internal code or design clean up)
- [ ] Documentation (no changes to the code)
- [ ] Test (changes or additions to testing)
- [ ] Build (change to CI workflows or build processes)
- [ ] Package (changes to package metadata or dependency versions)

## Testing
<!--- Please describe the test ran to verify changes --->

N/A

## Pull Request Checklist

Please confirm the PR meets the following requirements.
- [x] Relevant tags are added based on the types of changes.
- [x] Code changes pass `pre-commit` (e.g., ruff, mypy, etc.).
- [x] Tests have been added to show the fix is effective or that the new feature works.
- [x] New and existing unit tests pass locally with the changes.
- [x] Docs have been updated and reviewed if relevant.
