### PR TITLE
Add error handling around bad executor specification

### DIFF
--- a/academy/manager.py
+++ b/academy/manager.py
@@ -147,7 +147,7 @@ class Manager(Generic[ExchangeTransportT], NoPickleMixin):
 
     Raises:
         ValueError: If `default_executor` is specified but does not exist
-            in `executors`.
+            in `executors`, or if executors is badly typed.
     """
 
     def __init__(
@@ -166,6 +166,10 @@ class Manager(Generic[ExchangeTransportT], NoPickleMixin):
             default_executor = 'default'
         elif isinstance(executors, MutableMapping):
             self._executors.update(executors)
+        elif executors is None:
+            pass
+        else:  # unreachable if types are followed
+            raise ValueError('Invalid executors parameter')
 
         if default_executor not in self._executors:
             raise ValueError(

--- a/tests/unit/manager_test.py
+++ b/tests/unit/manager_test.py
@@ -47,14 +47,12 @@ async def test_from_exchange_factory() -> None:
 async def test_bad_executor_type() -> None:
     e: Any = ThreadPoolExecutor
 
-    # TODO: when we know what kind of exception should be raised,
-    # tighten this raises clause.
-    with pytest.raises(Exception):
+    with pytest.raises(ValueError, match='Invalid executors parameter'):
         async with await Manager.from_exchange_factory(
             factory=LocalExchangeFactory(),
             executors=e,
         ):
-            pass
+            ...
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Prior to this PR, an arbitrary object could be passed as the `executors` parameter of a manager. This would result in behaviour as if no executor had been specified.

Although `executors` has a type specification, that is not type checked at runtime, and this is a user-facing API that can be expected to have user errors.

This PR adds a test that demonstrates the actual typo that led me here (passing an executor class, rather than invoking it).


## Related Issues

## Changes

- [ ] Breaking (backwards incompatible changes to public interfaces)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (non-breaking change or feature addition)
- [ ] Refactor (internal code or design clean up)
- [ ] Documentation (no changes to the code)
- [ ] Test (changes or additions to testing)
- [ ] Build (change to CI workflows or build processes)
- [ ] Package (changes to package metadata or dependency versions)

## Testing
test case added. the test case fails before the bugfix in this PR.

## Pull Request Checklist

Please confirm the PR meets the following requirements.
- [ ] Relevant tags are added based on the types of changes.
- [x] Code changes pass `pre-commit` (e.g., ruff, mypy, etc.).
- [x] Tests have been added to show the fix is effective or that the new feature works.
- [x] New and existing unit tests pass locally with the changes.
- [x] Docs have been updated and reviewed if relevant.
