### PR TITLE
Launching Detached Agents

### DIFF
--- a/academy/manager.py
+++ b/academy/manager.py
@@ -4,6 +4,8 @@ import asyncio
 import contextlib
 import dataclasses
 import logging
+import pickle
+import subprocess
 import sys
 import warnings
 from collections.abc import Iterable
@@ -57,6 +59,7 @@ class _RunSpec(Generic[AgentT, ExchangeTransportT]):
     init_logging: bool = False
     loglevel: int | str = logging.INFO
     logfile: str | None = None
+    detached: bool = False
 
 
 async def _run_agent_async(
@@ -101,12 +104,36 @@ def _run_agent_on_worker(
     asyncio.run(_run_agent_async(spec))
 
 
+def _run_agent_detached(
+    spec: _RunSpec[AgentT, ExchangeTransportT],
+    academy_debug_mode: bool = False,
+    **kwargs: Any,
+) -> int:
+    args = [
+        sys.executable,
+        '-m',
+        'academy.remote',
+    ]
+    if academy_debug_mode:
+        args.append('--debug')
+    proc = subprocess.Popen(
+        args,
+        stdin=subprocess.PIPE,
+        start_new_session=True,
+    )
+    assert proc.stdin is not None  # Necessary for mypy
+    pickle.dump(spec, proc.stdin)
+    proc.stdin.close()
+    return proc.pid
+
+
 @dataclasses.dataclass
 class _ACB(Generic[AgentT]):
     # Agent Control Block
     agent_id: AgentId[AgentT]
     executor: str
     task: asyncio.Task[None]
+    detached: bool = False
 
 
 class Manager(Generic[ExchangeTransportT], NoPickleMixin):
@@ -276,7 +303,7 @@ class Manager(Generic[ExchangeTransportT], NoPickleMixin):
         self._closed.set()  # Stop from launching retries
 
         for acb in self._acbs.values():
-            if not acb.task.done():
+            if not acb.task.done() and not acb.detached:
                 handle = self.get_handle(acb.agent_id)
                 with contextlib.suppress(AgentTerminatedError):
                     await handle.shutdown()
@@ -345,7 +372,7 @@ class Manager(Generic[ExchangeTransportT], NoPickleMixin):
         self._default_executor = name
         return self
 
-    async def _run_agent(
+    async def _run_agent(  # noqa: C901
         self,
         executor: Executor | None,
         spec: _RunSpec[AgentT, ExchangeTransportT],
@@ -385,7 +412,22 @@ class Manager(Generic[ExchangeTransportT], NoPickleMixin):
             )
 
             try:
-                if executor is not None:
+                if spec.detached and executor is not None:
+                    await asyncio.wrap_future(
+                        executor.submit(
+                            _run_agent_detached,  # type: ignore[arg-type]
+                            spec,
+                            **spec.submit_kwargs,
+                        ),
+                        loop=loop,
+                    )
+                elif spec.detached and executor is None:
+                    await loop.run_in_executor(
+                        None,
+                        _run_agent_detached,
+                        spec,
+                    )
+                elif executor is not None:
                     await asyncio.wrap_future(
                         executor.submit(
                             _run_agent_on_worker,  # type: ignore[arg-type]
@@ -404,23 +446,18 @@ class Manager(Generic[ExchangeTransportT], NoPickleMixin):
                 )
                 raise
             except Exception:
+                logger.exception(
+                    'Received exception from %s, retries remaining: %d',
+                    agent_id,
+                    retries,
+                    extra={'academy.agent_id': agent_id},
+                )
                 if retries == 0:
-                    logger.exception(
-                        'Received exception from %s',
-                        agent_id,
-                        extra={'academy.agent_id': agent_id},
-                    )
                     if spec.config.terminate_on_error:
                         await self.exchange_client.terminate(
                             spec.registration.agent_id,
                         )
                     raise
-                else:
-                    logger.exception(
-                        'Restarting %s due to exception',
-                        agent_id,
-                        extra={'academy.agent_id': agent_id},
-                    )
             else:
                 logger.debug(
                     'Completed %s task',
@@ -443,6 +480,7 @@ class Manager(Generic[ExchangeTransportT], NoPickleMixin):
         init_logging: bool = False,
         loglevel: int | str = logging.INFO,
         logfile: str | None = None,
+        detach: bool = False,
     ) -> Handle[AgentT]:
         """Launch a new agent with a specified agent.
 
@@ -465,6 +503,10 @@ class Manager(Generic[ExchangeTransportT], NoPickleMixin):
             init_logging: Initialize logging before running agent.
             loglevel: Level of logging.
             logfile: Location to write logs.
+            detach: Run the agent in a separate process detached from the
+                life of the manager. (Manager only catches and retries errors
+                while spawning the agent process. Once the agent is detached,
+                the manager is no longer responsible for the agent.)
 
         Returns:
             Handle (client bound) used to interact with the agent.
@@ -510,6 +552,7 @@ class Manager(Generic[ExchangeTransportT], NoPickleMixin):
             init_logging=init_logging,
             loglevel=loglevel,
             logfile=logfile,
+            detached=detach,
         )
 
         task = asyncio.create_task(

--- a/academy/remote.py
+++ b/academy/remote.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+import argparse
+import pickle
+import sys
+from collections.abc import Sequence
+from typing import Any
+
+from academy.manager import _run_agent_on_worker
+from academy.manager import _RunSpec
+
+
+def _main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        '--debug',
+        action='store_true',
+        help='Use Academy debug mode',
+    )
+    parser.add_argument('--spec', default=None, help='Path to spec file')
+
+    argv = sys.argv[1:] if argv is None else argv
+    args = parser.parse_args(argv)
+
+    spec: _RunSpec[Any, Any]
+    if args.spec is None:
+        spec_bytes = sys.stdin.buffer.read()
+        spec = pickle.loads(spec_bytes)
+    else:
+        with open(args.spec, 'rb') as fp:
+            spec = pickle.load(fp)
+
+    _run_agent_on_worker(spec, args.debug)
+
+    return 0
+
+
+if __name__ == '__main__':
+    raise SystemExit(_main())

--- a/academy/testing.py
+++ b/academy/testing.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+import asyncio
+from typing import TypeVar
+
+from academy.agent import action
+from academy.agent import Agent
+from academy.agent import loop
+
+T = TypeVar('T')
+
+
+class EmptyAgent(Agent):
+    pass
+
+
+class ErrorAgent(Agent):
+    @action
+    async def fails(self) -> None:
+        raise RuntimeError('This action always fails.')
+
+
+class IdentityAgent(Agent):
+    @action
+    async def identity(self, value: T) -> T:
+        return value
+
+
+class WaitAgent(Agent):
+    @loop
+    async def wait(self, shutdown: asyncio.Event) -> None:
+        await shutdown.wait()
+
+
+class CounterAgent(Agent):
+    def __init__(self) -> None:
+        super().__init__()
+        self._count = 0
+
+    async def agent_on_startup(self) -> None:
+        self._count = 0
+
+    @action
+    async def add(self, value: int) -> None:
+        self._count += value
+
+    @action
+    async def count(self) -> int:
+        return self._count
+
+
+class SleepAgent(Agent):
+    def __init__(self, loop_sleep: float = 0.001) -> None:
+        super().__init__()
+        self.loop_sleep = loop_sleep
+        self.steps = 0
+
+    @loop
+    async def count(self, shutdown: asyncio.Event) -> None:
+        while not shutdown.is_set():
+            self.steps += 1
+            await asyncio.sleep(self.loop_sleep)
+
+    @action
+    async def sleep(self, action_sleep: float) -> None:
+        await asyncio.sleep(action_sleep)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,7 @@ dependencies = [
     "culsans",
     "globus_sdk>=4,<5",
     "pydantic>=2,<3",
+    "python-daemon>=3.1.2",
     "redis",
     "tomli ; python_version<'3.11'",
     "typing-extensions>=4.3.0 ; python_version<'3.11'",
@@ -200,6 +201,7 @@ required-imports = ["from __future__ import annotations"]
 "*/*_test.py" = ["D10"]
 "examples/*" = ["D"]
 "testing/*" = ["D"]
+"academy/testing.py" = ["D"]
 
 [tool.ruff.lint.pydocstyle]
 convention = "google"

--- a/tests/unit/manager_test.py
+++ b/tests/unit/manager_test.py
@@ -5,6 +5,7 @@ import multiprocessing
 import pathlib
 import time
 from collections.abc import Callable
+from concurrent.futures import Executor
 from concurrent.futures import Future
 from concurrent.futures import ProcessPoolExecutor
 from concurrent.futures import ThreadPoolExecutor
@@ -23,7 +24,7 @@ from academy.exchange import LocalExchangeFactory
 from academy.exchange import LocalExchangeTransport
 from academy.exchange import UserExchangeClient
 from academy.manager import Manager
-from testing.agents import EmptyAgent
+from academy.testing import EmptyAgent
 from testing.agents import IdentityAgent
 from testing.agents import SleepAgent
 from testing.constant import TEST_CONNECTION_TIMEOUT
@@ -456,3 +457,27 @@ async def test_terminate_mailbox_on_launch_error(
 
     with pytest.raises(RuntimeError):
         await manager.close()
+
+
+@pytest.mark.parametrize(
+    'executor',
+    (None, ProcessPoolExecutor()),
+)
+async def test_launch_agent_detached(
+    http_exchange_factory: HttpExchangeFactory,
+    executor: Executor | None,
+):
+    async with await Manager.from_exchange_factory(
+        factory=http_exchange_factory,
+        executors=executor,
+    ) as manager:
+        hdl = await manager.launch(
+            EmptyAgent,
+            detach=True,
+        )
+        await manager.wait([hdl])
+
+    async with await http_exchange_factory.create_user_client():
+        # Test agent is still active after manager shutdown
+        await hdl.ping(timeout=TEST_WAIT_TIMEOUT)
+        await hdl.shutdown()

--- a/tests/unit/remote_test.py
+++ b/tests/unit/remote_test.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+import pickle
+import sys
+from collections.abc import AsyncGenerator
+from typing import Any
+from unittest import mock
+
+import pytest_asyncio
+
+from academy.exchange import ExchangeFactory
+from academy.exchange.client import ExchangeClient
+from academy.remote import _main
+from testing.agents import SleepAgent
+from testing.fixture import EXCHANGE_FACTORY_TYPES
+
+
+@pytest_asyncio.fixture(params=EXCHANGE_FACTORY_TYPES)
+async def client(
+    request,
+    get_factory,
+) -> AsyncGenerator[ExchangeFactory[Any]]:
+    factory = get_factory(request.param)
+    client = await factory.create_user_client(start_listener=False)
+    try:
+        yield client
+    finally:
+        await client.close()
+
+
+async def test_run_agent_stdin(client: ExchangeClient[Any]):
+    agent_spec = await client.register_agent(SleepAgent)
+    with mock.patch('academy.remote._run_agent_on_worker'):
+        with mock.patch.object(
+            sys.stdin.buffer,
+            'read',
+            return_value=pickle.dumps(agent_spec),
+        ):
+            assert _main([]) == 0
+
+
+async def test_run_agent_file(client: ExchangeClient[Any], tmp_path):
+    agent_spec = await client.register_agent(SleepAgent)
+    file = tmp_path / 'agent_spec.pkl'
+    with file.open('wb') as fp:
+        pickle.dump(agent_spec, fp)
+
+    with mock.patch('academy.remote._run_agent_on_worker'):
+        assert _main(['--spec', str(tmp_path / 'agent_spec.pkl')]) == 0


### PR DESCRIPTION
## Summary
<!--- Provide a summary of the changes --->
Provides a mechanism to launch agents that automatically detach from a manager. I anticipate this is going to generate some discussion. I decided to use subprocess.Popen here to create a child process, and used `start_new_session` to free it from its parent process --- not sure if more should be done (i.e. to set the group or make process a daemon). This process reads the spec from standard in to load the agent for the first time. The retry and error catching mechanism of the manager are applied to the instantiation of the child process, but are not effective after that. This is dangerous (but necessary?) --- bugs and errors raised by the child are not propagated anywhere. Serialization becomes an immediately became an issue here, the `testing` package used in pytest causes errors when used in the child process. As an idea, I moved the `testing.agents` module into the `academy` package --- we could try to find another way around this (i.e. "mainify" an agent class for testing) or we could lean in fully and move the entire testing package to part of the `academy` package.

Other ideas worth mentioning/discussing:
- For the specific case of Globus Compute (which I anticipate is a common use case for this pattern) futures can outlive the executor naturally. In that case, all we really need to do is delete/ignore the future from the `manager` in order to detach the agent. I went with th a general solution that could be used for all executors but we could tailor this more to globus compute.
- The agent registration is not saved anywhere for restarting the agent, nor is the process id saved creating a mysterious process that is not kept track of which feels wrong --- we could potentially save these to a `local` folder enabling a restart mechanism (combined with the heartbeat PR #379)
- The add `remote.py` script ideally can be reused without the manager to launch agents as daemons/systemd units (#45)

This is part of a larger push toward long-lived agents which should be kept in mind when thinking about the ergonomics of this functionality.


## Related Issues
<!--- List any issue numbers above that this PR addresses --->

See discussion above.

## Changes
<!--- Check which of the following changes were made --->

- [ ] Breaking (backwards incompatible changes to public interfaces)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Enhancement (non-breaking change or feature addition)
- [ ] Refactor (internal code or design clean up)
- [ ] Documentation (no changes to the code)
- [ ] Test (changes or additions to testing)
- [ ] Build (change to CI workflows or build processes)
- [ ] Package (changes to package metadata or dependency versions)

## Testing
<!--- Please describe the test ran to verify changes --->

N/A

## Pull Request Checklist

Please confirm the PR meets the following requirements.
- [x] Relevant tags are added based on the types of changes.
- [x] Code changes pass `pre-commit` (e.g., ruff, mypy, etc.).
- [x] Tests have been added to show the fix is effective or that the new feature works.
- [x] New and existing unit tests pass locally with the changes.
- [ ] Docs have been updated and reviewed if relevant.
