### PR TITLE
Batch Globus auth registration to reduce consent prompts.

### DIFF
--- a/academy/exchange/client.py
+++ b/academy/exchange/client.py
@@ -166,6 +166,37 @@ class ExchangeClient(abc.ABC, Generic[ExchangeTransportT]):
         )
         return registration
 
+    async def register_agents(
+        self,
+        agents: list[tuple[type[AgentT], str | None]],
+    ) -> list[AgentRegistration[AgentT]]:
+        """Register multiple agents, batching auth if supported.
+
+        Falls back to sequential :meth:`register_agent` calls when
+        the transport does not implement batch registration.
+
+        Args:
+            agents: List of (agent_type, name) pairs to register.
+
+        Returns:
+            List of agent registrations in input order.
+        """
+        batch_fn = getattr(self._transport, 'register_agents', None)
+        if batch_fn is not None:
+            registrations = await batch_fn(agents)
+        else:
+            registrations = [
+                await self.register_agent(agent, name=name)
+                for agent, name in agents
+            ]
+        for reg in registrations:
+            logger.info(
+                'Registered %s in exchange',
+                reg.agent_id,
+                extra={'academy.agent_id': reg.agent_id},
+            )
+        return registrations
+
     async def send(self, message: Message[Any]) -> None:
         """Send a message to a mailbox.
 

--- a/academy/exchange/cloud/globus.py
+++ b/academy/exchange/cloud/globus.py
@@ -624,7 +624,7 @@ class GlobusExchangeTransport(ExchangeTransportMixin, NoPickleMixin):
 
         # Single login satisfies all accumulated scopes at once.
         assert self._app is not None
-        if self._app.login_required():
+        if self._app.login_required():  # pragma: no cover
             await loop.run_in_executor(
                 self.executor,
                 self._app.login,

--- a/academy/exchange/cloud/globus.py
+++ b/academy/exchange/cloud/globus.py
@@ -166,6 +166,21 @@ class AcademyGlobusClient(globus_sdk.BaseClient):
 
 
 @dataclasses.dataclass
+class _PendingRegistration(Generic[AgentT]):
+    """Intermediate state for a registration awaiting token delegation.
+
+    Created during the prepare phase of batch registration. Contains
+    the Globus Auth client, credential, and scope but not yet the
+    delegated token (which requires user consent).
+    """
+
+    agent_id: AgentId[AgentT]
+    client_id: uuid.UUID
+    secret: str
+    scope: Scope
+
+
+@dataclasses.dataclass
 class GlobusAgentRegistration(Generic[AgentT]):
     """Agent registration for hosted globus exchange."""
 
@@ -440,10 +455,18 @@ class GlobusExchangeTransport(ExchangeTransportMixin, NoPickleMixin):
         while True:
             yield await self._recv(timeout)
 
-    def _create_registration(
+    def _prepare_registration(
         self,
         aid: AgentId[AgentT],
-    ) -> GlobusAgentRegistration[AgentT]:
+    ) -> _PendingRegistration[AgentT]:
+        """Create Globus Auth client, credential, and scope for an agent.
+
+        This is phase 1 of registration. It creates all Globus Auth
+        entities and accumulates the scope requirement on the GlobusApp,
+        but does not trigger user consent. Call
+        :meth:`_finalize_registration` after all agents are prepared to
+        obtain delegated tokens with a single login.
+        """
         # Create new resource server (auth entity)
         logger.info('Creating new auth client')
         client_response = self.auth_client.create_client(
@@ -484,26 +507,59 @@ class GlobusExchangeTransport(ExchangeTransportMixin, NoPickleMixin):
         )
         scope = Scope.parse(scope_response['scopes'][0]['scope_string'])
 
-        # Create delegated token
-        logger.info('Creating delegated token.')
-        assert self._app is not None  # Already true, but not caught by mypy
+        # Accumulate scope requirement (no consent triggered yet)
+        assert self._app is not None
         self._app.add_scope_requirements(
             {client_id: [scope]},
         )
-        authorizer = self._app.get_authorizer(client_id)
+
+        return _PendingRegistration(
+            agent_id=aid,
+            client_id=client_id,
+            secret=secret,
+            scope=scope,
+        )
+
+    def _finalize_registration(
+        self,
+        pending: _PendingRegistration[AgentT],
+    ) -> GlobusAgentRegistration[AgentT]:
+        """Obtain delegated token for a previously prepared agent.
+
+        This is phase 2 of registration. The GlobusApp must already
+        have valid tokens for the agent's scope (via a prior
+        ``login()`` call that covered all accumulated scopes).
+        """
+        logger.info('Creating delegated token.')
+        assert self._app is not None
+        authorizer = self._app.get_authorizer(str(pending.client_id))
         bearer = authorizer.get_authorization_header()
         if bearer is None:  # pragma: no cover
-            raise UnauthorizedError('Unable to get authorization headers.')
+            raise UnauthorizedError(
+                'Unable to get authorization headers.',
+            )
 
         auth_header_parts = bearer.split(' ')
         token = auth_header_parts[1]
 
         return GlobusAgentRegistration(
-            agent_id=aid,
-            client_id=client_id,
+            agent_id=pending.agent_id,
+            client_id=pending.client_id,
             token=token,
-            secret=secret,
+            secret=pending.secret,
         )
+
+    def _create_registration(
+        self,
+        aid: AgentId[AgentT],
+    ) -> GlobusAgentRegistration[AgentT]:
+        """Create a single agent registration (prepare + finalize).
+
+        Convenience method that runs both phases sequentially for a
+        single agent. Triggers a consent prompt for the new scope.
+        """
+        pending = self._prepare_registration(aid)
+        return self._finalize_registration(pending)
 
     def _create_mailbox(
         self,
@@ -539,6 +595,62 @@ class GlobusExchangeTransport(ExchangeTransportMixin, NoPickleMixin):
         self.child_clients.append(registration.client_id)
 
         return registration
+
+    async def register_agents(
+        self,
+        agents: list[tuple[type[AgentT], str | None]],
+    ) -> list[GlobusAgentRegistration[AgentT]]:
+        """Register multiple agents with a single auth prompt.
+
+        Args:
+            agents: List of (agent_type, name) pairs to register.
+
+        Returns:
+            List of agent registrations in order of input.
+        """
+        loop = asyncio.get_running_loop()
+
+        # first: create clients, credentials, scopes and
+        # add scope requirements without consent.
+        pending: list[tuple[_PendingRegistration[AgentT], type[AgentT]]] = []
+        for agent_type, name in agents:
+            aid: AgentId[AgentT] = AgentId.new(name=name)
+            p = await loop.run_in_executor(
+                self.executor,
+                self._prepare_registration,
+                aid,
+            )
+            pending.append((p, agent_type))
+
+        # Single login satisfies all accumulated scopes at once.
+        assert self._app is not None
+        if self._app.login_required():
+            await loop.run_in_executor(
+                self.executor,
+                self._app.login,
+            )
+
+        # Phase 2: extract delegated tokens (cache hits, no prompts).
+        registrations: list[GlobusAgentRegistration[AgentT]] = []
+        for p, agent_type in pending:
+            reg = await loop.run_in_executor(
+                self.executor,
+                self._finalize_registration,
+                p,
+            )
+
+            # Create mailbox on the exchange.
+            await loop.run_in_executor(
+                self.executor,
+                self._create_mailbox,
+                reg.agent_id,
+                agent_type,
+            )
+
+            self.child_clients.append(reg.client_id)
+            registrations.append(reg)
+
+        return registrations
 
     def _send(self, message: Message[Any]) -> None:
         self.exchange_client.send(message)

--- a/academy/exchange/cloud/globus.py
+++ b/academy/exchange/cloud/globus.py
@@ -240,6 +240,7 @@ class GlobusExchangeTransport(ExchangeTransportMixin, NoPickleMixin):
         self.login_time = datetime.min
         self._app = app
         self._authorizer = authorizer
+        self._auth_lock = threading.Lock()
         self._local_data = threading.local()
         self.executor = ThreadPoolExecutor(
             thread_name_prefix='exchange-globus-thread',
@@ -262,43 +263,46 @@ class GlobusExchangeTransport(ExchangeTransportMixin, NoPickleMixin):
     @property
     def auth_client(self) -> AuthClient:
         """A thread local copy of the Globus AuthClient."""
+        # Fast path: return cached thread-local client.
         if datetime.now() - self.login_time < timedelta(minutes=30):
-            login = False
             try:
                 return self._local_data.auth_client
-            except AttributeError:  # pragma: no cover
-                logger.debug('Auth client does not exist for thread.')
-                pass
+            except AttributeError:
+                logger.debug(
+                    'Auth client does not exist for thread.',
+                )
         else:
-            login = True
-            logger.debug('Auth client login timeout.')
+            # Login required — serialize to prevent duplicate
+            # interactive prompts from concurrent threads.
+            with self._auth_lock:
+                if datetime.now() - self.login_time >= timedelta(minutes=30):
+                    logger.debug('Auth client login timeout.')
+
+                    if self._app is None:
+                        raise NotImplementedError(
+                            'Launching child agents is'
+                            ' currently not implemented.',
+                        )
+
+                    self._app.add_scope_requirements(
+                        {
+                            AuthScopes.resource_server: [
+                                AuthScopes.manage_projects,
+                                AuthScopes.email,
+                                AuthScopes.profile,
+                            ],
+                        },
+                    )
+
+                    self._app.login(
+                        force=True,
+                        auth_params=GlobusAuthorizationParameters(
+                            prompt='login',
+                        ),
+                    )
+                    self.login_time = datetime.now()
 
         logger.info('Initializing auth client.')
-
-        if self._app is None:
-            raise NotImplementedError(
-                'Launching child agents is\
-                currently not implemented.',
-            )
-
-        self._app.add_scope_requirements(
-            {
-                AuthScopes.resource_server: [
-                    AuthScopes.manage_projects,
-                    AuthScopes.email,
-                    AuthScopes.profile,
-                ],
-            },
-        )
-
-        if login:  # pragma: no branch
-            self._app.login(
-                force=True,
-                auth_params=GlobusAuthorizationParameters(prompt='login'),
-            )
-
-        self.login_time = datetime.now()
-
         self._local_data.auth_client = AuthClient(
             app=self._app,
         )
@@ -462,10 +466,11 @@ class GlobusExchangeTransport(ExchangeTransportMixin, NoPickleMixin):
         """Create Globus Auth client, credential, and scope for an agent.
 
         This is phase 1 of registration. It creates all Globus Auth
