### PR TITLE
Add distributed log configuration system

### DIFF
--- a/academy/exchange/cloud/config.py
+++ b/academy/exchange/cloud/config.py
@@ -25,8 +25,8 @@ from pydantic import Field
 from academy.exchange.cloud.backend import MailboxBackend
 from academy.exchange.cloud.backend import PythonBackend
 from academy.exchange.cloud.backend import RedisBackend
-from academy.logging import _Formatter
-from academy.logging import _os_thread_filter
+from academy.logging.helpers import _Formatter
+from academy.logging.helpers import _os_thread_filter
 
 if sys.version_info >= (3, 11):  # pragma: >=3.11 cover
     import tomllib

--- a/academy/logging/configs/base.py
+++ b/academy/logging/configs/base.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+import abc
+import uuid
+from collections.abc import Callable
+
+
+class LogConfig(abc.ABC):
+    """Implementations of this class can initialize Academy logging.
+
+    Academy logging is built around Python's `logging` system, with
+    an Academy-provided configuration system that allows multiple
+    configurations to be initialized and deinitialized within the
+    same process.
+
+    Configurations which might be shared between processes should expect to
+    be pickled/unpickled multiple times as they move around an Academy
+    distributed system.
+
+    A log configuration is identified across the distributed system by
+    the `uuid` attribute. This allows the `log_context` context manager to
+    only initialize a particular configuration once per process, and only
+    deinitialize it when all users of it are finished with it.
+    """
+
+    def __init__(self) -> None:
+        self.uuid = str(uuid.uuid4())
+
+    @abc.abstractmethod
+    def init_logging(self) -> Callable[[], None]:
+        """Initialize logging in current process.
+
+        This should not be called by end users. Instead, users should use
+        `with log_context(config)` to ensure that the configuration is
+        initialized and deinitialized properly when there are overlapping
+        uses of the same configuration.
+
+        This should return a callback to uninitialize the logging initialized
+        by this call. `log_context` will call that callback when appropriate.
+        """
+        ...

--- a/academy/logging/configs/console.py
+++ b/academy/logging/configs/console.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+import logging
+import sys
+from collections.abc import Callable
+
+from academy.logging.configs.base import LogConfig
+from academy.logging.helpers import _Formatter
+from academy.logging.helpers import _os_thread_filter
+
+logger = logging.getLogger(__name__)
+
+
+class ConsoleLogging(LogConfig):
+    """Configures logging to the console."""
+
+    def __init__(
+        self,
+        *,
+        level: int | str = logging.INFO,
+        color: bool = True,
+        extra: int = False,
+    ) -> None:
+        super().__init__()
+        self.level = level
+        self.color = color
+        self.extra = extra
+
+    def init_logging(self) -> Callable[[], None]:
+        """Initialize logging to console."""
+        stdout_handler = logging.StreamHandler(sys.stdout)
+        stdout_handler.setFormatter(
+            _Formatter(color=self.color, extra=self.extra),
+        )
+        stdout_handler.setLevel(self.level)
+        if self.extra:
+            stdout_handler.addFilter(_os_thread_filter)
+
+        root_logger = logging.getLogger()
+        root_logger.addHandler(stdout_handler)
+        root_logger.level = min(root_logger.level, stdout_handler.level)
+
+        logging.captureWarnings(True)
+
+        logger.info(
+            'Configured logger (stdout-level=%s)',
+            logging.getLevelName(self.level)
+            if isinstance(self.level, int)
+            else self.level,
+        )
+
+        def uninitialize_callback() -> None:
+            root_logger.removeHandler(stdout_handler)
+            stdout_handler.close()
+
+        return uninitialize_callback

--- a/academy/logging/configs/file.py
+++ b/academy/logging/configs/file.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+import logging
+import pathlib
+from collections.abc import Callable
+
+from academy.logging.configs.base import LogConfig
+from academy.logging.helpers import _Formatter
+from academy.logging.helpers import _os_thread_filter
+
+logger = logging.getLogger(__name__)
+
+
+class FileLogging(LogConfig):
+    """Configures logging to a file."""
+
+    def __init__(
+        self,
+        *,
+        logfile: str | pathlib.Path,
+        level: int | str = logging.INFO,
+        extra: int = False,
+    ) -> None:
+        super().__init__()
+        self.logfile = logfile
+        self.level = level
+        self.extra = extra
+
+    def init_logging(self) -> Callable[[], None]:
+        """Initialize logging to file."""
+        path = pathlib.Path(self.logfile)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        file_handler = logging.FileHandler(path)
+        file_handler.setFormatter(
+            _Formatter(color=False, extra=self.extra),
+        )
+        file_handler.setLevel(self.level)
+        if self.extra:
+            file_handler.addFilter(_os_thread_filter)
+
+        root_logger = logging.getLogger()
+        root_logger.addHandler(file_handler)
+
+        # if the root logger is not going to log at this level, reconfigure it
+        # to do so. (smaller log levels = more logging)
+        # for example, by default the root logger logs at level 30 WARNING,
+        # which means INFO (20) logs will not be recorded. But implicitly
+        # if the user is asking for INFO logs, we should provide INFO logs.
+        root_logger.level = min(root_logger.level, file_handler.level)
+
+        logging.captureWarnings(True)
+
+        logger.info(
+            'Configured logger (file-level=%s)',
+            logging.getLevelName(self.level)
+            if isinstance(self.level, int)
+            else self.level,
+        )
+        file_handler.flush()
+
+        def uninitialize_callback() -> None:
+            root_logger.removeHandler(file_handler)
+            file_handler.close()
+
+        return uninitialize_callback
+
+    def __repr__(self) -> str:
+        return (
+            f'<file config {self.logfile}, {self.level}, extra={self.extra}>'
+        )

--- a/academy/logging/configs/jsonpool.py
+++ b/academy/logging/configs/jsonpool.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+import logging
+import pathlib
+import uuid
+from collections.abc import Callable
+
+from academy.logging.configs.base import LogConfig
+from academy.logging.helpers import JSONHandler
+
+logger = logging.getLogger(__name__)
+
+
+class JSONPoolLogging(LogConfig):
+    """Configures logging to files in home directory based pool of logs.
+
+    This feature is aimed at mechanical processing of logs, rather than
+    human readability.
+
+    Logs written by this configuration are stored in JSON format under
+    `~/local/share/academy/logs/`
+
+    Under that directory, logs are first separated into directories by
+    the (distributed) identity of the log configuration: logs configured
+    by the same JSONPoolLogging object, or by a serialized/deserialized
+    copy of the same object, will appear under the same directory.
+
+    Within that directory, each instance of log initialization will get a
+    new log file.
+
+    This logger is not configurable: it is intended to capture full debug
+    logs from the root, with selection of log records made during the
+    mechanical analysis stage.
+    """
+
+    def __init__(
+        self,
+    ) -> None:
+        super().__init__()
+
+    def init_logging(self) -> Callable[[], None]:
+        """Initialize JSON logging into shared pool."""
+        instance_id = str(uuid.uuid4())
+
+        # Home resolution is deferred until init_logging time because the path
+        # can be different on every invocation as the config object is moved
+        # between execution hosts.
+        path = (
+            pathlib.Path.home()
+            / 'local'
+            / 'share'
+            / 'academy'
+            / 'logs'
+            / self.uuid
+            / instance_id
+        )
+        path.parent.mkdir(parents=True, exist_ok=True)
+
+        json_handler = JSONHandler(path.with_suffix('.jsonlog'))
+        json_handler.setLevel(logging.DEBUG)
+
+        root_logger = logging.getLogger()
+        root_logger.addHandler(json_handler)
+        root_logger.level = min(root_logger.level, json_handler.level)
+
+        logger.info(
+            'Configured JSONPoolLogging (pool uuid=%s, path=%s)',
+            self.uuid,
+            path,
+        )
+
+        def uninitialize_callback() -> None:
+            root_logger.removeHandler(json_handler)
+            json_handler.close()
+
+        return uninitialize_callback

