### PR TITLE
Adding logs that can be used for usage tracking in cloud exchange

### DIFF
--- a/academy/exchange/cloud/app.py
+++ b/academy/exchange/cloud/app.py
@@ -494,13 +494,13 @@ async def _listen_mailbox_route(
         )
 
     if status == MailboxStatus.MISSING:
-        logger.exception(f'Receive from unknown mailbox {mailbox_id}.')
+        logger.exception(f'Listening on unknown mailbox {mailbox_id}.')
         return Response(
             status=StatusCode.NOT_FOUND.value,
             text='Unknown mailbox ID',
         )
     elif status == MailboxStatus.TERMINATED:
-        logger.exception(f'Receive from terminated mailbox {mailbox_id}.')
+        logger.exception(f'Listening on terminated mailbox {mailbox_id}.')
         return Response(
             status=StatusCode.TERMINATED.value,
             text='Mailbox was closed',

--- a/academy/exchange/cloud/app.py
+++ b/academy/exchange/cloud/app.py
@@ -434,12 +434,16 @@ async def _send_message_route(request: Request) -> Response:
         )
 
     logger.info(
-        f'Placing message in mailbox {message.src} from {message.src}',
+        (
+            f'Placing message {message.tag} in mailbox '
+            f'{message.src} from {message.src}'
+        ),
         extra={
             'academy.message.event': 'PUT',
             'academy.message.src': message.src,
             'academy.message.dest': message.dest,
             'academy.message.size': sys.getsizeof(message.body),
+            'academy.message.tag': message.tag,
         },
     )
     return Response(status=StatusCode.OKAY.value)
@@ -513,13 +517,14 @@ async def _listen_mailbox_route(
                 )
                 logger.info(
                     (
-                        f'Fetching message mailbox {message.dest} '
-                        f'from {message.src}',
+                        f'Fetched message {message.tag} from '
+                        f'mailbox {message.dest}',
                     ),
                     extra={
                         'academy.message.event': 'GET',
                         'academy.message.src': message.src,
                         'academy.message.dest': message.dest,
+                        'academy.message.tag': message.tag,
                     },
                 )
                 await response.send(message.model_dump_json())
@@ -596,11 +601,12 @@ async def _recv_message_route(request: Request) -> Response:  # noqa: PLR0911
         )
 
     logger.info(
-        f'Fetching message mailbox {message.dest} from {message.src}',
+        (f'Fetched message {message.tag} from mailbox {message.dest}',),
         extra={
             'academy.message.event': 'GET',
             'academy.message.src': message.src,
             'academy.message.dest': message.dest,
+            'academy.message.tag': message.tag,
         },
     )
     return json_response({'message': message.model_dump_json()})

--- a/academy/exchange/cloud/app.py
+++ b/academy/exchange/cloud/app.py
@@ -443,7 +443,7 @@ async def _send_message_route(request: Request) -> Response:
             'academy.message.src': message.src,
             'academy.message.dest': message.dest,
             'academy.message.size': sys.getsizeof(message.body),
-            'academy.message.tag': message.tag,
+            'academy.message_tag': message.tag,
         },
     )
     return Response(status=StatusCode.OKAY.value)
@@ -518,13 +518,13 @@ async def _listen_mailbox_route(
                 logger.info(
                     (
                         f'Fetched message {message.tag} from '
-                        f'mailbox {message.dest}',
+                        f'mailbox {message.dest}'
                     ),
                     extra={
                         'academy.message.event': 'GET',
                         'academy.message.src': message.src,
                         'academy.message.dest': message.dest,
-                        'academy.message.tag': message.tag,
+                        'academy.message_tag': message.tag,
                     },
                 )
                 await response.send(message.model_dump_json())
@@ -606,7 +606,7 @@ async def _recv_message_route(request: Request) -> Response:  # noqa: PLR0911
             'academy.message.event': 'GET',
             'academy.message.src': message.src,
             'academy.message.dest': message.dest,
-            'academy.message.tag': message.tag,
+            'academy.message_tag': message.tag,
         },
     )
     return json_response({'message': message.model_dump_json()})