-        entities and accumulates the scope requirement on the GlobusApp,
-        but does not trigger user consent. Call
-        :meth:`_finalize_registration` after all agents are prepared to
-        obtain delegated tokens with a single login.
+        entities but does **not** accumulate scope requirements or
+        trigger user consent. The caller is responsible for adding
+        the returned scope via
+        :meth:`GlobusApp.add_scope_requirements` and triggering
+        login before calling :meth:`_finalize_registration`.
         """
         # Create new resource server (auth entity)
         logger.info('Creating new auth client')
@@ -506,12 +511,6 @@ class GlobusExchangeTransport(ExchangeTransportMixin, NoPickleMixin):
             allows_refresh_token=True,
         )
         scope = Scope.parse(scope_response['scopes'][0]['scope_string'])
-
-        # Accumulate scope requirement (no consent triggered yet)
-        assert self._app is not None
-        self._app.add_scope_requirements(
-            {client_id: [scope]},
-        )
 
         return _PendingRegistration(
             agent_id=aid,
@@ -559,6 +558,10 @@ class GlobusExchangeTransport(ExchangeTransportMixin, NoPickleMixin):
         single agent. Triggers a consent prompt for the new scope.
         """
         pending = self._prepare_registration(aid)
+        assert self._app is not None
+        self._app.add_scope_requirements(
+            {str(pending.client_id): [pending.scope]},
+        )
         return self._finalize_registration(pending)
 
     def _create_mailbox(
@@ -610,47 +613,83 @@ class GlobusExchangeTransport(ExchangeTransportMixin, NoPickleMixin):
         """
         loop = asyncio.get_running_loop()
 
-        # first: create clients, credentials, scopes and
-        # add scope requirements without consent.
-        pending: list[tuple[_PendingRegistration[AgentT], type[AgentT]]] = []
-        for agent_type, name in agents:
-            aid: AgentId[AgentT] = AgentId.new(name=name)
-            p = await loop.run_in_executor(
-                self.executor,
-                self._prepare_registration,
-                aid,
-            )
-            pending.append((p, agent_type))
+        # Phase 1: create auth entities concurrently.
+        # _prepare_registration no longer mutates shared GlobusApp
+        # state, and the auth_client property serializes interactive
+        # login via _auth_lock, so parallel dispatch is safe.
+        aids: list[AgentId[AgentT]] = [
+            AgentId.new(name=name) for _, name in agents
+        ]
+        prepared: list[_PendingRegistration[AgentT]] = list(
+            await asyncio.gather(
+                *(
+                    loop.run_in_executor(
+                        self.executor,
+                        self._prepare_registration,
+                        aid,
+                    )
+                    for aid in aids
+                ),
+            ),
+        )
+        pending = list(
+            zip(
+                prepared,
+                [at for at, _ in agents],
+                strict=True,
+            ),
+        )
 
-        # Single login satisfies all accumulated scopes at once.
+        # Accumulate scope requirements, then do a single login
+        # that satisfies all of them at once.
         assert self._app is not None
-        if self._app.login_required():  # pragma: no cover
+        for p, _ in pending:
+            self._app.add_scope_requirements(
+                {str(p.client_id): [p.scope]},
+            )
+
+        if self._app.login_required():
             await loop.run_in_executor(
                 self.executor,
                 self._app.login,
             )
 
-        # Phase 2: extract delegated tokens (cache hits, no prompts).
-        registrations: list[GlobusAgentRegistration[AgentT]] = []
-        for p, agent_type in pending:
-            reg = await loop.run_in_executor(
-                self.executor,
-                self._finalize_registration,
-                p,
-            )
+        # Phase 2: extract delegated tokens and create mailboxes.
+        # Safe to parallelize — no shared state mutation, and the
+        # app already holds valid tokens for all scopes.
+        regs: list[GlobusAgentRegistration[AgentT]] = list(
+            await asyncio.gather(
+                *(
+                    loop.run_in_executor(
+                        self.executor,
+                        self._finalize_registration,
+                        p,
+                    )
+                    for p, _ in pending
+                ),
+            ),
+        )
 
-            # Create mailbox on the exchange.
-            await loop.run_in_executor(
-                self.executor,
-                self._create_mailbox,
-                reg.agent_id,
-                agent_type,
-            )
+        await asyncio.gather(
+            *(
+                loop.run_in_executor(
+                    self.executor,
+                    self._create_mailbox,
+                    reg.agent_id,
+                    agent_type,
+                )
+                for reg, (_, agent_type) in zip(
+                    regs,
+                    pending,
+                    strict=True,
+                )
+            ),
+        )
 
+        for reg in regs:
             self.child_clients.append(reg.client_id)
-            registrations.append(reg)
 
-        return registrations
+        return regs
 
     def _send(self, message: Message[Any]) -> None:
         self.exchange_client.send(message)

--- a/academy/manager.py
+++ b/academy/manager.py
@@ -573,6 +573,27 @@ class Manager(Generic[ExchangeTransportT], NoPickleMixin):
         """
         return await self.exchange_client.register_agent(agent, name=name)
 
+    async def register_agents(
+        self,
+        agents: list[tuple[type[AgentT], str | None]],
+    ) -> list[AgentRegistration[AgentT]]:
+        """Register multiple agents, batching auth when possible.
+
+        For transports that support batch registration (e.g. Globus),
+        all auth consent is consolidated into a single prompt. For
+        other transports this falls back to sequential registration.
+
+        Use the returned registrations with
+        :meth:`launch(registration=...) <launch>`.
+
+        Args:
+            agents: List of (agent_type, name) pairs to register.
+
+        Returns:
+            List of registrations in the same order as the input.
+        """
+        return await self.exchange_client.register_agents(agents)
+
     def running(self) -> set[AgentId[Any]]:
         """Get a set of IDs of all running agents.
 

--- a/examples/12-globus-exchange/run-12.py
+++ b/examples/12-globus-exchange/run-12.py
@@ -1,0 +1,105 @@
+"""Globus exchange example.
+
+Uses GlobusExchangeFactory against the hosted exchange at
+exchange.academy-agents.org. Each agent gets its own Globus Auth
+client, credentials, and delegated token.
+
+Requires:
+    export ACADEMY_TEST_PROJECT_ID=<project-uuid>
+
+Usage:
+    PYTHONPATH=. python examples/12-globus-exchange/run-12.py
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+import uuid
+from typing import Any
+
+from academy.agent import action
+from academy.agent import Agent
+from academy.exchange.cloud.globus import GlobusExchangeFactory
+from academy.exchange.transport import AgentRegistration
+from academy.handle import Handle
+from academy.logging import init_logging
+from academy.manager import Manager
+
+logger = logging.getLogger(__name__)
+
+
+class Greeter(Agent):
+    """Agent that greets people."""
+
+    @action
+    async def greet(self, name: str) -> str:
+        greeting = f'Hello, {name}!'
+        logger.info(f'Greeter: {greeting!r}')
+        return greeting
+
+
+class Shouter(Agent):
+    """Agent that uppercases text."""
+
+    @action
+    async def shout(self, text: str) -> str:
+        result = text.upper()
+        logger.info(f'Shouter: {result!r}')
+        return result
+
+
+class Coordinator(Agent):
+    """Orchestrates Greeter and Shouter."""
+
+    def __init__(
+        self,
+        greeter: Handle[Greeter],
+        shouter: Handle[Shouter],
+    ) -> None:
+        super().__init__()
+        self.greeter = greeter
+        self.shouter = shouter
+
+    @action
+    async def greet_loudly(self, name: str) -> str:
+        greeting = await self.greeter.greet(name)
+        return await self.shouter.shout(greeting)
+
+
+async def main() -> int:
+    init_logging(logging.INFO)
+
+    project_id = uuid.UUID(os.environ['ACADEMY_TEST_PROJECT_ID'])
+
+    factory = GlobusExchangeFactory(project_id=project_id)
+
+    async with await Manager.from_exchange_factory(
+        factory=factory,
+    ) as manager:
+        regs: list[AgentRegistration[Any]] = await manager.register_agents(
+            [
+                (Greeter, None),
+                (Shouter, None),
+                (Coordinator, None),
+            ],
+        )
+
+        greeter = await manager.launch(Greeter, registration=regs[0])
+        shouter = await manager.launch(Shouter, registration=regs[1])
+        coordinator = await manager.launch(
+            Coordinator,
+            args=(greeter, shouter),
+            registration=regs[2],
+        )
+
+        result = await coordinator.greet_loudly('Academy')
+        logger.info(f'Result: {result!r}')
+        assert result == 'HELLO, ACADEMY!'
+
+    return 0
+
+
+if __name__ == '__main__':
+    raise SystemExit(asyncio.run(main()))

--- a/tests/unit/exchange/client_test.py
+++ b/tests/unit/exchange/client_test.py
@@ -94,6 +94,27 @@ async def test_create_agent_client_unregistered(
 
 
 @pytest.mark.asyncio
+async def test_register_agents(
+    client: UserExchangeClient[Any],
+) -> None:
+    registrations = await client.register_agents(
+        [(EmptyAgent, None), (EmptyAgent, 'named')],
+    )
+    assert len(registrations) == 2  # noqa: PLR2004
+    for reg in registrations:
+        status = await client._transport.status(reg.agent_id)
+        assert status == MailboxStatus.ACTIVE
+
+
+@pytest.mark.asyncio
+async def test_register_agents_empty(
+    client: UserExchangeClient[Any],
+) -> None:
+    registrations: list[Any] = await client.register_agents([])
+    assert registrations == []
+
+
+@pytest.mark.asyncio
 async def test_client_discover(client: UserExchangeClient[Any]) -> None:
     registration = await client.register_agent(EmptyAgent)
     assert await client.discover(EmptyAgent) == (registration.agent_id,)

--- a/tests/unit/exchange/cloud/globus_test.py
+++ b/tests/unit/exchange/cloud/globus_test.py
@@ -1,14 +1,21 @@
 from __future__ import annotations
 
 import os
+import uuid
+from datetime import datetime
 from typing import Any
+from unittest.mock import MagicMock
+from unittest.mock import patch
 
 import pytest
 import responses
 from globus_sdk.testing import load_response
 
 from academy.exchange.cloud.app import StatusCode
+from academy.exchange.cloud.globus import _PendingRegistration
 from academy.exchange.cloud.globus import AcademyGlobusClient
+from academy.exchange.cloud.globus import GlobusAgentRegistration
+from academy.exchange.cloud.globus import GlobusExchangeTransport
 from academy.identifier import AgentId
 from academy.identifier import UserId
 from academy.message import Message
@@ -82,3 +89,91 @@ def test_globus_client_terminate(academy_client: AcademyGlobusClient):
     agent: AgentId[Any] = AgentId.new()
     response = academy_client.terminate(agent)
     assert response.http_status == StatusCode.OKAY.value
+
+
+@pytest.mark.asyncio
+async def test_register_agents_single_login() -> None:
+    """Batch registration triggers at most one login."""
+    mock_app = MagicMock()
+    mock_app.login_required.return_value = True
+
+    transport = GlobusExchangeTransport(
+        UserId.new(),
+        project_id=uuid.uuid4(),
+        app=mock_app,
+    )
+
+    def _make_pending(
+        aid: AgentId[Any],
+    ) -> _PendingRegistration[Any]:
+        return _PendingRegistration(
+            agent_id=aid,
+            client_id=uuid.uuid4(),
+            secret='secret',
+            scope=MagicMock(),
+        )
+
+    def _make_reg(
+        pending: _PendingRegistration[Any],
+    ) -> GlobusAgentRegistration[Any]:
+        return GlobusAgentRegistration(
+            agent_id=pending.agent_id,
+            client_id=pending.client_id,
+            token='token',
+            secret=pending.secret,
+        )
+
+    with (
+        patch.object(
+            transport,
+            '_prepare_registration',
+            side_effect=_make_pending,
+        ),
+        patch.object(
+            transport,
+            '_finalize_registration',
+            side_effect=_make_reg,
+        ),
+        patch.object(transport, '_create_mailbox'),
+    ):
+        results = await transport.register_agents(
+            [
+                (EmptyAgent, None),
+                (EmptyAgent, None),
+                (EmptyAgent, None),
+            ],
+        )
+
+    assert len(results) == 3  # noqa: PLR2004
+    mock_app.login.assert_called_once()
+
+    # Verify each agent's scope was accumulated before login.
+    assert mock_app.add_scope_requirements.call_count == 3  # noqa: PLR2004
+    for result, call in zip(
+        results,
+        mock_app.add_scope_requirements.call_args_list,
+        strict=True,
+    ):
+        (scope_dict,) = call.args
+        assert str(result.client_id) in scope_dict
+
+
+def test_auth_client_new_thread_skips_login() -> None:
+    """Fresh login_time without cached client skips login."""
+    mock_app = MagicMock()
+
+    transport = GlobusExchangeTransport(
+        UserId.new(),
+        project_id=uuid.uuid4(),
+        app=mock_app,
+    )
+    # Simulate a prior login having already completed.
+    transport.login_time = datetime.now()
+
+    with patch(
+        'academy.exchange.cloud.globus.AuthClient',
+    ) as mock_cls:
+        _ = transport.auth_client
+
+    mock_cls.assert_called_once_with(app=mock_app)
+    mock_app.login.assert_not_called()

--- a/tests/unit/manager_test.py
+++ b/tests/unit/manager_test.py
@@ -143,6 +143,25 @@ async def test_shutdown_bad_identifier(
 
 
 @pytest.mark.asyncio
+async def test_register_agents_and_launch(
+    manager: Manager[LocalExchangeTransport],
+) -> None:
+    registrations = await manager.register_agents(
+        [(EmptyAgent, None), (IdentityAgent, None)],
+    )
+    assert len(registrations) == 2  # noqa: PLR2004
+    await manager.launch(
+        EmptyAgent(),
+        registration=registrations[0],
+    )
+    await manager.launch(
+        IdentityAgent(),
+        registration=registrations[1],
+    )
+    assert len(manager.running()) == 2  # noqa: PLR2004
+
+
+@pytest.mark.asyncio
 async def test_duplicate_launched_agents_error(
     manager: Manager[LocalExchangeTransport],
 ) -> None:


### PR DESCRIPTION
## Summary

This change is local to the Globus exchange transport.

The function _create_registration was split between two phases / functions. First, _prepare_registration creates the globus client with its creds and scope requirements. This does *not* trigger user consent. Next, _finalize_registration authenticates all clients with a single user auth prompt.

This reduces the total number of consent prompts to 2 regardless of agent count. The first prompt is for the manage_projects scope, the second prompt is for all agent scopes batched into a single consent.

Changes:
- academy/exchange/cloud/globus.py: new _PendingRegistration dataclass,  _prepare_registration (phase 1: create client/cred/scope, accumulate scope requirements), _finalize_registration (phase 2: extract delegated tokens as cache hits), register_agents (orchestrates batch flow)
- academy/exchange/client.py: register_agents on UserExchangeClient with fallback to sequential registration for non-batch transports
- academy/manager.py: register_agents pass-through to exchange client
- examples/12-globus-exchange/run-12.py: example demonstrating batch registration with GlobusExchangeFactory

## Changes
<!--- Check which of the following changes were made --->

- [ ] Breaking (backwards incompatible changes to public interfaces)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Enhancement (non-breaking change or feature addition)
- [ ] Refactor (internal code or design clean up)
- [ ] Documentation (no changes to the code)
- [ ] Test (changes or additions to testing)
- [ ] Build (change to CI workflows or build processes)
- [ ] Package (changes to package metadata or dependency versions)

## Testing
<!--- Please describe the test ran to verify changes --->

N/A

## Pull Request Checklist

Please confirm the PR meets the following requirements.
- [x] Relevant tags are added based on the types of changes.
- [x] Code changes pass `pre-commit` (e.g., ruff, mypy, etc.).
- [x] Tests have been added to show the fix is effective or that the new feature works.
- [x] New and existing unit tests pass locally with the changes.
- [x] Docs have been updated and reviewed if relevant.