--- a/academy/logging/configs/multi.py
+++ b/academy/logging/configs/multi.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+import logging
+from collections.abc import Callable
+
+from academy.logging.configs.base import LogConfig
+
+logger = logging.getLogger(__name__)
+
+
+class MultiLogging(LogConfig):
+    """This captures a collection of other LogConfigs.
+
+    The configurations can be (de)initialized and moved around a distributed
+    system all together.
+    """
+
+    def __init__(
+        self,
+        configs: list[LogConfig],
+    ) -> None:
+        super().__init__()
+        self._configs = configs
+
+    def init_logging(self) -> Callable[[], None]:
+        """Initializes logging for all of the supplied configs."""
+        uninits = [c.init_logging() for c in self._configs]
+
+        def uninit_callback() -> None:
+            for uninit in uninits:
+                assert callable(uninit)
+                uninit()
+
+        return uninit_callback
+
+    def __repr__(self) -> str:
+        return (
+            '<MultiLogging ['
+            + ', '.join([repr(r) for r in self._configs])
+            + '>'
+        )

--- a/academy/logging/helpers.py
+++ b/academy/logging/helpers.py
@@ -1,14 +1,20 @@
 from __future__ import annotations
 
+import contextlib
 import json
 import logging
 import pathlib
 import sys
 import threading
 from asyncio import Future
+from collections.abc import Callable
+from collections.abc import Generator
 from typing import Any
 
+from academy.logging.configs.base import LogConfig
+
 logger = logging.getLogger(__name__)
+
 
 # extra keys with this prefix will be added to human-readable logs
 # when `extra > 1`
@@ -38,10 +44,12 @@ class _Formatter(logging.Formatter):
             self.reset = ''
 
         if extra:
-            extra_fmt = (
-                f'{self.green}[tid=%(os_thread)d pid=%(process)d '
-                f'task=%(taskName)s] {self.reset} '
-            )
+            extra_fmt = f'{self.green}[tid=%(os_thread)d pid=%(process)d'
+
+            if sys.version_info >= (3, 12):  # pragma: >3.12 cover
+                extra_fmt += ' task=%(taskName)s'
+
+            extra_fmt += f'] {self.reset} '
         else:
             extra_fmt = ''
 
