### PR TITLE
Add asyncio task identifier along side thread and process

### DIFF
--- a/academy/logging.py
+++ b/academy/logging.py
@@ -39,7 +39,8 @@ class _Formatter(logging.Formatter):
 
         if extra:
             extra_fmt = (
-                f'{self.green}[tid=%(os_thread)d pid=%(process)d]{self.reset} '
+                f'{self.green}[tid=%(os_thread)d pid=%(process)d '
+                f'task=%(taskName)s] {self.reset} '
             )
         else:
             extra_fmt = ''


### PR DESCRIPTION
The kind of person who wants to know thread and process identity is probably also interested in which asyncio task is logging something, in our asyncio heavy environment.

Before:

```
[2026-02-26 16:50:14.708] [tid=11431 pid=11431] INFO     (academy.exchange.local) Registered UserId<43509d11> in exchange
```

After:

```
[2026-02-26 16:50:04.602] [tid=11410 pid=11410 task=Task-1]  INFO     (academy.exchange.local) Registered UserId<fb97504e> in exchange
```

## Related Issues

Part of general log work e.g. #295 

## Changes
<!--- Check which of the following changes were made --->

- [ ] Breaking (backwards incompatible changes to public interfaces)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Enhancement (non-breaking change or feature addition)
- [ ] Refactor (internal code or design clean up)
- [ ] Documentation (no changes to the code)
- [ ] Test (changes or additions to testing)
- [ ] Build (change to CI workflows or build processes)
- [ ] Package (changes to package metadata or dependency versions)

## Testing

manual verification to generate the above log line pastes using a modified version of examples/01-actor-client/run-01.py

## Pull Request Checklist

Please confirm the PR meets the following requirements.
- [x] Relevant tags are added based on the types of changes.
- [x] Code changes pass `pre-commit` (e.g., ruff, mypy, etc.).
- [ ] Tests have been added to show the fix is effective or that the new feature works.
- [x] New and existing unit tests pass locally with the changes.
- [ ] Docs have been updated and reviewed if relevant.
