### PR TITLE
Default Timeout for Cloud Exchange Listen and Receive

### DIFF
--- a/academy/exchange/cloud/app.py
+++ b/academy/exchange/cloud/app.py
@@ -330,6 +330,18 @@ async def _listen_mailbox_route(
         raw_mailbox_id,
     )
     timeout = data.get('timeout', request.app[TIMEOUT_KEY])
+    if timeout <= 0 or timeout > request.app[TIMEOUT_KEY]:
+        logger.warning(
+            f'Invalid timeout in listen request: {timeout}.',
+        )
+        return Response(
+            status=StatusCode.BAD_REQUEST.value,
+            text=(
+                'Invalid timeout (must be less than '
+                f'{request.app[TIMEOUT_KEY]} and greater than 0)'
+            ),
+        )
+
     client = get_client_info(request)
     status = await manager.check_mailbox(client, mailbox_id)
 
@@ -388,6 +400,18 @@ async def _recv_message_route(request: Request) -> Response:
         raw_mailbox_id,
     )
     timeout = data.get('timeout', request.app[TIMEOUT_KEY])
+    if timeout <= 0 or timeout > request.app[TIMEOUT_KEY]:
+        logger.warning(
+            f'Invalid timeout in listen request: {timeout}.',
+        )
+        return Response(
+            status=StatusCode.BAD_REQUEST.value,
+            text=(
+                'Invalid timeout (must be less than '
+                f'{request.app[TIMEOUT_KEY]} and greater than 0)'
+            ),
+        )
+
     client = get_client_info(request)
     try:
         message = await manager.get(client, mailbox_id, timeout=timeout)