@@ -92,82 +100,6 @@ def _os_thread_filter(
     return record
 
 
-def init_logging(  # noqa: PLR0913
-    level: int | str = logging.INFO,
-    *,
-    logfile: str | pathlib.Path | None = None,
-    logfile_level: int | str | None = None,
-    color: bool = True,
-    extra: int = False,
-    force: bool = False,
-) -> logging.Logger:
-    """Initialize global logger.
-
-    Args:
-        level: Minimum logging level.
-        logfile: Configure a file handler for this path.
-        logfile_level: Minimum logging level for the file handler. Defaults
-            to that of `level`.
-        color: Use colorful logging for stdout.
-        extra: Include extra info in log messages, such as thread ID and
-            process ID. This is helpful for debugging. True or 1 adds some
-            extra info. 2 adds on observability-style logging of key-value
-            metadata, and adds a second logfile formatted as JSON.
-        force: Remove any existing handlers attached to the root
-            handler. This option is useful to silencing the third-party
-            package logging. Note: should not be set when running inside
-            pytest.
-
-    Returns:
-        The root logger.
-    """
-    stdout_handler = logging.StreamHandler(sys.stdout)
-    stdout_handler.setFormatter(_Formatter(color=color, extra=extra))
-    stdout_handler.setLevel(level)
-    if extra:
-        stdout_handler.addFilter(_os_thread_filter)
-    handlers: list[logging.Handler] = [stdout_handler]
-
-    if logfile is not None:
-        logfile_level = level if logfile_level is None else logfile_level
-        path = pathlib.Path(logfile)
-        path.parent.mkdir(parents=True, exist_ok=True)
-        human_handler = logging.FileHandler(path)
-        human_handler.setFormatter(_Formatter(color=False, extra=extra))
-        human_handler.setLevel(logfile_level)
-        if extra:
-            human_handler.addFilter(_os_thread_filter)
-        handlers.append(human_handler)
-
-        if extra > 1:
-            json_handler = JSONHandler(path.with_suffix('.jsonlog'))
-            json_handler.setLevel(logfile_level)
-            handlers.append(json_handler)
-
-    logging.basicConfig(
-        datefmt='%Y-%m-%d %H:%M:%S',
-        level=logging.NOTSET,
-        handlers=handlers,
-        force=force,
-    )
-
-    # This needs to be after the configuration of the root logger because
-    # warnings get logged to a 'py.warnings' logger.
-    logging.captureWarnings(True)
-
-    logger = logging.getLogger()
-    logger.info(
-        'Configured logger (stdout-level=%s, logfile=%s, logfile-level=%s)',
-        logging.getLevelName(level) if isinstance(level, int) else level,
-        logfile,
-        logging.getLevelName(logfile_level)
-        if isinstance(logfile_level, int)
-        else logfile_level,
-    )
-
-    return logger
-
-
 class JSONHandler(logging.Handler):
     """A LogHandler which outputs records as JSON objects, one per line."""
 
@@ -214,3 +146,68 @@ async def execute_and_log_traceback(
     except Exception:
         logger.exception('Background task raised an exception.')
         raise
+
+
+class _ConfigReference:
+    def __init__(self, uninit: Callable[[], None]) -> None:
+        self.count = 1
+        self.uninit = uninit
+
+
+# ID to reference count. ID is something very unique, such as the
+# string representation of a UUID or a message-id style string.
+# It is a string, so string comparison rules apply, not (for example)
+# UUID comparison rules.
+
+# This state is module scoped so that it is process-global, the same scope
+# as Python `logging` configuration.
+initialized_log_contexts: dict[str, _ConfigReference] = {}
+
+log_context_lock: threading.Lock = threading.Lock()
+
+
+@contextlib.contextmanager
+def log_context(c: LogConfig | None) -> Generator[None, None, None]:
+    """Context manager for using an LogConfig."""
+    if c is None:
+        # If there's no config, let the context body run without doing
+        # anything interesting with logging. This allows log_context
+        # to be used to wrap blocks when a user wants to only optionally
+        # configure logging.
+        yield
+        return
+
+    logger.debug(
+        f'Entering log_context context manager, with log config {c!r}',
+    )
+
+    with log_context_lock:
+        if c.uuid in initialized_log_contexts:
+            initialized_log_contexts[c.uuid].count += 1
+            logger.debug('Configuration already initialized')
+        else:
+            logger.debug(f'First entry to log config {c} (in this process)')
+            initialized_log_contexts[c.uuid] = _ConfigReference(
+                c.init_logging(),
+            )
+            assert callable(initialized_log_contexts[c.uuid].uninit), (
+                f'Log config {c} should have returned a callable'
+            )
+
+        assert c.uuid in initialized_log_contexts
+
+    yield
+
+    with log_context_lock:
+        # Buggy use of reference counting might have removed this from the
+        # structure, if unpaired references have been dropped.
+        assert c.uuid in initialized_log_contexts
+
+        if initialized_log_contexts[c.uuid].count > 1:
+            logger.debug('Configuration is still in use - not uninitializing')
+            initialized_log_contexts[c.uuid].count -= 1
+        else:
+            logger.debug('Configuration has no more users - uninitializing')
+            assert initialized_log_contexts[c.uuid].count == 1
+            initialized_log_contexts[c.uuid].uninit()
+            del initialized_log_contexts[c.uuid]

--- a/academy/logging/recommended.py
+++ b/academy/logging/recommended.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+import logging
+import pathlib
+
+from academy.logging.configs.base import LogConfig
+from academy.logging.configs.console import ConsoleLogging
+from academy.logging.configs.file import FileLogging
+from academy.logging.configs.multi import MultiLogging
+
+
+def recommended_logging(
+    level: int | str = logging.INFO,
+    *,
+    logfile: str | pathlib.Path | None = None,
+    logfile_level: int | str | None = None,
+    color: bool = True,
+    extra: int = False,
+) -> LogConfig:
+    """Returns a LogConfig that is hopefully useful to most users.
+
+    The config object can be passed to other environments to get the same
+    log configuration in those other environments.
+    """
+    configs: list[LogConfig] = []
+
+    # Always makes a console logger.
+    configs.append(ConsoleLogging(level=level, color=color, extra=extra))
+
+    # If a log file is specified, make human readable logger
+    if logfile is not None:
+        logfile_level = level if logfile_level is None else logfile_level
+        configs.append(
+            FileLogging(logfile=logfile, level=logfile_level, extra=extra),
+        )
+
+    lc = configs[0] if len(configs) == 1 else MultiLogging(configs)
+
+    return lc

--- a/academy/manager.py
+++ b/academy/manager.py
@@ -9,7 +9,6 @@ import warnings
 from collections.abc import Iterable
 from collections.abc import MutableMapping
 from concurrent.futures import Executor
-from concurrent.futures import ThreadPoolExecutor
 from types import TracebackType
 from typing import Any
 from typing import Generic
@@ -32,7 +31,8 @@ from academy.handle import exchange_context
 from academy.handle import Handle
 from academy.identifier import AgentId
 from academy.identifier import EntityId
-from academy.logging import init_logging
+from academy.logging.configs.base import LogConfig
+from academy.logging.helpers import log_context
 from academy.runtime import Runtime
 from academy.runtime import RuntimeConfig
 from academy.serialize import NoPickleMixin
@@ -54,9 +54,7 @@ class _RunSpec(Generic[AgentT, ExchangeTransportT]):
     agent_args: tuple[Any, ...]
     agent_kwargs: dict[str, Any]
     submit_kwargs: dict[str, Any]
-    init_logging: bool = False
-    loglevel: int | str = logging.INFO
-    logfile: str | None = None
+    log_config: LogConfig | None = None
 
 
 async def _run_agent_async(
@@ -89,16 +87,9 @@ def _run_agent_on_worker(
     academy_debug_mode: bool = False,
     **kwargs: Any,
 ) -> None:
-    if spec.init_logging:
-        if spec.logfile is not None:
-            logfile = spec.logfile.format(agent_id=spec.registration.agent_id)
-        else:
-            logfile = None
-
-        init_logging(level=spec.loglevel, logfile=logfile)
-
-    set_academy_debug(academy_debug_mode)
-    asyncio.run(_run_agent_async(spec))
+    with log_context(spec.log_config):
+        set_academy_debug(academy_debug_mode)
+        asyncio.run(_run_agent_async(spec))
 
 
 @dataclasses.dataclass
@@ -120,12 +111,6 @@ class Manager(Generic[ExchangeTransportT], NoPickleMixin):
         This class can be used as a context manager. Upon exiting the context,
         running agents will be shutdown, any agent handles created by the
         manager will be closed, and the executors will be shutdown.
-
-    Tip:
-        When using
-        [`ProcessPoolExecutors`][concurrent.futures.ProcessPoolExecutor],
-        use the `initializer` argument to configure logging in the worker
-        processes that will execute agents.
 
     Note:
         The manager takes ownership of the exchange client and executors,
@@ -159,6 +144,7 @@ class Manager(Generic[ExchangeTransportT], NoPickleMixin):
         *,
         default_executor: str = 'event_loop',
         max_retries: int = 0,
+        log_config: LogConfig | None = None,
     ) -> None:
         self._executors: dict[str, Executor | None] = {'event_loop': None}
         if isinstance(executors, Executor):
@@ -186,14 +172,17 @@ class Manager(Generic[ExchangeTransportT], NoPickleMixin):
 
         self._handles: dict[AgentId[Any], Handle[Any]] = {}
         self._acbs: dict[AgentId[Any], _ACB[Any]] = {}
+        self._log_config = log_config
 
+    async def __aenter__(self) -> Self:
+        self._log_context = log_context(self._log_config)
+        # nicer syntax for nesting context managers?
+        self._log_context.__enter__()
         logger.info(
-            'Initialized manager (%s)',
+            'Entered manager context (%s)',
             self.user_id,
             extra={'academy.user_id': self.user_id},
         )
-
-    async def __aenter__(self) -> Self:
         self.exchange_context_token = exchange_context.set(
             self.exchange_client,
         )
@@ -207,6 +196,7 @@ class Manager(Generic[ExchangeTransportT], NoPickleMixin):
     ) -> None:
         await self.close()
         exchange_context.reset(self.exchange_context_token)
+        self._log_context.__exit__(exc_type, exc_value, exc_traceback)
 
     def __repr__(self) -> str:
         executors_repr = ', '.join(
@@ -233,6 +223,7 @@ class Manager(Generic[ExchangeTransportT], NoPickleMixin):
         *,
         default_executor: str = 'event_loop',
         max_retries: int = 0,
+        log_config: LogConfig | None = None,
     ) -> Self:
         """Instantiate a new exchange client and manager from a factory."""
         client = await factory.create_user_client()
@@ -241,6 +232,7 @@ class Manager(Generic[ExchangeTransportT], NoPickleMixin):
             executors,
             default_executor=default_executor,
             max_retries=max_retries,
+            log_config=log_config,
         )
 
     @property
@@ -440,9 +432,7 @@ class Manager(Generic[ExchangeTransportT], NoPickleMixin):
         submit_kwargs: dict[str, Any] | None = None,
         name: str | None = None,
         registration: AgentRegistration[AgentT] | None = None,