--- a/academy/exchange/cloud/app.py
+++ b/academy/exchange/cloud/app.py
@@ -436,7 +436,7 @@ async def _send_message_route(request: Request) -> Response:
     logger.info(
         (
             f'Placing message {message.tag} in mailbox '
-            f'{message.src} from {message.dest}'
+            f'{message.dest} from {message.src}'
         ),
         extra={
             'academy.message.event': 'PUT',

--- a/academy/exchange/cloud/app.py
+++ b/academy/exchange/cloud/app.py
@@ -436,7 +436,7 @@ async def _send_message_route(request: Request) -> Response:
     logger.info(
         (
             f'Placing message {message.tag} in mailbox '
-            f'{message.src} from {message.src}'
+            f'{message.src} from {message.dest}'
         ),
         extra={
             'academy.message.event': 'PUT',
@@ -601,7 +601,7 @@ async def _recv_message_route(request: Request) -> Response:  # noqa: PLR0911
         )
 
     logger.info(
-        (f'Fetched message {message.tag} from mailbox {message.dest}',),
+        f'Fetched message {message.tag} from mailbox {message.dest}',
         extra={
             'academy.message.event': 'GET',
             'academy.message.src': message.src,

--- a/academy/exchange/cloud/app.py
+++ b/academy/exchange/cloud/app.py
@@ -140,6 +140,14 @@ async def _share_mailbox_route(request: Request) -> Response:
             status=StatusCode.TERMINATED.value,
             text='Mailbox was closed',
         )
+
+    logger.info(
+        f'Sharing mailbox {mailbox_id} with group {group_id}',
+        extra={
+            'academy.mailbox_id': mailbox_id,
+            'academy.group_id': group_id,
+        },
+    )
     return Response(status=StatusCode.OKAY.value)
 
 
@@ -232,6 +240,14 @@ async def _remove_mailbox_shares_route(request: Request) -> Response:
             status=StatusCode.TERMINATED.value,
             text='Mailbox was closed',
         )
+
+    logger.info(
+        f'Unsharing mailbox {mailbox_id} with group {group_id}',
+        extra={
+            'academy.mailbox_id': mailbox_id,
+            'academy.group_id': group_id,
+        },
+    )
     return Response(status=StatusCode.OKAY.value)
 
 
@@ -265,6 +281,15 @@ async def _create_mailbox_route(request: Request) -> Response:
             status=StatusCode.FORBIDDEN.value,
             text='Incorrect permissions',
         )
+
+    logger.info(
+        f'Creating mailbox {mailbox_id} of type {agent}',
+        extra={
+            'academy.mailbox_id': mailbox_id,
+            'academy.agent': agent,
+            'academy.client_id': client.client_id,
+        },
+    )
     return Response(status=StatusCode.OKAY.value)
 
 
@@ -296,6 +321,13 @@ async def _terminate_route(request: Request) -> Response:
             status=StatusCode.FORBIDDEN.value,
             text='Incorrect permissions',
         )
+
+    logger.info(
+        f'Terminating mailbox {mailbox_id}',
+        extra={
+            'academy.mailbox_id': mailbox_id,
+        },
+    )
     return Response(status=StatusCode.OKAY.value)
 
 
@@ -400,8 +432,17 @@ async def _send_message_route(request: Request) -> Response:
             status=StatusCode.TOO_LARGE.value,
             text=f'Message of size {e.size} larger than limit {e.limit}.',
         )
-    else:
-        return Response(status=StatusCode.OKAY.value)
+
+    logger.info(
+        f'Placing message in mailbox {message.src} from {message.src}',
+        extra={
+            'academy.message.event': 'PUT',
+            'academy.message.src': message.src,
+            'academy.message.dest': message.dest,
+            'academy.message.size': sys.getsizeof(message.body),
+        },
+    )
+    return Response(status=StatusCode.OKAY.value)
 
 
 async def _listen_mailbox_route(
@@ -470,7 +511,17 @@ async def _listen_mailbox_route(
                     mailbox_id,
                     timeout=timeout,
                 )
-                logger.debug(f'Message at mailbox {message.dest} retrieved.')
+                logger.info(
+                    (
+                        f'Fetching message mailbox {message.dest} '
+                        f'from {message.src}',
+                    ),
+                    extra={
+                        'academy.message.event': 'GET',
+                        'academy.message.src': message.src,
+                        'academy.message.dest': message.dest,
+                    },
+                )
                 await response.send(message.model_dump_json())
             except (MailboxTerminatedError, TimeoutError) as e:
                 # These messages are not necessarily a sign something is wrong
@@ -543,8 +594,16 @@ async def _recv_message_route(request: Request) -> Response:  # noqa: PLR0911
             status=StatusCode.TIMEOUT.value,
             text='Request timeout',
         )
