### PR TITLE
Add hosted exchange as default for `CloudExchangeFactory`

### DIFF
--- a/academy/exchange/cloud/client.py
+++ b/academy/exchange/cloud/client.py
@@ -377,7 +377,7 @@ class HttpExchangeFactory(ExchangeFactory[HttpExchangeTransport]):
     """Http exchange client factory.
 
     Args:
-        url: Address of HTTP exchange
+        url: Address of HTTP exchange. Defaults to the Academy-hosted exchange
         auth_method: Method to get authorization headers
         additional_headers: Any other information necessary to communicate
             with the exchange. Used for passing the Globus bearer token
@@ -388,7 +388,7 @@ class HttpExchangeFactory(ExchangeFactory[HttpExchangeTransport]):
 
     def __init__(
         self,
-        url: str,
+        url: str = 'https://exchange.academy-agents.org',
         auth_method: Literal['globus'] | None = None,
         additional_headers: dict[str, str] | None = None,
         request_timeout_s: float = 60,


### PR DESCRIPTION
## Summary

We have reasonable confidence in our hosted exchange and would like to encourage users to use it. To that end, this PR sets the `CloudExchangeFactory(url: str)` field to the hosted exchange address `https://exchange.academy-agents.org`.


## Related Issues
N/A


## Changes

- [x] Enhancement (non-breaking change or feature addition)

## Testing

This change merely adds a default.

## Pull Request Checklist

Please confirm the PR meets the following requirements.
- [ ] Relevant tags are added based on the types of changes.
- [x] Code changes pass `pre-commit` (e.g., ruff, mypy, etc.).
- [x] Tests have been added to show the fix is effective or that the new feature works.
- [x] New and existing unit tests pass locally with the changes.
- [x] Docs have been updated and reviewed if relevant.