-        init_logging: bool = False,
-        loglevel: int | str = logging.INFO,
-        logfile: str | None = None,
+        log_config: LogConfig | None = None,
     ) -> Handle[AgentT]:
         """Launch a new agent with a specified agent.
 
@@ -462,9 +452,8 @@ class Manager(Generic[ExchangeTransportT], NoPickleMixin):
             name: Readable name of the agent used when registering a new agent.
             registration: If `None`, a new agent will be registered with
                 the exchange.
-            init_logging: Initialize logging before running agent.
-            loglevel: Level of logging.
-            logfile: Location to write logs.
+            log_config: log configuration to use. If `None`, log configuration
+                will be inherited from the enclosing `Manager`.
 
         Returns:
             Handle (client bound) used to interact with the agent.
@@ -485,18 +474,6 @@ class Manager(Generic[ExchangeTransportT], NoPickleMixin):
                 f'{registration.agent_id} has already been executed.',
             )
 
-        if init_logging and (
-            executor_instance is None
-            or isinstance(executor_instance, ThreadPoolExecutor)
-        ):
-            warnings.warn(
-                f'`init_logging` was specified for agent '
-                f'{registration.agent_id} running in the same process as the '
-                f'Manager. `init_logging` should only be called once per '
-                f'process.',
-                stacklevel=2,
-            )
-
         agent_id = registration.agent_id
 
         spec = _RunSpec(
@@ -507,9 +484,7 @@ class Manager(Generic[ExchangeTransportT], NoPickleMixin):
             agent_args=() if args is None else args,
             agent_kwargs={} if kwargs is None else kwargs,
             submit_kwargs={} if submit_kwargs is None else submit_kwargs,
-            init_logging=init_logging,
-            loglevel=loglevel,
-            logfile=logfile,
+            log_config=self._log_config if log_config is None else log_config,
         )
 
         task = asyncio.create_task(

--- a/academy/task.py
+++ b/academy/task.py
@@ -6,7 +6,7 @@ from collections.abc import Coroutine
 from typing import Any
 
 from academy.debug import get_academy_debug
-from academy.logging import execute_and_log_traceback
+from academy.logging.helpers import execute_and_log_traceback
 
 logger = logging.getLogger(__name__)
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -6,25 +6,23 @@
 
 ### How to enable agent logging in the Manager?
 
-The [`Manager`][academy.manager.Manager] does not configure logging when an agent starts on a worker within an executor.
-We recommend using the worker initialization features of executors to configure logging, such as by calling [`init_logging()`][academy.logging.init_logging] or [`logging.basicConfig()`][logging.basicConfig].
-For example, use the `initializer` argument when using a [`ProcessPoolExecutor`][concurrent.futures.ProcessPoolExecutor].
+The [`Manager`][academy.manager.Manager] can configure logging when an agent starts on a worker within an executor.
+
+Pass a [`LogConfig`][academy.logging.configs.base.LogConfig] to `Manager.launch`.
 
 ```python
 import logging
 import multiprocessing
 from concurrent.futures import ProcessPoolExecutor
-from academy.logging import init_logging
+from academy.logging.helpers import log_context
 from academy.manager import Manager
 
 mp_context = multiprocessing.get_context('spawn')
 executor = ProcessPoolExecutor(
     max_workers=3,
-    initializer=init_logging,
-    initargs=(logging.INFO,),
     mp_context=mp_context,
 )
 
 async with await Manager(..., executors=executor) as manager:
-    ...
+    manager.launch(agent, log_config=...)
 ```

--- a/docs/get-started.md
+++ b/docs/get-started.md
@@ -31,7 +31,7 @@ import asyncio
 from concurrent.futures import ThreadPoolExecutor
 from academy.agent import Agent, action
 from academy.exchange import LocalExchangeFactory
-from academy.logging import init_logging
+from academy.logging.recommended import recommended_logging
 from academy.manager import Manager
 
 class ExampleAgent(Agent):  # (1)!
@@ -40,11 +40,11 @@ class ExampleAgent(Agent):  # (1)!
         return value * value
 
 async def main() -> None:
-    init_logging('INFO')
 
     async with await Manager.from_exchange_factory(  # (3)!
         factory=LocalExchangeFactory(),  # (4)!
         executors=ThreadPoolExecutor(),  # (5)!
+        log_config=recommended_logging(),
     ) as manager:
         agent_handle = await manager.launch(ExampleAgent())  # (6)!
 
@@ -143,15 +143,15 @@ import asyncio
 from concurrent.futures import ThreadPoolExecutor
 from academy.agent import Agent, action
 from academy.exchange import LocalExchangeFactory
-from academy.logging import init_logging
+from academy.logging.recommended import recommended_logging
 from academy.manager import Manager
 
 async def main() -> None:
-    init_logging(logging.INFO)
 
     async with await Manager.from_exchange_factory(
         factory=LocalExchangeFactory(),
         executors=ThreadPoolExecutor(),
+        log_config=recommended_logging(),
     ) as manager:
         lowerer = await manager.launch(Lowerer)
         reverser = await manager.launch(Reverser)

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -10,6 +10,25 @@ All future changes—including breaking changes and deprecations—will be docum
 
 Please refer to our [Version Policy](version-policy.md) for more details on when we make breaking changes.
 
+## Academy v0.5
+
+This version of Academy introduces new logging configuration which is intended to help users configure logging across multiple processes, and to provide a base for development of other log-oriented features (such as provenance tracking, and distributed/cloud based logging)
+
+The once-per-process `init_logging` helper function has been removed. Instead pass log configs when creating managers.
+
+
+```python
+  from academy.logging.helpers import recommended_logging, log_context
+  with Manager.from_exchange_factory(..., log_config=recommended_logging()):
+    ...
+```
+
+This will initialize logging for the lifetime of the manager, and use the configuration for agents launched through that manager, even when they are remote.
+
+Multiple log contexts can be active in a process at any one time - for example, a coordinating process and multiple agents in the same process might each want to initialize their own logging. In previous versions of academy, init_logging would either only initialize based on the first call, or would forget previous configurations. In the new logging system, all configurations will see all log lines in a process, which is still a conflict but results in more, rather than less, logging.
+
+Academy comes with three ways of configuring logging: to the console, to a log file, and to a shared home directory JSON logfile store. Developers can implement new logging configurations by subclassing the LogConfig class.
+
 ## Academy v0.4
 
 ## Globus SDK version has been updated

--- a/examples/01-actor-client/run-01.py
+++ b/examples/01-actor-client/run-01.py
@@ -1,13 +1,12 @@
 from __future__ import annotations
 
 import asyncio
-import logging
 from concurrent.futures import ThreadPoolExecutor
 
 from academy.agent import action
 from academy.agent import Agent
 from academy.exchange import LocalExchangeFactory
-from academy.logging import init_logging
+from academy.logging.recommended import recommended_logging
 from academy.manager import Manager
 
 
@@ -27,11 +26,10 @@ class Counter(Agent):
 
 
 async def main() -> int:
-    init_logging(logging.INFO)
-
     async with await Manager.from_exchange_factory(
         factory=LocalExchangeFactory(),
         executors=ThreadPoolExecutor(),
+        log_config=recommended_logging(),
     ) as manager:
         agent_handle = await manager.launch(Counter)
 

--- a/examples/02-agent-loop/run-02.py
+++ b/examples/02-agent-loop/run-02.py
@@ -8,7 +8,7 @@ from academy.agent import action
 from academy.agent import Agent
 from academy.agent import loop
 from academy.exchange import LocalExchangeFactory
-from academy.logging import init_logging
+from academy.logging.recommended import recommended_logging
 from academy.manager import Manager
 
 logger = logging.getLogger(__name__)
@@ -32,11 +32,10 @@ class Counter(Agent):
 
 
 async def main() -> int:
-    init_logging(logging.INFO)
-
     async with await Manager.from_exchange_factory(
         factory=LocalExchangeFactory(),
         executors=ThreadPoolExecutor(),
+        log_config=recommended_logging(),
     ) as manager:
         agent = await manager.launch(Counter)
 

--- a/examples/03-agent-agent/run-03.py
+++ b/examples/03-agent-agent/run-03.py
@@ -8,7 +8,7 @@ from academy.agent import action
 from academy.agent import Agent
 from academy.exchange import LocalExchangeFactory
 from academy.handle import Handle
-from academy.logging import init_logging
+from academy.logging.recommended import recommended_logging
 from academy.manager import Manager
 
 logger = logging.getLogger(__name__)
@@ -44,11 +44,10 @@ class Reverser(Agent):
 
 
 async def main() -> int:
-    init_logging(logging.INFO)
-
     async with await Manager.from_exchange_factory(
         factory=LocalExchangeFactory(),
         executors=ThreadPoolExecutor(),
+        log_config=recommended_logging(),
     ) as manager:
         lowerer = await manager.launch(Lowerer)
         reverser = await manager.launch(Reverser)
@@ -60,7 +59,11 @@ async def main() -> int:
         text = 'DEADBEEF'
         expected = 'feebdaed'
 
-        logger.info('Invoking process("%s") on %s', text, coordinator.agent_id)
+        logger.info(
+            'Invoking process("%s") on %s',
+            text,
+            coordinator.agent_id,
+        )
         result = await coordinator.process(text)
         assert result == expected
         logger.info('Received result: "%s"', result)

--- a/examples/04-execution/run-04.py
+++ b/examples/04-execution/run-04.py
@@ -9,7 +9,7 @@ from academy.agent import action
 from academy.agent import Agent
 from academy.exchange.cloud.client import HttpExchangeFactory
 from academy.handle import Handle
-from academy.logging import init_logging
+from academy.logging.recommended import recommended_logging
 from academy.manager import Manager
 
 EXCHANGE_PORT = 5346
@@ -46,11 +46,10 @@ class Reverser(Agent):
 
 
 async def main() -> int:
-    init_logging(logging.INFO)
+
     mp_context = multiprocessing.get_context('spawn')
     executor = ProcessPoolExecutor(
         max_workers=3,
-        initializer=init_logging,
         mp_context=mp_context,
     )
 
@@ -59,6 +58,7 @@ async def main() -> int:
         # Agents are run by the manager in the processes of this
         # process pool executor.
         executors=executor,
+        log_config=recommended_logging(),
     ) as manager:
         # Launch each of the three agents types. The returned type is
         # a handle to that agent used to invoke actions.
@@ -80,8 +80,9 @@ async def main() -> int:
         assert result == expected
         logger.info('Received result: "%s"', result)
 
-        # Upon exit, the Manager context will instruct each agent to shutdown,
-        # closing their respective handles, and shutting down the executors.
+        # Upon exit, the Manager context will instruct each agent to
+        # shutdown, closing their respective handles, and shutting down
+        # the executors.
 
     return 0
 

--- a/examples/05-parsl/run-05.py
+++ b/examples/05-parsl/run-05.py
@@ -11,7 +11,7 @@ from parsl import HighThroughputExecutor
 from academy.agent import action
 from academy.agent import Agent
 from academy.exchange.cloud import spawn_http_exchange
-from academy.logging import init_logging
+from academy.logging.recommended import recommended_logging
 from academy.manager import Manager
 
 EXCHANGE_PORT = 5346
@@ -46,14 +46,16 @@ class SimulationAgent(Agent):
 
 
 async def main() -> int:
-    init_logging(logging.INFO)
-
-    with spawn_http_exchange('localhost', EXCHANGE_PORT) as factory:
+    with spawn_http_exchange(
+        'localhost',
+        EXCHANGE_PORT,
+    ) as factory:
         executor = ThreadPoolExecutor()
 
         async with await Manager.from_exchange_factory(
             factory=factory,
             executors=executor,
+            log_config=recommended_logging(),
         ) as manager:
             agent = await manager.launch(SimulationAgent)
             expected = 42
@@ -66,8 +68,9 @@ async def main() -> int:
             assert result == expected
             logger.info('The answer to life is: "%s"', result)
 
-        # Upon exit, the Manager context will instruct each agent to shutdown,
-        # closing their respective handles, and shutting down the executors.
+        # Upon exit, the Manager context will instruct each agent to
+        # shutdown, closing their respective handles, and shutting down
+        # the executors.
 
     return 0
 

--- a/examples/06-llm/run-06.py
+++ b/examples/06-llm/run-06.py
@@ -12,7 +12,6 @@ from academy.agent import action
 from academy.agent import Agent
 from academy.exchange import LocalExchangeFactory
 from academy.handle import Handle
-from academy.logging import init_logging
 from academy.manager import Manager
 
 logger = logging.getLogger(__name__)
@@ -93,8 +92,6 @@ class Orchestrator(Agent):
 
 # The main program creates the two Academy agents, SIMULATOR and ORCHESTRATOR
 async def main() -> int:
-    init_logging(logging.INFO)
-
     model = await asyncio.to_thread(input, 'Please input a model name: ')
     token = await asyncio.to_thread(input, 'Please input an access token: ')
     url_input = await asyncio.to_thread(

--- a/examples/07-mol-design/run-07.py
+++ b/examples/07-mol-design/run-07.py
@@ -12,15 +12,12 @@ from parsl.concurrent import ParslPoolExecutor
 from parsl.providers import LocalProvider
 
 from academy.exchange import RedisExchangeFactory
-from academy.logging import init_logging
 from academy.manager import Manager
 
 logger = logging.getLogger(__name__)
 
 
 async def main() -> int:
-    init_logging(logging.INFO)
-
     config = Config(
         executors=[
             HighThroughputExecutor(

--- a/examples/08-discussion/run-08.py
+++ b/examples/08-discussion/run-08.py
@@ -9,14 +9,12 @@ from langchain_openai import ChatOpenAI
 
 from academy.exchange import LocalExchangeFactory
 from academy.handle import Handle
-from academy.logging import init_logging
 from academy.manager import Manager
 
 logger = logging.getLogger(__name__)
 
 
 async def main() -> int:
-    init_logging(logging.INFO)
     llm = ChatOpenAI(model='meta-llama/Llama-4-Scout-17B-16E-Instruct')
     agents = [
         GroupChatAgent(

--- a/examples/12-globus-exchange/run-12.py
+++ b/examples/12-globus-exchange/run-12.py
@@ -24,7 +24,7 @@ from academy.agent import Agent
 from academy.exchange.cloud.globus import GlobusExchangeFactory
 from academy.exchange.transport import AgentRegistration
 from academy.handle import Handle
-from academy.logging import init_logging
+from academy.logging.recommended import recommended_logging
 from academy.manager import Manager
 
 logger = logging.getLogger(__name__)
@@ -69,7 +69,6 @@ class Coordinator(Agent):
 
 
 async def main() -> int:
-    init_logging(logging.INFO)
 
     project_id = uuid.UUID(os.environ['ACADEMY_TEST_PROJECT_ID'])
 
@@ -77,6 +76,7 @@ async def main() -> int:
 
     async with await Manager.from_exchange_factory(
         factory=factory,
+        log_config=recommended_logging(),
     ) as manager:
         regs: list[AgentRegistration[Any]] = await manager.register_agents(
             [

--- a/tests/integration/manager_logs_test.py
+++ b/tests/integration/manager_logs_test.py
@@ -1,0 +1,87 @@
+from __future__ import annotations
+
+import logging
+import multiprocessing
+import uuid
+from concurrent.futures import ProcessPoolExecutor
+
+import pytest
+
+from academy.agent import Agent
+from academy.logging.recommended import recommended_logging
+from academy.manager import Manager
+
+logger = logging.getLogger(__name__)
+
+
+class LogAgent(Agent):
+    def __init__(self, s) -> None:
+        super().__init__()
+        self._s = s
+
+    async def agent_on_startup(self) -> None:
+        logger.info(f'Log agent proof-of-log token {self._s}')
+
+
+@pytest.mark.asyncio
+async def test_manager_configured_agent_logs(http_exchange_factory, tmp_path):
+    spawn_context = multiprocessing.get_context('spawn')
+
+    # arbitrary strings to log that we expect to not otherwise occur
+    a_str = str(uuid.uuid4())
+    b_str = str(uuid.uuid4())
+    m_str = str(uuid.uuid4())
+    m_ended_str = str(uuid.uuid4())
+
+    m_filepath = str(tmp_path / f'{uuid.uuid4()!s}.log')
+
+    # it is important to have max_workers=1 here so that both agents will
+    # run inside the same process, and so share a single Python-level
+    # logging system.
+    async with await Manager.from_exchange_factory(
+        http_exchange_factory,
+        executors=ProcessPoolExecutor(
+            max_workers=1,
+            mp_context=spawn_context,
+        ),
+        log_config=recommended_logging(
+            logfile=m_filepath,
+            extra=2,
+            level=logging.DEBUG,
+        ),
+    ) as manager:
+        logger.info(f'Manager proof of log {m_str}')
+
+        agent = LogAgent(a_str)
+        handle = await manager.launch(
+            agent,
+        )
+        await handle.shutdown()
+
+        # Reaching this point doesn't mean that the agent has actually
+        # shut down, but the other agent won't start (and so its log
+        # configuration won't happen) until the first agent shuts down
+        # because there's a single worker.
+
+        agent = LogAgent(b_str)
+        handle = await manager.launch(
+            agent,
+        )
+
+        await handle.shutdown()
+
+        await manager.wait((handle,))
+
+        with open(m_filepath) as f:
+            m_contents = f.read()
+
+    logger.info(f'Manager proof of log {m_ended_str}')
+
+    assert a_str in m_contents, f'A-log should be in log file {m_filepath}'
+    assert b_str in m_contents, f'B-log should be in log file {m_filepath}'
+    assert m_str in m_contents, (
+        f'manager log should be in log file {m_filepath}'
+    )
+    assert m_ended_str not in m_contents, (
+        f'manager ended log should not be in log file {m_filepath}'
+    )

--- a/tests/integration/overlapping_logs_test.py
+++ b/tests/integration/overlapping_logs_test.py
@@ -1,0 +1,106 @@
+from __future__ import annotations
+
+import logging
+import uuid
+
+import pytest
+
+from academy.logging.helpers import log_context
+from academy.logging.recommended import recommended_logging
+
+logger = logging.getLogger(__name__)
+
+
+@pytest.mark.asyncio
+async def test_nested_log_configs(http_exchange_factory, tmp_path):
+    """Test that nested initializations of same config do not interfere."""
+    m_filepath = str(tmp_path / f'{uuid.uuid4()!s}.log')
+
+    lc = recommended_logging(logfile=m_filepath, extra=2, level=logging.INFO)
+
+    with log_context(lc):
+        logger.info('inside outer log context')
+
+        m1_str = str(uuid.uuid4())
+        logger.info(m1_str)
+
+        with log_context(lc):
+            m2_str = str(uuid.uuid4())
+            logger.info(m2_str)
+
+        m3_str = str(uuid.uuid4())
+        logger.info(m3_str)
+
+    m4_str = str(uuid.uuid4())
+    logger.info(m4_str)
+
+    with open(m_filepath) as f:
+        assert len([line for line in f if m1_str in line]) == 1, (
+            f'uuid should appear once in logfile {m_filepath}'
+        )
+    with open(m_filepath) as f:
+        assert len([line for line in f if m2_str in line]) == 1, (
+            f'uuid should appear once in logfile {m_filepath}'
+        )
+    with open(m_filepath) as f:
+        assert len([line for line in f if m3_str in line]) == 1, (
+            f'uuid should appear once in logfile {m_filepath}'
+        )
+    with open(m_filepath) as f:
+        assert len([line for line in f if m4_str in line]) == 0, (
+            f'uuid should not appear in logfile {m_filepath}'
+        )
+
+
+@pytest.mark.asyncio
+async def test_non_nested_log_configs(http_exchange_factory, tmp_path):
+    """Test non-nested log config overlaps do not interfere."""
+    m_filepath = str(tmp_path / f'{uuid.uuid4()!s}.log')
+
+    lc = recommended_logging(logfile=m_filepath, extra=2, level=logging.INFO)
+
+    ctx1 = log_context(lc)
+    ctx2 = log_context(lc)
+
+    ctx1.__enter__()
+    # now we are in only ctx1
+
+    logger.info('inside outer log context')
+
+    m1_str = str(uuid.uuid4())
+    logger.info(m1_str)
+
+    ctx2.__enter__()
+    # now we are in both ctx1 and ctx2
+
+    m2_str = str(uuid.uuid4())
+    logger.info(m2_str)
+
+    ctx1.__exit__(None, None, None)
+    # now we are in only ctx2
+
+    m3_str = str(uuid.uuid4())
+    logger.info(m3_str)
+
+    ctx2.__exit__(None, None, None)
+    # now we are in no context
+
+    m4_str = str(uuid.uuid4())
+    logger.info(m4_str)
+
+    with open(m_filepath) as f:
+        assert len([line for line in f if m1_str in line]) == 1, (
+            f'uuid should appear once in logfile {m_filepath}'
+        )
+    with open(m_filepath) as f:
+        assert len([line for line in f if m3_str in line]) == 1, (
+            f'uuid should appear once in logfile {m_filepath}'
+        )
+    with open(m_filepath) as f:
+        assert len([line for line in f if m2_str in line]) == 1, (
+            f'uuid should appear once in logfile {m_filepath}'
+        )
+    with open(m_filepath) as f:
+        assert len([line for line in f if m4_str in line]) == 0, (
+            f'uuid should not appear in logfile {m_filepath}'
+        )

--- a/tests/integration/sequential_agent_logs_test.py
+++ b/tests/integration/sequential_agent_logs_test.py
@@ -1,0 +1,87 @@
+from __future__ import annotations
+
+import logging
+import multiprocessing
+import uuid
+from concurrent.futures import ProcessPoolExecutor
+
+import pytest
+
+from academy.agent import Agent
+from academy.logging.configs.file import FileLogging
+from academy.manager import Manager
+
+logger = logging.getLogger(__name__)
+
+
+class LogAgent(Agent):
+    def __init__(self, s) -> None:
+        super().__init__()
+        self._s = s
+
+    async def agent_on_startup(self) -> None:
+        logger.info(f'Log agent proof-of-log token {self._s}')
+
+
+@pytest.mark.asyncio
+async def test_sequential_agents(http_exchange_factory, tmp_path):
+    spawn_context = multiprocessing.get_context('spawn')
+
+    # arbitrary strings to log that we expect to not otherwise occur
+    a_str = str(uuid.uuid4())
+    b_str = str(uuid.uuid4())
+
+    # it is important to have max_workers=1 here so that both agents will
+    # run inside the same process, and so share a single Python-level
+    # logging system.
+    async with await Manager.from_exchange_factory(
+        http_exchange_factory,
+        executors=ProcessPoolExecutor(
+            max_workers=1,
+            mp_context=spawn_context,
+        ),
+    ) as manager:
+        a_filepath = str(tmp_path / f'{uuid.uuid4()!s}.log')
+        a_lc = FileLogging(logfile=a_filepath, level=logging.INFO)
+        agent = LogAgent(a_str)
+        handle = await manager.launch(
+            agent,
+            log_config=a_lc,
+        )
+        await handle.shutdown()
+
+        # Reaching this point doesn't mean that the agent has actually
+        # shut down, but the other agent won't start (and so its log
+        # configuration won't happen) until the first agent shuts down
+        # because there's a single worker.
+
+        b_filepath = str(tmp_path / f'{uuid.uuid4()!s}.log')
+        b_lc = FileLogging(logfile=b_filepath, level=logging.INFO)
+        agent = LogAgent(b_str)
+        handle = await manager.launch(
+            agent,
+            log_config=b_lc,
+        )
+
+        await handle.shutdown()
+
+        await manager.wait((handle,))
+
+        with open(a_filepath) as f:
+            a_contents = f.read()
+        with open(b_filepath) as f:
+            b_contents = f.read()
+
+        assert a_str in a_contents, (
+            f'A-log should be in first log file {a_filepath}'
+        )
+        assert a_str not in b_contents, (
+            f'A-log should not be in second log file {b_filepath}'
+        )
+
+        assert b_str not in a_contents, (
+            f'B-log should not be in first log file {a_filepath}'
+        )
+        assert b_str in b_contents, (
+            f'B-log should be in second log file {b_filepath}'
+        )

--- a/tests/manual/globus_client/run_globus_client_test.py
+++ b/tests/manual/globus_client/run_globus_client_test.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import asyncio
-import logging
 import multiprocessing
 import os
 import uuid
@@ -10,7 +9,8 @@ from concurrent.futures import ProcessPoolExecutor
 from academy.agent import action
 from academy.agent import Agent
 from academy.exchange.cloud.globus import GlobusExchangeFactory
-from academy.logging import init_logging
+from academy.logging.helpers import log_context
+from academy.logging.recommended import recommended_logging
 from academy.manager import Manager
 
 
@@ -39,28 +39,26 @@ async def test_full_globus_exchange_client() -> None:
     Globus Auth. However, we don't mock enough of the responses to
     run this as part of CI/CD integration testing.
     """