-    else:
-        return json_response({'message': message.model_dump_json()})
+
+    logger.info(
+        f'Fetching message mailbox {message.dest} from {message.src}',
+        extra={
+            'academy.message.event': 'GET',
+            'academy.message.src': message.src,
+            'academy.message.dest': message.dest,
+        },
+    )
+    return json_response({'message': message.model_dump_json()})
 
 
 def authenticate_factory(

--- a/academy/exchange/cloud/backend.py
+++ b/academy/exchange/cloud/backend.py
@@ -345,11 +345,6 @@ class PythonBackend:
             self._locks[uid] = asyncio.Lock()
             if agent is not None and isinstance(uid, AgentId):
                 self._agents[uid] = agent
-            logger.info(
-                'Created mailbox for %s',
-                uid,
-                extra={'academy.mailbox_id': uid},
-            )
 
     async def terminate(self, client: ClientInfo, uid: EntityId) -> None:
         """Close a mailbox.
@@ -386,11 +381,6 @@ class PythonBackend:
                         await self.put(client, response)
 
             mailbox.shutdown(immediate=True)
-            logger.info(
-                'Closed mailbox for %s',
-                uid,
-                extra={'academy.mailbox_id': uid},
-            )
 
     async def discover(
         self,
@@ -532,7 +522,6 @@ class PythonBackend:
             self._shares[uid] = set()
 
         self._shares[uid].add(group_uid)
-        logger.info('Mailbox %s shared with group %s', uid, group_uid)
 
     async def get_mailbox_shares(
         self,
@@ -606,7 +595,6 @@ class PythonBackend:
             )
 
         self._shares[uid].discard(group_uid)
-        logger.info('Group %s removed from mailbox %s', group_uid, uid)
 
 
 async def _drain_queue(queue: AsyncQueue[Message[Any]]) -> list[Message[Any]]:

--- a/academy/exchange/cloud/config.py
+++ b/academy/exchange/cloud/config.py
@@ -26,6 +26,7 @@ from academy.exchange.cloud.backend import MailboxBackend
 from academy.exchange.cloud.backend import PythonBackend
 from academy.exchange.cloud.backend import RedisBackend
 from academy.logging import _Formatter
+from academy.logging import _os_thread_filter
 
 if sys.version_info >= (3, 11):  # pragma: >=3.11 cover
     import tomllib
@@ -82,7 +83,8 @@ class LogConfig(BaseModel):
             else:
                 file_handler = logging.FileHandler(path)
 
-            file_handler.setFormatter(_Formatter(color=False))
+            file_handler.addFilter(_os_thread_filter)
+            file_handler.setFormatter(_Formatter(color=False, extra=2))
             file_handler.setLevel(logfile_level)
             handlers.append(file_handler)
 


### PR DESCRIPTION
## Summary
Adding information to logs in the HttpExchange that can later be inspected for usage information. Fits in line with the new observability training.

## Related Issues
- Related to #360

## Changes
<!--- Check which of the following changes were made --->

- [ ] Breaking (backwards incompatible changes to public interfaces)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Enhancement (non-breaking change or feature addition)
- [ ] Refactor (internal code or design clean up)
- [ ] Documentation (no changes to the code)
- [ ] Test (changes or additions to testing)
- [ ] Build (change to CI workflows or build processes)
- [ ] Package (changes to package metadata or dependency versions)

## Testing
<!--- Please describe the test ran to verify changes --->

N/A

## Pull Request Checklist

Please confirm the PR meets the following requirements.
- [x] Relevant tags are added based on the types of changes.
- [x] Code changes pass `pre-commit` (e.g., ruff, mypy, etc.).
- [ ] Tests have been added to show the fix is effective or that the new feature works.
- [ ] New and existing unit tests pass locally with the changes.
- [ ] Docs have been updated and reviewed if relevant.
