### PR TITLE
Unify message tag and action invocation ID

### DIFF
--- a/academy/message.py
+++ b/academy/message.py
@@ -235,7 +235,6 @@ class Header(BaseModel):
     src: EntityId = Field(description='Message source ID.')
     dest: EntityId = Field(description='Message destination ID.')
     tag: uuid.UUID = Field(
-        default_factory=uuid.uuid4,
         description='Unique message tag used to match requests and responses.',
     )
     label: uuid.UUID | None = Field(
@@ -332,6 +331,7 @@ class Message(BaseModel, Generic[BodyT]):
         body: BodyT,
         *,
         label: uuid.UUID | None = None,
+        tag: uuid.UUID | None = None,
     ) -> Message[BodyT]:
         """Create a new message with the specified header and body.
 
@@ -340,6 +340,7 @@ class Message(BaseModel, Generic[BodyT]):
             dest: Destination entity ID.
             body: Message body.
             label: Optional label for disambiguation.
+            tag: Optional tag for relating responses to requests.
 
         Returns:
             A new message instance.
@@ -350,7 +351,11 @@ class Message(BaseModel, Generic[BodyT]):
             kind = 'response'
         else:
             raise AssertionError('Unreachable.')
-        header = Header(src=src, dest=dest, label=label, kind=kind)
+
+        if tag is None:
+            tag = uuid.uuid4()
+
+        header = Header(src=src, dest=dest, label=label, kind=kind, tag=tag)
         request: Message[BodyT] = Message(header=header, body=body)
         return request
 

--- a/tests/unit/handle_test.py
+++ b/tests/unit/handle_test.py
@@ -445,13 +445,13 @@ async def test_handle_ignore_context_error(
         Handle(registration.agent_id, ignore_context=True)
 
 
-def assert_one_invocation_id(caplog) -> None:
+def assert_one_tag_id(caplog) -> None:
     ids = {
-        r.__dict__['academy.action_invocation']
+        r.__dict__['academy.action_tag']
         for r in caplog.records
-        if 'academy.action_invocation' in r.__dict__
+        if 'academy.action_tag' in r.__dict__
     }
-    assert len(ids) == 1, 'Log records should have a single invocation ID'
+    assert len(ids) == 1, 'Log records should have a single tag ID'
 
 
 def get_invocation_states(caplog) -> set[str]:
@@ -475,7 +475,7 @@ async def test_handle_logs_actions_success(
         with caplog.at_level(logging.DEBUG):
             await handle.action('add', 1)
 
-        assert_one_invocation_id(caplog)
+        assert_one_tag_id(caplog)
 
         assert get_invocation_states(caplog) == {
             'start',
@@ -501,7 +501,7 @@ async def test_handle_logs_actions_fails(
             with pytest.raises(RuntimeError):
                 await handle.action('fails')
 
-        assert_one_invocation_id(caplog)
+        assert_one_tag_id(caplog)
 
         assert get_invocation_states(caplog) == {
             'start',
@@ -526,7 +526,7 @@ async def test_handle_logs_actions_cancelled(
             with pytest.raises(asyncio.TimeoutError):
                 await asyncio.wait_for(handle.action('sleep', 0.1), 0.01)
 
-        assert_one_invocation_id(caplog)
+        assert_one_tag_id(caplog)
 
         # sending and waiting states might appear, or not, depending on
         # when the cancellation happens.

--- a/tests/unit/message_test.py
+++ b/tests/unit/message_test.py
@@ -32,6 +32,7 @@ def test_request_message(message_body: Any) -> None:
         src=AgentId.new(),
         dest=AgentId.new(),
         body=message_body,
+        tag=uuid.uuid4(),
     )
     assert isinstance(str(message), str)
     assert isinstance(repr(message), str)
@@ -54,7 +55,12 @@ def test_request_message(message_body: Any) -> None:
     ),
 )
 def test_response_message(message_body: Any) -> None:
-    header = Header(src=AgentId.new(), dest=AgentId.new(), kind='response')
+    header = Header(
+        src=AgentId.new(),
+        dest=AgentId.new(),
+        tag=uuid.uuid4(),
+        kind='response',
+    )
     message: Message[Any] = Message(header=header, body=message_body)
     assert isinstance(str(message), str)
     assert isinstance(repr(message), str)


### PR DESCRIPTION
These two identifiers were almost the same thing.

After this PR, the tag/invocation ID now correlates action invocations on the submit side, messages in the exchange, and hopefully later more logging on the submit side (such as in academy-flowcept prototype) around action execution.

So the tag ID because something a bit like a task ID, if you regard agent action invocations as tasks.

## Related Issues

Part of general log work eg. #295 

## Changes
<!--- Check which of the following changes were made --->

- [ ] Breaking (backwards incompatible changes to public interfaces)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Enhancement (non-breaking change or feature addition)
- [ ] Refactor (internal code or design clean up)
- [ ] Documentation (no changes to the code)
- [ ] Test (changes or additions to testing)
- [ ] Build (change to CI workflows or build processes)
- [ ] Package (changes to package metadata or dependency versions)

## Testing

there's an update in the PR to the test


## Pull Request Checklist

Please confirm the PR meets the following requirements.
- [x] Relevant tags are added based on the types of changes.
- [x] Code changes pass `pre-commit` (e.g., ruff, mypy, etc.).
- [ ] Tests have been added to show the fix is effective or that the new feature works.
- [x] New and existing unit tests pass locally with the changes.
- [ ] Docs have been updated and reviewed if relevant.