-    init_logging(logging.DEBUG)
+    lc = recommended_logging()
+    with log_context(lc):
+        factory = GlobusExchangeFactory(
+            project_id=uuid.UUID(os.environ['ACADEMY_TEST_PROJECT_ID']),
+            client_params={'base_url': 'http://0.0.0.0:8700'},
+        )
+        mp_context = multiprocessing.get_context('spawn')
+        executor = ProcessPoolExecutor(
+            max_workers=1,
+            mp_context=mp_context,
+        )
 
-    factory = GlobusExchangeFactory(
-        project_id=uuid.UUID(os.environ['ACADEMY_TEST_PROJECT_ID']),
-        client_params={'base_url': 'http://0.0.0.0:8700'},
-    )
-    mp_context = multiprocessing.get_context('spawn')
-    executor = ProcessPoolExecutor(
-        max_workers=1,
-        initializer=init_logging,
-        initargs=(logging.INFO,),
-        mp_context=mp_context,
-    )
-
-    async with await Manager.from_exchange_factory(
-        factory=factory,
-        executors=executor,
-    ) as manager:
-        echo = await manager.launch(Echo)
-        text = 'DEADBEEF'
-        result = await echo.echo(text)
-        assert result == text
+        async with await Manager.from_exchange_factory(
+            factory=factory,
+            executors=executor,
+        ) as manager:
+            echo = await manager.launch(Echo, log_config=lc)
+            text = 'DEADBEEF'
+            result = await echo.echo(text)
+            assert result == text
 
 
 if __name__ == '__main__':