@@ -486,7 +510,7 @@ def create_app(
 
     app = Application(middlewares=middlewares)
     app[MANAGER_KEY] = backend
-    app[TIMEOUT_KEY] = config.listen_timeout
+    app[TIMEOUT_KEY] = config.listen_timeout_s
 
     app.router.add_post('/mailbox', _create_mailbox_route)
     app.router.add_post('/mailbox/share', _share_mailbox_route)

--- a/academy/exchange/cloud/app.py
+++ b/academy/exchange/cloud/app.py
@@ -60,10 +60,7 @@ from academy.exception import UnauthorizedError
 from academy.exchange.cloud.authenticate import Authenticator
 from academy.exchange.cloud.authenticate import get_authenticator
 from academy.exchange.cloud.backend import MailboxBackend
-from academy.exchange.cloud.backend import PythonBackend
 from academy.exchange.cloud.client_info import ClientInfo
-from academy.exchange.cloud.config import BackendConfig
-from academy.exchange.cloud.config import ExchangeAuthConfig
 from academy.exchange.cloud.config import ExchangeServingConfig
 from academy.exchange.transport import MailboxStatus
 from academy.identifier import EntityId
@@ -87,6 +84,7 @@ class StatusCode(enum.Enum):
 
 
 MANAGER_KEY = AppKey('manager', MailboxBackend)
+TIMEOUT_KEY = AppKey('listen_timeout', int)
 
 
 def get_client_info(request: Request) -> ClientInfo:
@@ -331,7 +329,7 @@ async def _listen_mailbox_route(
     mailbox_id: EntityId = TypeAdapter(EntityId).validate_json(
         raw_mailbox_id,
     )
-    timeout = data.get('timeout', None)
+    timeout = data.get('timeout', request.app[TIMEOUT_KEY])
     client = get_client_info(request)
     status = await manager.check_mailbox(client, mailbox_id)
 
@@ -389,7 +387,7 @@ async def _recv_message_route(request: Request) -> Response:
     mailbox_id: EntityId = TypeAdapter(EntityId).validate_json(
         raw_mailbox_id,
     )
-    timeout = data.get('timeout', None)
+    timeout = data.get('timeout', request.app[TIMEOUT_KEY])
     client = get_client_info(request)
     try:
         message = await manager.get(client, mailbox_id, timeout=timeout)
@@ -476,22 +474,19 @@ def authenticate_factory(
 
 
 def create_app(
-    backend_config: BackendConfig | None = None,
-    auth_config: ExchangeAuthConfig | None = None,
+    config: ExchangeServingConfig | None = None,
 ) -> Application:
     """Create a new server application."""
-    if backend_config is not None:
-        backend = backend_config.get_backend()
-    else:
-        backend = PythonBackend()
+    if config is None:
+        config = ExchangeServingConfig()
 
-    middlewares = []
-    if auth_config is not None:
-        authenticator = get_authenticator(auth_config)
-        middlewares.append(authenticate_factory(authenticator))
+    backend = config.backend.get_backend()
+    authenticator = get_authenticator(config.auth)
+    middlewares = [authenticate_factory(authenticator)]
 
     app = Application(middlewares=middlewares)
     app[MANAGER_KEY] = backend
+    app[TIMEOUT_KEY] = config.listen_timeout
 
     app.router.add_post('/mailbox', _create_mailbox_route)
     app.router.add_post('/mailbox/share', _share_mailbox_route)
@@ -511,7 +506,7 @@ def _run(
     config: ExchangeServingConfig,
 ) -> None:
     config.logger.init_logger()
-    app = create_app(config.backend, config.auth)
+    app = create_app(config)
     logger = logging.getLogger('root')
     logger.info(
         'Exchange listening on %s:%s (ctrl-C to exit)',

--- a/academy/exchange/cloud/client.py
+++ b/academy/exchange/cloud/client.py
@@ -238,6 +238,9 @@ class HttpExchangeTransport(ExchangeTransportMixin, NoPickleMixin):
                     self._info.request_timeout_s,
                 )
             )
+            if internal_timeout <= 0:
+                raise TimeoutError()
+
             response = await self._session.get(
                 self._listen_url,
                 json={

--- a/academy/exchange/cloud/config.py
+++ b/academy/exchange/cloud/config.py
@@ -209,6 +209,7 @@ class ExchangeServingConfig(BaseModel):
     port: int = 8700
     certfile: str | None = None
     keyfile: str | None = None
+    listen_timeout: int = 60
     auth: ExchangeAuthConfig = Field(default_factory=ExchangeAuthConfig)
     backend: BackendConfigT = Field(default_factory=PythonBackendConfig)
     logger: LogConfig = Field(default_factory=LogConfig)

--- a/academy/exchange/cloud/config.py
+++ b/academy/exchange/cloud/config.py
@@ -198,9 +198,10 @@ class ExchangeServingConfig(BaseModel):
         certfile: Certificate file (PEM format) use to enable TLS.
         keyfile: Private key file. If not specified, the key will be
             taken from the certfile.
+        listen_timeout_s: Default timeout on listen and recv requests.
         auth: Authentication configuration.
-        log_file: Location to write logs.
-        log_level: Verbosity of logs.
+        backend: Configured store for mailboxes.
+        logger: Log configuration.
     """
 
     model_config = ConfigDict(extra='forbid')
@@ -209,7 +210,7 @@ class ExchangeServingConfig(BaseModel):
     port: int = 8700
     certfile: str | None = None
     keyfile: str | None = None
-    listen_timeout: int = 60
+    listen_timeout_s: int = 60
     auth: ExchangeAuthConfig = Field(default_factory=ExchangeAuthConfig)
     backend: BackendConfigT = Field(default_factory=PythonBackendConfig)
     logger: LogConfig = Field(default_factory=LogConfig)

--- a/academy/exchange/cloud/globus.py
+++ b/academy/exchange/cloud/globus.py
@@ -117,7 +117,7 @@ class AcademyGlobusClient(globus_sdk.BaseClient):
     def recv(
         self,
         mailbox_id: EntityId,
-        timeout: float | None = None,
+        timeout: float,
     ) -> GlobusHTTPResponse:
         return self.request(
             'GET',
@@ -416,7 +416,7 @@ class GlobusExchangeTransport(ExchangeTransportMixin, NoPickleMixin):
     def factory(self) -> GlobusExchangeFactory:
         return GlobusExchangeFactory(self.project, self.client_params)
 
-    def _recv_sync(self, timeout: float | None) -> GlobusHTTPResponse:
+    def _recv_sync(self, timeout: float) -> GlobusHTTPResponse:
         return self.exchange_client.recv(self.mailbox_id, timeout)
 
     async def _recv(self, timeout: float | None = None) -> Message[Any]:
@@ -441,7 +441,7 @@ class GlobusExchangeTransport(ExchangeTransportMixin, NoPickleMixin):
                     loop.run_in_executor(
                         self.executor,
                         self._recv_sync,
-                        timeout,
+                        internal_timeout,
                     ),
                     timeout,
                 )

--- a/testing/fixture.py
+++ b/testing/fixture.py
@@ -23,7 +23,6 @@ from academy.exchange import LocalExchangeTransport
 from academy.exchange import RedisExchangeFactory
 from academy.exchange import UserExchangeClient
 from academy.exchange.cloud.app import create_app
-from academy.exchange.cloud.config import ExchangeAuthConfig
 from academy.exchange.cloud.globus import AcademyGlobusClient
 from academy.exchange.cloud.globus import GlobusExchangeFactory
 from academy.exchange.cloud.login import ACADEMY_GLOBUS_CLIENT_ID_ENV_NAME
@@ -155,7 +154,7 @@ async def manager(
 @pytest_asyncio.fixture
 async def http_exchange_server() -> AsyncGenerator[tuple[str, int]]:
     host, port = 'localhost', open_port()
-    app = create_app(auth_config=ExchangeAuthConfig())
+    app = create_app()
 
     runner = AppRunner(app)
     await runner.setup()

--- a/tests/unit/exchange/cloud/app_test.py
+++ b/tests/unit/exchange/cloud/app_test.py
@@ -200,7 +200,7 @@ async def test_check_mailbox_validation_error(cli) -> None:
 
 
 @pytest.mark.asyncio
-async def test_send_mailbox_validation_error(cli) -> None:
+async def test_send_mailbox_mailbox_validation_error(cli) -> None:
     response = await cli.put('/message', json={'message': 'foo'})
     assert response.status == StatusCode.BAD_REQUEST.value
     assert 'Missing or invalid field' in (await response.text())
@@ -212,6 +212,22 @@ async def test_recv_mailbox_validation_error(cli) -> None:
     assert response.status == StatusCode.BAD_REQUEST.value
     assert 'Missing or invalid field' in (await response.text())
 
+
+@pytest.mark.asyncio
+async def test_recv_mailbox_timeout_validation_error(cli) -> None:
+    response = await cli.get(
+        '/message',
+        json={
+            'mailbox': UserId.new().model_dump_json(),
+            'timeout': ExchangeServingConfig().listen_timeout_s + 1,
+        },
+    )
+    assert response.status == StatusCode.BAD_REQUEST.value
+    assert 'Invalid timeout' in (await response.text())
+
+
+@pytest.mark.asyncio
+async def test_recv_mailbox_unkown_error(cli) -> None:
     response = await cli.get(
         '/message',
         json={'mailbox': UserId.new().model_dump_json()},
@@ -226,6 +242,22 @@ async def test_listen_mailbox_validation_error(cli) -> None:
     assert response.status == StatusCode.BAD_REQUEST.value
     assert 'Missing or invalid field' in (await response.text())
 
+
+@pytest.mark.asyncio
+async def test_listen_mailbox_timeout_validation_error(cli) -> None:
+    response = await cli.get(
+        '/mailbox/listen',
+        json={
+            'mailbox': UserId.new().model_dump_json(),
+            'timeout': ExchangeServingConfig().listen_timeout_s + 1,
+        },
+    )
+    assert response.status == StatusCode.BAD_REQUEST.value
+    assert 'Invalid timeout' in (await response.text())
+
+
+@pytest.mark.asyncio
+async def test_listen_mailbox_unkown_error(cli) -> None:
     response = await cli.get(
         '/mailbox/listen',
         json={'mailbox': UserId.new().model_dump_json()},

--- a/tests/unit/exchange/cloud/app_test.py
+++ b/tests/unit/exchange/cloud/app_test.py
@@ -24,7 +24,6 @@ from academy.exchange.cloud.app import StatusCode
 from academy.exchange.cloud.client_info import ClientInfo
 from academy.exchange.cloud.config import ExchangeAuthConfig
 from academy.exchange.cloud.config import ExchangeServingConfig
-from academy.exchange.cloud.config import PythonBackendConfig
 from academy.identifier import AgentId
 from academy.identifier import UserId
 from academy.message import Message
@@ -287,10 +286,8 @@ async def test_send_mailbox_message_too_large(cli) -> None:
 
 
 @pytest.mark.asyncio
-async def test_null_auth_client() -> None:
-    auth = ExchangeAuthConfig()
-    backend = PythonBackendConfig()
-    app = create_app(backend, auth)
+async def test_create_app_explicit_config() -> None:
+    app = create_app(ExchangeServingConfig())
     async with TestClient(TestServer(app)) as client:
         response = await client.get('/message', json={'mailbox': 'foo'})
         assert response.status == StatusCode.BAD_REQUEST.value
@@ -343,13 +340,11 @@ async def auth_client(
         else:
             raise ForbiddenError()
 
-    backend = PythonBackendConfig()
-
     with mock.patch(
         'academy.exchange.cloud.authenticate.GlobusAuthenticator.authenticate_user',
     ) as mock_user_auth:
         mock_user_auth.side_effect = authorize
-        app = create_app(backend, auth)
+        app = create_app(ExchangeServingConfig(auth=auth))
         async with TestClient(TestServer(app)) as client:
             yield client
 

--- a/tests/unit/exchange/cloud/globus_test.py
+++ b/tests/unit/exchange/cloud/globus_test.py
@@ -22,6 +22,7 @@ from academy.identifier import UserId
 from academy.message import Message
 from academy.message import PingRequest
 from testing.agents import EmptyAgent
+from testing.constant import TEST_WAIT_TIMEOUT
 
 
 @pytest.fixture(autouse=True)
@@ -47,7 +48,7 @@ def test_globus_client_discover(academy_client: AcademyGlobusClient):
 
 def test_globus_client_recv(academy_client: AcademyGlobusClient):
     load_response(AcademyGlobusClient.recv)
-    response = academy_client.recv(UserId.new())
+    response = academy_client.recv(UserId.new(), TEST_WAIT_TIMEOUT)
     assert response.http_status == StatusCode.OKAY.value
     assert 'message' in response.data
 


### PR DESCRIPTION
## Summary
<!--- Provide a summary of the changes --->
In the cloud exchange, unclosed redis connections are causing out  of resource errors. I think the issue is that people are still using version 0.3.1 of the code, which does not have a timeout on `listen`/`receive` requests. When this goes to the redis backend, the `blpop` call is made with no timeout, so it exists forever. Even when the client disconnects, no exception is raised within the handler, so the Redis connection persists until the app is restarted. This doesn't happen in the latest releases because the code by default has a timeout for `listen` requests. Still we need to deal with older requests (and requests that explicitly set the timeout to None). The tricky part is that these timeouts will raise unexpected exceptions in v0.3.1, so any agent that is expecting to live longer than that `timeout` without receiving requests must upgrade the newer version in order to use our hosted exchange.

## Related Issues
<!--- List any issue numbers above that this PR addresses --->

- Closes #386 

## Changes
<!--- Check which of the following changes were made --->

- [ ] Breaking (backwards incompatible changes to public interfaces)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (non-breaking change or feature addition)
- [ ] Refactor (internal code or design clean up)
- [ ] Documentation (no changes to the code)
- [ ] Test (changes or additions to testing)
- [ ] Build (change to CI workflows or build processes)
- [ ] Package (changes to package metadata or dependency versions)

## Testing
<!--- Please describe the test ran to verify changes --->

N/A

## Pull Request Checklist

Please confirm the PR meets the following requirements.
- [x] Relevant tags are added based on the types of changes.
- [x] Code changes pass `pre-commit` (e.g., ruff, mypy, etc.).
- [x] Tests have been added to show the fix is effective or that the new feature works.
- [x] New and existing unit tests pass locally with the changes.
- [] Docs have been updated and reviewed if relevant.
