### PR TITLE
Removing system exit on token validation error

### DIFF
--- a/academy/exchange/cloud/login.py
+++ b/academy/exchange/cloud/login.py
@@ -16,7 +16,6 @@ from globus_sdk.globus_app import GlobusApp
 from globus_sdk.globus_app import GlobusAppConfig
 from globus_sdk.globus_app import UserApp
 from globus_sdk.login_flows import CommandLineLoginFlowManager
-from globus_sdk.tokenstorage import TokenValidationError
 
 from academy.exchange.cloud.scopes import AcademyExchangeScopes
 from academy.exchange.cloud.token_store import SafeSQLiteTokenStorage
@@ -214,12 +213,9 @@ def get_auth_headers(
                 ],
             },
         )
-        try:
-            authorizer = app.get_authorizer(
-                AcademyExchangeScopes.resource_server,
-            )
-        except TokenValidationError:
-            raise SystemExit(1) from None
+        authorizer = app.get_authorizer(
+            AcademyExchangeScopes.resource_server,
+        )
 
         bearer = authorizer.get_authorization_header()
         assert bearer is not None

--- a/tests/unit/exchange/cloud/login_test.py
+++ b/tests/unit/exchange/cloud/login_test.py
@@ -12,7 +12,6 @@ from globus_sdk.globus_app import ClientApp
 from globus_sdk.globus_app import GlobusAppConfig
 from globus_sdk.globus_app import UserApp
 from globus_sdk.tokenstorage import MemoryTokenStorage
-from globus_sdk.tokenstorage import TokenValidationError
 
 from academy.exchange.cloud.login import ACADEMY_GLOBUS_CLIENT_ID_ENV_NAME
 from academy.exchange.cloud.login import ACADEMY_GLOBUS_CLIENT_SECRET_ENV_NAME
@@ -152,21 +151,3 @@ def test_get_auth_headers_globus(globus_app) -> None:
         ),
     ):
         assert get_auth_headers('globus')['Authorization'] == header
-
-
-def test_get_auth_headers_globus_missing(globus_app) -> None:
-    with (
-        mock.patch(
-            'academy.exchange.cloud.login.get_globus_app',
-            return_value=globus_app,
-        ),
-        mock.patch.object(
-            globus_app,
-            'get_authorizer',
-            side_effect=TokenValidationError(),
-        ),
-        pytest.raises(
-            SystemExit,
-        ),
-    ):
-        assert get_auth_headers('globus')


### PR DESCRIPTION
## Summary
Instead of raising exceptions from `app.get_authorizer()` we used to force a SystemExit(). To be honest, I don't know why we did that. This PR directly raises any exceptions from `app.get_authorizer()`.

## Related Issues
NA

## Changes
<!--- Check which of the following changes were made --->

- [ ] Breaking (backwards incompatible changes to public interfaces)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (non-breaking change or feature addition)
- [x] Refactor (internal code or design clean up)
- [ ] Documentation (no changes to the code)
- [ ] Test (changes or additions to testing)
- [ ] Build (change to CI workflows or build processes)
- [ ] Package (changes to package metadata or dependency versions)

## Testing
<!--- Please describe the test ran to verify changes --->

N/A

## Pull Request Checklist

Please confirm the PR meets the following requirements.
- [x] Relevant tags are added based on the types of changes.
- [x] Code changes pass `pre-commit` (e.g., ruff, mypy, etc.).
- [] Tests have been added to show the fix is effective or that the new feature works.
- [x] New and existing unit tests pass locally with the changes.
- [] Docs have been updated and reviewed if relevant.