--- a/tests/unit/logging_test.py
+++ b/tests/unit/logging_test.py
@@ -3,39 +3,209 @@ from __future__ import annotations
 import json
 import logging
 import pathlib
+import uuid
+from unittest import mock
 
 import pytest
 
-from academy.logging import init_logging
-from academy.logging import JSONHandler
-
-# Note: these tests are just for coverage to make sure the code is functional.
-# It does not test the agent of init_logging because pytest captures
-# logging already.
+from academy.logging.configs.base import LogConfig
+from academy.logging.configs.console import ConsoleLogging
+from academy.logging.configs.file import FileLogging
+from academy.logging.configs.jsonpool import JSONPoolLogging
+from academy.logging.configs.multi import MultiLogging
+from academy.logging.helpers import initialized_log_contexts
+from academy.logging.helpers import JSONHandler
+from academy.logging.helpers import log_context
+from academy.logging.recommended import recommended_logging
 
 
 @pytest.mark.parametrize(('color', 'extra'), ((True, True), (False, False)))
-def test_logging_no_file(color: bool, extra: bool) -> None:
-    init_logging(color=color, extra=extra)
+def test_console_logging(color: bool, extra: bool, capteesys) -> None:
+    lc = ConsoleLogging(color=color, extra=extra)
+    with log_context(lc):
+        logger = logging.getLogger()
+        logger.info('Test logging')
+        assert 'Test logging' in capteesys.readouterr().out
 
