### PR TITLE
Log action args and result as logging extras

### DIFF
--- a/academy/handle.py
+++ b/academy/handle.py
@@ -249,6 +249,9 @@ class Handle(Generic[AgentT_co]):
             extra=invocation_extra
             | {
                 'academy.action_state': 'start',
+                'academy.action_args': args,
+                'academy.action_kwargs': kwargs,
+                'academy.agent_id': self.agent_id,
             },
         )
         exchange = self.exchange
@@ -323,6 +326,7 @@ class Handle(Generic[AgentT_co]):
 
         assert future.done()
         assert future.exception() is None
+        result = future.result()
 
         logger.debug(
             'Successfully completed action %s with tag id %s',
@@ -331,10 +335,12 @@ class Handle(Generic[AgentT_co]):
             extra=invocation_extra
             | {
                 'academy.action_state': 'success',
+                'academy.result': result,
+                'academy.agent_id': self.agent_id,
             },
         )
 
-        return future.result()
+        return result
 
     async def ping(self, *, timeout: float | None = None) -> float:
         """Ping the agent.


### PR DESCRIPTION
This information is useful for provence-style log consumers, most immediately the academy-flowcept prototype I built earlier this year.

Some caution about the size of args and result:

In the log call, before hitting any handlers, this is just a few more object references and so nothing serious - the size of the graphs referenced (i.e. the size of the args and result) is irrelevant at that stage.

Later on in log processing, log handlers which choose to do something with academy.* extra fields probably need to be aware that these fields might render into something large.

Right now the text format and JSON handlers don't do anything special for these fields beyond their normal string rendering when extra info is turned on.

If this turns out to be a problem, it should be straightforward to make the log handlers do something to make those fields rendered smaller.

In at least the flowcept case, the handler doesn't need to render the fields at all - it is handed to flowcept, which makes its own decisions about what to do.

## Related Issues
- Related to #295 

## Changes
<!--- Check which of the following changes were made --->

- [ ] Breaking (backwards incompatible changes to public interfaces)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Enhancement (non-breaking change or feature addition)
- [ ] Refactor (internal code or design clean up)
- [ ] Documentation (no changes to the code)
- [ ] Test (changes or additions to testing)
- [ ] Build (change to CI workflows or build processes)
- [ ] Package (changes to package metadata or dependency versions)

## Testing
<!--- Please describe the test ran to verify changes --->

N/A

## Pull Request Checklist

Please confirm the PR meets the following requirements.
- [x] Relevant tags are added based on the types of changes.
- [x] Code changes pass `pre-commit` (e.g., ruff, mypy, etc.).
- [ ] Tests have been added to show the fix is effective or that the new feature works.
- [x] New and existing unit tests pass locally with the changes.
- [ ] Docs have been updated and reviewed if relevant.
