### PR TITLE
Add action invocation log pseudo-states to runtime side

### DIFF
--- a/academy/runtime.py
+++ b/academy/runtime.py
@@ -218,6 +218,23 @@ class Runtime(Generic[AgentT], NoPickleMixin):
     async def _execute_action(self, request: Message[ActionRequest]) -> None:
         body = request.get_body()
         response: Message[Response]
+
+        invocation_id = request.tag
+        invocation_extra = {
+            'academy.action': body.action,
+            'academy.action_tag': invocation_id,
+        }
+
+        logger.debug(
+            'Invoking action %s with invocation id %s',
+            body.action,
+            invocation_id,
+            extra=invocation_extra
+            | {
+                'academy.action_state': 'execute_start',
+            },
+        )
+
         try:
             # Do not run the method until the startup sequence has finished
             await self._started_event.wait()
@@ -227,15 +244,44 @@ class Runtime(Generic[AgentT], NoPickleMixin):
                 args=body.get_args(),
                 kwargs=body.get_kwargs(),
             )
+
         except asyncio.CancelledError:
             response = request.create_response(
                 ErrorResponse(exception=ActionCancelledError(body.action)),
             )
+            logger.debug(
+                'Cancelled action %s with invocation id %s',
+                body.action,
+                invocation_id,
+                extra=invocation_extra
+                | {
+                    'academy.action_state': 'execute_cancelled',
+                },
+            )
         except Exception as e:
             response = request.create_response(ErrorResponse(exception=e))
+            logger.debug(
+                'Action %s ended with exception, with invocation id %s',
+                body.action,
+                invocation_id,
+                extra=invocation_extra
+                | {
+                    'academy.action_state': 'execute_exception',
+                },
+                exc_info=e,
+            )
         else:
             response = request.create_response(
                 ActionResponse(result=result),
+            )
+            logger.debug(
+                'Completed action %s with invocation id %s',
+                body.action,
+                invocation_id,
+                extra=invocation_extra
+                | {
+                    'academy.action_state': 'execute_success',
+                },
             )
         finally:
             # Shield sending the result from being cancelled so the requester

--- a/tests/unit/handle_test.py
+++ b/tests/unit/handle_test.py
@@ -481,6 +481,8 @@ async def test_handle_logs_actions_success(
             'start',
             'sending',
             'waiting',
+            'execute_start',
+            'execute_success',
             'success',
         }, 'Log records should show successful-path states'
 
@@ -507,6 +509,8 @@ async def test_handle_logs_actions_fails(
             'start',
             'sending',
             'waiting',
+            'execute_start',
+            'execute_exception',
             'exception',
         }, 'Log records should show failure-path states'
 


### PR DESCRIPTION
This PR adds more log states to the action quasi-state-machine to represent what is happening with an action invocation on the execution side.

This uses tag ID to correlate with messages on the sending side. This pairs up with PR #345 which makes the sending side use tag ID as an action invocation identifier.

This is driven by the academy-flowcept prototype, but I think is generally useful to anyone interested in what is happening with their actions.

## Related Issues
general log work, eg #295 

## Changes
<!--- Check which of the following changes were made --->

- [ ] Breaking (backwards incompatible changes to public interfaces)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Enhancement (non-breaking change or feature addition)
- [ ] Refactor (internal code or design clean up)
- [ ] Documentation (no changes to the code)
- [ ] Test (changes or additions to testing)
- [ ] Build (change to CI workflows or build processes)
- [ ] Package (changes to package metadata or dependency versions)

## Testing

tests modified to look for new states

## Pull Request Checklist

Please confirm the PR meets the following requirements.
- [x] Relevant tags are added based on the types of changes.
- [x] Code changes pass `pre-commit` (e.g., ruff, mypy, etc.).
- [x] Tests have been added to show the fix is effective or that the new feature works.
- [x] New and existing unit tests pass locally with the changes.
- [ ] Docs have been updated and reviewed if relevant.
