### PR TITLE
Remove under-defined action field from Response

### DIFF
--- a/academy/message.py
+++ b/academy/message.py
@@ -133,7 +133,6 @@ class ActionResponse(BaseModel):
         This can have non-trivial time and space overheads for large results.
     """
 
-    action: str = Field(description='Name of the requested action.')
     result: SkipValidation[Any] = Field(
         description='Result of the action, if successful.',
     )

--- a/academy/runtime.py
+++ b/academy/runtime.py
@@ -235,7 +235,7 @@ class Runtime(Generic[AgentT], NoPickleMixin):
             response = request.create_response(ErrorResponse(exception=e))
         else:
             response = request.create_response(
-                ActionResponse(action=body.action, result=result),
+                ActionResponse(result=result),
             )
         finally:
             # Shield sending the result from being cancelled so the requester

--- a/tests/unit/exchange/proxystore_test.py
+++ b/tests/unit/exchange/proxystore_test.py
@@ -116,7 +116,7 @@ async def test_wrap_basic_transport_functionality(
             assert (type(new) is Proxy) == should_proxy(old)
             assert old == new
 
-        sent_response = ActionResponse(action='test', result='result')
+        sent_response = ActionResponse(result='result')
         sent_response_message = sent_request_message.create_response(
             sent_response,
         )

--- a/tests/unit/message_test.py
+++ b/tests/unit/message_test.py
@@ -49,7 +49,7 @@ def test_request_message(message_body: Any) -> None:
 @pytest.mark.parametrize(
     'message_body',
     (
-        ActionResponse(action='foo', result=b'bar'),
+        ActionResponse(result=b'bar'),
         ErrorResponse(exception=Exception()),
         SuccessResponse(),
     ),
@@ -112,7 +112,7 @@ def test_action_request_lazy_deserialize() -> None:
 
 
 def test_action_response_lazy_deserialize() -> None:
-    response = ActionResponse(action='foo', result={'foo': 'bar'})
+    response = ActionResponse(result={'foo': 'bar'})
 
     json = response.model_dump_json()
     reconstructed = ActionResponse.model_validate_json(json)


### PR DESCRIPTION
Under-defined in the sense of:

Should this be aligned with the action field in the corresponding Request? What is the behaviour when it is not?

## Changes
<!--- Check which of the following changes were made --->

- [ ] Breaking (backwards incompatible changes to public interfaces)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (non-breaking change or feature addition)
- [x] Refactor (internal code or design clean up)
- [ ] Documentation (no changes to the code)
- [ ] Test (changes or additions to testing)
- [ ] Build (change to CI workflows or build processes)
- [ ] Package (changes to package metadata or dependency versions)

## Testing

tests failed until i modified the tests in this PR.

## Pull Request Checklist

Please confirm the PR meets the following requirements.
- [x] Relevant tags are added based on the types of changes.
- [x] Code changes pass `pre-commit` (e.g., ruff, mypy, etc.).
- [x] Tests have been added to show the fix is effective or that the new feature works.
- [x] New and existing unit tests pass locally with the changes.
- [ ] Docs have been updated and reviewed if relevant.
