### PR TITLE
Add Response on ShutdownRequest

### DIFF
--- a/academy/handle.py
+++ b/academy/handle.py
@@ -109,7 +109,6 @@ class Handle(Generic[AgentT_co]):
             uuid.UUID,
             asyncio.Future[Any],
         ] = {}
-        self._shutdown_requests: set[uuid.UUID] = set()
 
         if self._exchange is not None:
             self._register_with_exchange(self._exchange)
@@ -167,33 +166,6 @@ class Handle(Generic[AgentT_co]):
         return remote_method_call
 
     async def _process_response(self, response: Message[ResponseT]) -> None:
-        # Check if this is an error response for a shutdown request as those
-        # are handled differently than other requests types (action, ping)
-        # which always expect a response.
-        if response.tag in self._shutdown_requests:
-            self._shutdown_requests.remove(response.tag)
-            body = response.get_body()
-            assert isinstance(body, ErrorResponse)
-            exception = body.get_exception()
-            # The only ok error to be ignored is if the agent we intended to
-            # shutdown was already shutdown.
-            if (
-                not isinstance(exception, AgentTerminatedError)
-                or exception.uid != self.agent_id
-            ):
-                logger.error(
-                    'Failure requesting shutdown for %s: %s (type: %s)',
-                    self.agent_id,
-                    exception,
-                    type(exception),
-                    extra={
-                        'academy.agent_id': self.agent_id,
-                        'academy.exception': exception,
-                        'academy.exception_type': type(exception),
-                    },
-                )
-            return
-
         future = self._pending_response_futures.pop(response.tag)
 
         if not future.cancelled():
@@ -395,11 +367,32 @@ class Handle(Generic[AgentT_co]):
         )
         return elapsed
 
+    def _shutdown_callback(self, future: asyncio.Future[Any]) -> None:
+        if future.exception() is None:
+            return
+
+        exception = future.exception()
+        # The only ok error to be ignored is if the agent we intended to
+        # shutdown was already shutdown.
+        if (
+            not isinstance(exception, AgentTerminatedError)
+            or exception.uid != self.agent_id
+        ):
+            logger.error(
+                'Failure requesting shutdown for %s: %s (type: %s)',
+                self.agent_id,
+                exception,
+                type(exception),
+                extra={
+                    'academy.agent_id': self.agent_id,
+                    'academy.exception': exception,
+                    'academy.exception_type': type(exception),
+                },
+            )
+        return
+
     async def shutdown(self, *, terminate: bool | None = None) -> None:
         """Instruct the agent to shutdown.
-
-        This is non-blocking and will only send the request. Any unexpected
-        error responses sent by the exchange will be logged.
 
         Args:
             terminate: Override the termination behavior of the agent defined
@@ -419,14 +412,20 @@ class Handle(Generic[AgentT_co]):
             label=self.handle_id,
             body=ShutdownRequest(terminate=terminate),
         )
-        self._shutdown_requests.add(request.tag)
+
+        loop = asyncio.get_running_loop()
+        future: asyncio.Future[None] = loop.create_future()
+        self._pending_response_futures[request.tag] = future
         await self.exchange.send(request)
+
         logger.debug(
             'Sent shutdown request from %s to %s',
             exchange.client_id,
             self.agent_id,
             extra=request.log_extra(),
         )
+
+        future.add_done_callback(self._shutdown_callback)
 
 
 class ProxyHandle(Handle[AgentT]):

--- a/academy/handle.py
+++ b/academy/handle.py
@@ -394,6 +394,8 @@ class Handle(Generic[AgentT_co]):
     async def shutdown(self, *, terminate: bool | None = None) -> None:
         """Instruct the agent to shutdown.
 
+        This is non-blocking and will only send the message.
+
         Args:
             terminate: Override the termination behavior of the agent defined
                 in the [`RuntimeConfig`][academy.runtime.RuntimeConfig].

--- a/academy/runtime.py
+++ b/academy/runtime.py
@@ -372,6 +372,10 @@ class Runtime(Generic[AgentT], NoPickleMixin):
                 lambda _: self._action_tasks.pop(request.tag),
             )
         elif isinstance(body, ShutdownRequest):
+            response = request.create_response(SuccessResponse())
+            # We need to block here, because if we send this async,
+            # the exchange could be closed before the message is sent
+            await self._send_response(response)
             self.signal_shutdown(expected=True, terminate=body.terminate)
         else:
             raise AssertionError('Unreachable.')