-    logger = logging.getLogger()
-    logger.info('Test logging')
+
+def test_none_logging() -> None:
+    with log_context(None):
+        logger = logging.getLogger()
+        logger.info('Test logging')
+        # Nothing to assert about where this log message went...
+        # just testing that we can go into the log_context with no config
+
+
+def test_recommended_logging_console(capteesys) -> None:
+    with log_context(recommended_logging()):
+        logger = logging.getLogger()
+        logger.info('Test logging')
+        assert 'Test logging' in capteesys.readouterr().out
+
+
+def test_recommended_logging_file(capteesys, tmp_path) -> None:
+    logfile = tmp_path / 'log'
+    with log_context(recommended_logging(logfile=logfile)):
+        logger = logging.getLogger()
+        logger.info('Test logging')
+        assert 'Test logging' in capteesys.readouterr().out
+        with open(logfile) as f:
+            assert 'Test logging' in f.read()
+
+
+def test_nested_context() -> None:
+    """This tests that nesting/reference counting happens based on string ID.
+
+    The behaviour under test is that a configuration may be defined in one
+    process (e.g. workflow submit process) and then be conveyed using pickle
+    multiple times to a destination process, such as a Parsl worker process,
+    resulting in two distinct objects for the same configuration, and that
+    configuration should be initialized only once.
+    """
+    lc = mock.Mock()
+    assert lc.uuid not in initialized_log_contexts, (
+        'lc should not be in a context yet'
+    )
+    with log_context(lc):
+        assert initialized_log_contexts[lc.uuid].count == 1, (
+            'lc should have one reference'
+        )
+        with log_context(lc):
+            # PLR2004 Magic value used in comparison
+            # This is a lexical property of the surrounding code, the nesting
+            # depth.
+            assert initialized_log_contexts[lc.uuid].count == 2, (  # noqa: PLR2004
+                'lc should have two references'
+            )
+        assert initialized_log_contexts[lc.uuid].count == 1, (
+            'lc should have one reference after end of one with block'
+        )
+    assert lc.uuid not in initialized_log_contexts, (
+        'lc should not be in a context after all with blocks exited'
+    )
+
+
+def test_nested_context_same_uuid_different_object() -> None:
+    """This tests that nesting/reference counting happens based on uuid.
+
+    The behaviour under test is that a configuration may be defined in one
+    process (e.g. workflow submit process) and then be conveyed using pickle
+    multiple times to a destination process, such as a Parsl worker process,
+    resulting in two distinct objects for the same configuration, and that
+    configuration should be initialized only once.
+    """
+    u = str(uuid.uuid4())
+    lc1 = mock.Mock(LogConfig)
+    lc1.uuid = u
+    lc2 = mock.Mock(LogConfig)
+    lc2.uuid = u
+
+    assert u not in initialized_log_contexts, (
+        'config should not be in a context yet'
+    )
+
+    lc1.init_logging.assert_not_called()
+    with log_context(lc1):
+        lc1.init_logging.assert_called_once()
+        assert initialized_log_contexts[u].count == 1, (
+            'config should have one reference'
+        )
+        with log_context(lc2):
+            # PLR2004 Magic value used in comparison
+            # This is a lexical property of the surrounding code, the nesting
+            # depth.
+            assert initialized_log_contexts[u].count == 2, (  # noqa: PLR2004
+                'config should have two references'
+            )
+        assert initialized_log_contexts[u].count == 1, (
+            'config should have one reference after end of one with block'
+        )
+    assert u not in initialized_log_contexts, (
+        'config should not be in a context after all with blocks exited'
+    )
+
+    lc1.init_logging.assert_called_once()
+    lc2.init_logging.assert_not_called()
+
+
+def test_nested_context_different_uuid() -> None:
+    """This tests that two different configs are both initialized.
+
+    The behaviour under test is that multiple configurations may
+    "visit" a Python process and both be initialised, rather than
+    one configuration being favoured.
+    """
+    lc1 = mock.Mock(LogConfig)
+    lc1.uuid = str(uuid.uuid4())
+    lc2 = mock.Mock(LogConfig)
+    lc2.uuid = str(uuid.uuid4())
+
+    lc1.init_logging.assert_not_called()
+    lc2.init_logging.assert_not_called()
+    with log_context(lc1):
+        lc1.init_logging.assert_called_once()
+        with log_context(lc2):
+            lc2.init_logging.assert_called_once()
+    lc1.init_logging.assert_called_once()
+    lc2.init_logging.assert_called_once()
 
 
 @pytest.mark.parametrize(
-    ('color', 'extra'),
-    ((True, True), (False, False), (False, 2)),
+    'extra',
+    (False, True, 2),
 )
 def test_logging_with_file(
-    color: bool,
-    extra: bool,
     tmp_path: pathlib.Path,
+    extra: bool,
 ) -> None:
-    filepath = tmp_path / 'log.txt'
-    init_logging(logfile=filepath, color=color, extra=extra)
+    _filepath = tmp_path / 'log.txt'
+    assert isinstance(extra, int)
+    lc = FileLogging(logfile=_filepath, extra=extra)
+    with log_context(lc):
+        logger = logging.getLogger()
+        logger.info('Test logging')
 
-    logger = logging.getLogger()
-    logger.info('Test logging')
+        contents = _filepath.read_text()
+        assert 'Test logging' in contents
+
+
+def test_logging_with_jsonpool() -> None:
+    lc = JSONPoolLogging()
+    with log_context(lc):
+        logger = logging.getLogger()
+        logger.info('Test logging')
+
+        path = (
+            pathlib.Path.home()
+            / 'local'
+            / 'share'
+            / 'academy'
+            / 'logs'
+            / lc.uuid
+        )
+
+        files = list(path.iterdir())
+        assert len(files) == 1, (
+            'There should be one log file in the pool directory'
+        )
+
+        log_file = files[0]
+        contents = log_file.read_text()
+        assert 'Test logging' in contents
+
+
+def test_multi_config_repr() -> None:
+    a = JSONPoolLogging()
+    b = ConsoleLogging()
+
+    lc = MultiLogging([a, b])
+
+    assert repr(a) in repr(lc), (
+        'MultiLogging repr should include subconfig repr'
+    )
+    assert repr(b) in repr(lc), (
+        'MultiLogging repr should include subconfig repr'
+    )
 
 
 def test_json_handler_emit(tmp_path: pathlib.Path) -> None:

--- a/tests/unit/manager_test.py
+++ b/tests/unit/manager_test.py
@@ -22,6 +22,7 @@ from academy.exchange import HttpExchangeFactory
 from academy.exchange import LocalExchangeFactory
 from academy.exchange import LocalExchangeTransport
 from academy.exchange import UserExchangeClient
+from academy.logging.configs.file import FileLogging
 from academy.manager import Manager
 from testing.agents import EmptyAgent
 from testing.agents import IdentityAgent
@@ -365,34 +366,16 @@ async def test_executor_pass_kwargs(
 
 
 # Logging done in a subprocess is not captured by pytest so we cannot use
-# pytest's caplog fixture to validate output. Set level to WARNING to avoid
-# adding more noise in stdout.
-@pytest.mark.asyncio
-async def test_worker_init_logging_no_logfile(
-    http_exchange_factory: HttpExchangeFactory,
-) -> None:
-    spawn_context = multiprocessing.get_context('spawn')
-    async with await Manager.from_exchange_factory(
-        http_exchange_factory,
-        executors=ProcessPoolExecutor(max_workers=1, mp_context=spawn_context),
-    ) as manager:
-        agent = SleepAgent(TEST_SLEEP_INTERVAL)
-        handle = await manager.launch(
-            agent,
-            init_logging=True,
-            loglevel='WARNING',
-        )
-        await handle.shutdown()
-        await manager.wait({handle})
-
-
+# pytest's caplog fixture to validate output.
 @pytest.mark.asyncio
 async def test_worker_init_logging_logfile(
     http_exchange_factory: HttpExchangeFactory,
     tmp_path: pathlib.Path,
 ) -> None:
-    spawn_context = multiprocessing.get_context('spawn')
     filepath = tmp_path / 'test-worker-init-logging.log'
+
+    lc = FileLogging(logfile=filepath)
+    spawn_context = multiprocessing.get_context('spawn')
 
     async with await Manager.from_exchange_factory(
         http_exchange_factory,
@@ -401,26 +384,12 @@ async def test_worker_init_logging_logfile(
         agent = SleepAgent(TEST_SLEEP_INTERVAL)
         handle = await manager.launch(
             agent,
-            init_logging=True,
-            loglevel='WARNING',
-            logfile=str(filepath),
+            log_config=lc,
         )
         await handle.shutdown()
         await manager.wait({handle})
 
     assert filepath.exists(), 'log file from manager should exist'
-
-
-@pytest.mark.asyncio
-async def test_worker_init_logging_warn(
-    manager: Manager[LocalExchangeTransport],
-) -> None:
-    agent = SleepAgent(TEST_SLEEP_INTERVAL)
-    with pytest.warns(UserWarning, match='init_logging'):
-        handle = await manager.launch(agent, init_logging=True)
-
-    await handle.shutdown()
-    await manager.wait({handle})
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

This PR introduces the concept of distributed Python `logging` configuration:

i) a user might want the same log configuration in several processes, because their workflow comprises several processes that should be observed together - an example would be a laptop-based workflow orchestration/submit side, and an HPC worker node based execution process.

ii) several authorities might regard themselves as the one entitled to configure logging for a Python process. An example here might be academy launching an agent in a remote Parsl worker inside a Globus Compute endpoint (and wanting to observe log information), and the enclosing Globus Compute endpoint also wanting to observe log information.

iii) users, implementers and researchers are interested in observing logging novel means: for example, under development distributed logging systems -- see diaspora or via systems focused on specific uses (for example) provenance - see flowcept.

These are handled quite badly/informally at the moment: Academy does some remote log configuration, but using logger.basicConfiguration which only happens if no one else has configured the root logger. That means it is very sensitive to what anyone else has done. The academy remote configuration is also restricted to a tiny language which can describe file targets on the remote file system and nothing else.

The notion of log configuration introduced in this PR is:

Log configurations are described by `LogConfig` objects, each of a class that knows how to configure logging in a particular way.

These configuration objects are expected to be serialized to other Python processes, primarily using pickle. In the presence of multiple serializations, these objects can still tell if they are from the same original source object (by use of an identifier field, rather than expecting the serialization system to preserve this identity relation).

These configuration objects are expected to know how to initialize their local process in their own particular way, on demand, and to know how to undo that configuration on demand.

None of these log configuration objects should expect to be the main log configuration for a process and should always expect to be alongside other configurations (either of this form, or set up by some other piece of Python code) - they are *visiting* a process in the sense that a Parsl task is a visitor inside a Parsl worker process , which has a separate existence (and so an academy worker inside a Parsl task is also a visitor).

Some academy scaffolding (`log_context`) manages these log configurations - for example as a context manager - to avoid duplicate initializations or too-early de-initializations.

This PR splits the log configuration from before this PR into a couple of different `LogConfig` implementations:

`ConsoleLogging` - which knows about logging to stdout, including with ANSI color.

`FileLogging` - which knows about logging to a file on the co-located filesystem.

There is a new `LogConfig` called `JSONPool` which knows how to log to an automatically named directory under the users home directory, in JSON format. This is intended for machine consumption.

There is a new `MultiLogConfig` which joins several `LogConfig` objects into one. This supports use cases such as logging to a file and also to some other experimental system simultanously.

Outside of this PR, I have also prototyped a `LogConfig` which knows how to send some logs into flowcept - https://github.com/ORNL/flowcept. I have also worked with Diaspora Octopus to drive some ideas for implementation, though I don't have a working implementation right now.

## Related Issues

## Changes

- [x] Breaking (backwards incompatible changes to public interfaces)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (non-breaking change or feature addition)
- [ ] Refactor (internal code or design clean up)
- [ ] Documentation (no changes to the code)
- [ ] Test (changes or additions to testing)
- [ ] Build (change to CI workflows or build processes)
- [ ] Package (changes to package metadata or dependency versions)

## Testing

Added a bunch of tests around logging to the test suite.

## Pull Request Checklist

Please confirm the PR meets the following requirements.
- [x] Relevant tags are added based on the types of changes.
- [x] Code changes pass `pre-commit` (e.g., ruff, mypy, etc.).
- [x] Tests have been added to show the fix is effective or that the new feature works.
- [x] New and existing unit tests pass locally with the changes.
- [x] Docs have been updated and reviewed if relevant.