--- a/tests/unit/handle_test.py
+++ b/tests/unit/handle_test.py
@@ -23,14 +23,11 @@ from academy.handle import exchange_context
 from academy.handle import Handle
 from academy.handle import ProxyHandle
 from academy.identifier import AgentId
-from academy.identifier import UserId
 from academy.manager import Manager
 from academy.message import ActionRequest
 from academy.message import CancelRequest
-from academy.message import ErrorResponse
 from academy.message import Message
 from academy.message import Request
-from academy.message import ShutdownRequest
 from testing.agents import CounterAgent
 from testing.agents import EmptyAgent
 from testing.agents import ErrorAgent
@@ -202,38 +199,21 @@ async def test_client_handle_ping_timeout(
         await handle.ping(timeout=TEST_SLEEP_INTERVAL)
 
 
-@pytest.mark.asyncio
 async def test_client_handle_shutdown_ignore_already_terminated() -> None:
     handle: Handle[EmptyAgent] = Handle(AgentId.new())
-
-    request = Message.create(
-        src=UserId.new(),
-        dest=handle.agent_id,
-        body=ShutdownRequest(),
-    )
-    handle._shutdown_requests.add(request.tag)
-    response = request.create_response(
-        ErrorResponse(exception=AgentTerminatedError(handle.agent_id)),
-    )
-    await handle._process_response(response)
+    future: asyncio.Future[None] = asyncio.Future()
+    future.set_exception(AgentTerminatedError(handle.agent_id))
+    handle._shutdown_callback(future)
 
 
 @pytest.mark.asyncio
 async def test_client_handle_shutdown_log_error_response(caplog) -> None:
     handle: Handle[EmptyAgent] = Handle(AgentId.new())
-
-    request = Message.create(
-        src=AgentId.new(),
-        dest=handle.agent_id,
-        body=ShutdownRequest(),
-    )
-    handle._shutdown_requests.add(request.tag)
-    response = request.create_response(
-        ErrorResponse(exception=AgentTerminatedError(AgentId.new())),
-    )
+    future: asyncio.Future[None] = asyncio.Future()
+    future.set_exception(AgentTerminatedError(AgentId.new()))
 
     with caplog.at_level(logging.ERROR):
-        await handle._process_response(response)
+        handle._shutdown_callback(future)
     assert f'Failure requesting shutdown for {handle.agent_id}' in caplog.text
 
 

--- a/tests/unit/runtime_test.py
+++ b/tests/unit/runtime_test.py
@@ -492,14 +492,17 @@ async def test_runtime_cancel_action_requests_on_shutdown(
     )
     await exchange_client.send(shutdown)
 
-    message = await anext(listener)
-    body = message.get_body()
-    if cancel:
-        assert isinstance(body, ErrorResponse)
-        assert isinstance(body.get_exception(), ActionCancelledError)
-    else:
-        assert isinstance(body, ActionResponse)
-        assert body.get_result() is None
+    for _ in range(2):
+        message = await anext(listener)
+        body = message.get_body()
+        if message.tag == shutdown.tag:
+            assert isinstance(body, SuccessResponse)
+        elif cancel:
+            assert isinstance(body, ErrorResponse)
+            assert isinstance(body.get_exception(), ActionCancelledError)
+        else:
+            assert isinstance(body, ActionResponse)
+            assert body.get_result() is None
 
     await asyncio.wait_for(task, timeout=TEST_WAIT_TIMEOUT)
 


### PR DESCRIPTION
## Summary
Add a response in the Runtime for shutdown requests. This simplified the handling of shutdown requests in the handle. To maintain the semantics of the current shutdown request, the acknowledgment is not waited for in `handle.shutdown`.


## Related Issues
<!--- List any issue numbers above that this PR addresses --->

- Closes #378 

## Changes
<!--- Check which of the following changes were made --->

- [ ] Breaking (backwards incompatible changes to public interfaces)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (non-breaking change or feature addition)
- [ ] Refactor (internal code or design clean up)
- [ ] Documentation (no changes to the code)
- [ ] Test (changes or additions to testing)
- [ ] Build (change to CI workflows or build processes)
- [ ] Package (changes to package metadata or dependency versions)

## Testing
<!--- Please describe the test ran to verify changes --->

N/A

## Pull Request Checklist

Please confirm the PR meets the following requirements.
- [x] Relevant tags are added based on the types of changes.
- [x] Code changes pass `pre-commit` (e.g., ruff, mypy, etc.).
- [x] Tests have been added to show the fix is effective or that the new feature works.
- [x] New and existing unit tests pass locally with the changes.
- [ ] Docs have been updated and reviewed if relevant.
