### PR TITLE
Refactoring servers errors into wrapper method

### DIFF
--- a/academy/exchange/cloud/app.py
+++ b/academy/exchange/cloud/app.py
@@ -21,11 +21,13 @@ from __future__ import annotations
 
 import argparse
 import enum
+import functools
 import logging
 import ssl
 import sys
 from collections.abc import Awaitable
 from collections.abc import Callable
+from collections.abc import Coroutine
 from collections.abc import Sequence
 from typing import Any
 
@@ -98,49 +100,82 @@ def get_client_info(request: Request) -> ClientInfo:
     return client_info
 
 
+def exception_to_response(request_name: str) -> Callable[..., Any]:
+    """Convert exceptions to responses.
+
+    Args:
+        request_name: Request name for logging.
+    """
+
+    def decorator(
+        func: Callable[[Any], Coroutine[None, None, Response]],
+    ) -> Callable[[Any], Coroutine[None, None, Response]]:
+        @functools.wraps(func)
+        async def wrapper(*args: Any, **kwargs: Any) -> Response:  # noqa: PLR0911
+            try:
+                return await func(*args, **kwargs)
+            except (KeyError, ValidationError) as e:
+                logger.warning(
+                    f'Missing or invalid field in {request_name} request.',
+                )
+                return Response(
+                    status=StatusCode.BAD_REQUEST.value,
+                    text=f'Missing or invalid field: {e}',
+                )
+            except BadEntityIdError:
+                logger.exception(f'Unknown mailbox id in {request_name}')
+                return Response(
+                    status=StatusCode.NOT_FOUND.value,
+                    text='Unknown mailbox ID',
+                )
+            except ForbiddenError:
+                logger.exception(f'Incorrect permissions in {request_name}')
+                return Response(
+                    status=StatusCode.FORBIDDEN.value,
+                    text='Incorrect permissions',
+                )
+            except MailboxTerminatedError:
+                logger.exception(
+                    f'Mailbox in {request_name} request was terminated.',
+                )
+                return Response(
+                    status=StatusCode.TERMINATED.value,
+                    text='Mailbox was closed',
+                )
+            except MessageTooLargeError as e:
+                logger.exception('Message to mailbox too large.')
+                return Response(
+                    status=StatusCode.TOO_LARGE.value,
+                    text=(
+                        f'Message of size {e.size} larger than limit '
+                        f'{e.limit}.'
+                    ),
+                )
+            except ConnectionResetError:  # pragma: no cover
+                # This happens when the client cancels it's task, and
+                # closes its connection. In this case, we don't
+                # need to do anything because the client disconnected
+                # itself. error, If we don't catch this aiohttp will
+                # just log an error message each time this happens.
+                return Response(status=StatusCode.NO_RESPONSE.value)
+
+        return wrapper
+
+    return decorator
+
+
+@exception_to_response('share mailbox')
 async def _share_mailbox_route(request: Request) -> Response:
     """Share mailbox with a Globus Group."""
     data = await request.json()
     manager: MailboxBackend = request.app[MANAGER_KEY]
-    try:
-        raw_mailbox_id = data['mailbox']
-        mailbox_id: EntityId = TypeAdapter(EntityId).validate_json(
-            raw_mailbox_id,
-        )
-        group_id = data['group_id']
-
-    except (KeyError, ValidationError):
-        logger.warning(
-            'Missing or invalid mailbox id in request.',
-            exc_info=True,
-        )
-        return Response(
-            status=StatusCode.BAD_REQUEST.value,
-            text='Missing or invalid mailbox ID',
-        )
-
+    raw_mailbox_id = data['mailbox']
+    mailbox_id: EntityId = TypeAdapter(EntityId).validate_json(
+        raw_mailbox_id,
+    )
+    group_id = data['group_id']
     client = get_client_info(request)
-    try:
-        await manager.share_mailbox(client, mailbox_id, group_id)
-    except BadEntityIdError:
-        logger.exception('Unknown mailbox id to share.')
-        return Response(
-            status=StatusCode.NOT_FOUND.value,
-            text='Unknown mailbox ID',
-        )
-    except ForbiddenError:
-        logger.exception('Incorrect permissions to share mailbox.')
-        return Response(
-            status=StatusCode.FORBIDDEN.value,
-            text='Incorrect permissions',
-        )
-    except MailboxTerminatedError:
-        logger.exception(f'Mailbox {mailbox_id} was terminated.')
-        return Response(
-            status=StatusCode.TERMINATED.value,
-            text='Mailbox was closed',
-        )
-
+    await manager.share_mailbox(client, mailbox_id, group_id)
     logger.info(
         f'Sharing mailbox {mailbox_id} with group {group_id}',
         extra={
@@ -151,96 +186,34 @@ async def _share_mailbox_route(request: Request) -> Response:
     return Response(status=StatusCode.OKAY.value)
 
 
+@exception_to_response('get shares')
 async def _get_mailbox_shares_route(request: Request) -> Response:
     """Share mailbox with a Globus Group."""
     data = await request.json()
     manager: MailboxBackend = request.app[MANAGER_KEY]
-    try:
-        raw_mailbox_id = data['mailbox']
-        mailbox_id: EntityId = TypeAdapter(EntityId).validate_json(
-            raw_mailbox_id,
-        )
-    except (KeyError, ValidationError):
-        logger.warning(
-            'Missing or invalid mailbox id in request.',
-            exc_info=True,
-        )
-        return Response(
-            status=StatusCode.BAD_REQUEST.value,
-            text='Missing or invalid mailbox ID',
-        )
-
+    raw_mailbox_id = data['mailbox']
+    mailbox_id: EntityId = TypeAdapter(EntityId).validate_json(
+        raw_mailbox_id,
+    )
     client = get_client_info(request)
-    try:
-        shares = await manager.get_mailbox_shares(client, mailbox_id)
-    except BadEntityIdError:
-        logger.exception('Unknown mailbox id to share.')
-        return Response(
-            status=StatusCode.NOT_FOUND.value,
-            text='Unknown mailbox ID',
-        )
-    except ForbiddenError:
-        logger.exception('Incorrect permissions to view mailbox groups.')
-        return Response(
-            status=StatusCode.FORBIDDEN.value,
-            text='Incorrect permissions',
-        )
-    except MailboxTerminatedError:
-        logger.exception(f'Mailbox {mailbox_id} was terminated.')
-        return Response(
-            status=StatusCode.TERMINATED.value,
-            text='Mailbox was closed',
-        )
+    shares = await manager.get_mailbox_shares(client, mailbox_id)
     return json_response(
         {'group_ids': shares},
     )
 
 
+@exception_to_response('remove shares')
 async def _remove_mailbox_shares_route(request: Request) -> Response:
     """Stop sharing a mailbox with a Globus Group."""
     data = await request.json()
     manager: MailboxBackend = request.app[MANAGER_KEY]
-    try:
-        raw_mailbox_id = data['mailbox']
-        mailbox_id: EntityId = TypeAdapter(EntityId).validate_json(
-            raw_mailbox_id,
-        )
-        group_id = data['group_id']
-
-    except (KeyError, ValidationError):
-        logger.warning(
-            'Missing or invalid mailbox id in request.',
-            exc_info=True,
-        )
-        return Response(
-            status=StatusCode.BAD_REQUEST.value,
-            text='Missing or invalid mailbox ID',
-        )
-
+    raw_mailbox_id = data['mailbox']
+    mailbox_id: EntityId = TypeAdapter(EntityId).validate_json(
+        raw_mailbox_id,
+    )
+    group_id = data['group_id']
     client = get_client_info(request)
-    try:
-        await manager.remove_mailbox_shares(client, mailbox_id, group_id)
-    except BadEntityIdError:
-        logger.exception(f'Unknown mailbox id {mailbox_id}.')
-        return Response(
-            status=StatusCode.NOT_FOUND.value,
-            text='Unknown mailbox ID',
-        )
-    except ForbiddenError:
-        logger.exception(
-            'Incorrect permissions to change mailbox permissions.',
-        )
-        return Response(
-            status=StatusCode.FORBIDDEN.value,
-            text='Incorrect permissions',
-        )
-    except MailboxTerminatedError:
-        logger.exception(f'Mailbox {mailbox_id} was terminated.')
-        return Response(
-            status=StatusCode.TERMINATED.value,
-            text='Mailbox was closed',
-        )
-
+    await manager.remove_mailbox_shares(client, mailbox_id, group_id)
     logger.info(
         f'Unsharing mailbox {mailbox_id} with group {group_id}',
         extra={
@@ -251,37 +224,19 @@ async def _remove_mailbox_shares_route(request: Request) -> Response:
     return Response(status=StatusCode.OKAY.value)
 
 
+@exception_to_response('create')
 async def _create_mailbox_route(request: Request) -> Response:
     data = await request.json()
     manager: MailboxBackend = request.app[MANAGER_KEY]
-
-    try:
-        raw_mailbox_id = data['mailbox']
-        mailbox_id: EntityId = TypeAdapter(EntityId).validate_json(
-            raw_mailbox_id,
-        )
-        agent_raw = data.get('agent', None)
-        agent = agent_raw.split(',') if agent_raw is not None else None
-    except (KeyError, ValidationError):
-        logger.warning(
-            'Invalid or missing mailbox id in request.',
-            exc_info=True,
-        )
-        return Response(
-            status=StatusCode.BAD_REQUEST.value,
-            text='Missing or invalid mailbox ID',
-        )
+    raw_mailbox_id = data['mailbox']
+    mailbox_id: EntityId = TypeAdapter(EntityId).validate_json(
+        raw_mailbox_id,
+    )
+    agent_raw = data.get('agent', None)
+    agent = agent_raw.split(',') if agent_raw is not None else None
 
     client = get_client_info(request)
-    try:
-        await manager.create_mailbox(client, mailbox_id, agent)
-    except ForbiddenError:
-        logger.exception('Incorrect permissions to create mailbox.')
-        return Response(
-            status=StatusCode.FORBIDDEN.value,
-            text='Incorrect permissions',
-        )
-
+    await manager.create_mailbox(client, mailbox_id, agent)
     logger.info(
         f'Creating mailbox {mailbox_id} of type {agent}',
         extra={
@@ -293,35 +248,16 @@ async def _create_mailbox_route(request: Request) -> Response:
     return Response(status=StatusCode.OKAY.value)
 
 
+@exception_to_response('terminate')
 async def _terminate_route(request: Request) -> Response:
     data = await request.json()
     manager: MailboxBackend = request.app[MANAGER_KEY]
-
-    try:
-        raw_mailbox_id = data['mailbox']
-        mailbox_id: EntityId = TypeAdapter(EntityId).validate_json(
-            raw_mailbox_id,
-        )
-    except (KeyError, ValidationError):
-        logger.warning(
-            'Invalid or missing mailbox id in request.',
-            exc_info=True,
-        )
-        return Response(
-            status=StatusCode.BAD_REQUEST.value,
-            text='Missing or invalid mailbox ID',
-        )
-
+    raw_mailbox_id = data['mailbox']
+    mailbox_id: EntityId = TypeAdapter(EntityId).validate_json(
+        raw_mailbox_id,
+    )
     client = get_client_info(request)
-    try:
-        await manager.terminate(client, mailbox_id)
-    except ForbiddenError:
-        logger.exception('Incorrect permissions to terminate mailbox.')
-        return Response(
-            status=StatusCode.FORBIDDEN.value,
-            text='Incorrect permissions',
-        )
-
+    await manager.terminate(client, mailbox_id)
     logger.info(
         f'Terminating mailbox {mailbox_id}',
         extra={
@@ -331,108 +267,44 @@ async def _terminate_route(request: Request) -> Response:
     return Response(status=StatusCode.OKAY.value)
 
 
+@exception_to_response('discover')
 async def _discover_route(request: Request) -> Response:
     data = await request.json()
     manager: MailboxBackend = request.app[MANAGER_KEY]
-
-    try:
-        agent = data['agent']
-        allow_subclasses = data['allow_subclasses']
-    except (KeyError, ValidationError):
-        logger.warning('Missing fields for discover request.', exc_info=True)
-        return Response(
-            status=StatusCode.BAD_REQUEST.value,
-            text='Missing or invalid arguments',
-        )
-
+    agent = data['agent']
+    allow_subclasses = data['allow_subclasses']
     client = get_client_info(request)
     agent_ids = await manager.discover(
         client,
         agent,
         allow_subclasses,
     )
-
     return json_response(
         {'agent_ids': ','.join(str(aid.uid) for aid in agent_ids)},
     )
 
 
+@exception_to_response('status')
 async def _check_mailbox_route(request: Request) -> Response:
     data = await request.json()
     manager: MailboxBackend = request.app[MANAGER_KEY]
-
-    try:
-        raw_mailbox_id = data['mailbox']
-        mailbox_id: EntityId = TypeAdapter(EntityId).validate_json(
-            raw_mailbox_id,
-        )
-    except (KeyError, ValidationError):
-        logger.warning(
-            'Invalid or missing mailbox id in request.',
-            exc_info=True,
-        )
-        return Response(
-            status=StatusCode.BAD_REQUEST.value,
-            text='Missing or invalid mailbox ID',
-        )
-
+    raw_mailbox_id = data['mailbox']
+    mailbox_id: EntityId = TypeAdapter(EntityId).validate_json(
+        raw_mailbox_id,
+    )
     client = get_client_info(request)
-    try:
-        status = await manager.check_mailbox(client, mailbox_id)
-    except ForbiddenError:
-        logger.exception('Incorrect permissions to view mailbox status.')
-        return Response(
-            status=StatusCode.FORBIDDEN.value,
-            text='Incorrect permissions',
-        )
+    status = await manager.check_mailbox(client, mailbox_id)
     return json_response({'status': status.value})
 
 
+@exception_to_response('send')
 async def _send_message_route(request: Request) -> Response:
     data = await request.json()
     manager: MailboxBackend = request.app[MANAGER_KEY]
-
-    try:
-        raw_message = data.get('message')
-        message: Message[Any] = Message.model_validate_json(raw_message)
-    except (KeyError, ValidationError):
-        logger.warning(
-            'Invalid or missing mailbox id in request.',
-            exc_info=True,
-        )
-        return Response(
-            status=StatusCode.BAD_REQUEST.value,
-            text='Missing or invalid message',
-        )
-
+    raw_message = data.get('message')
+    message: Message[Any] = Message.model_validate_json(raw_message)
     client = get_client_info(request)
-    try:
-        await manager.put(client, message)
-    except BadEntityIdError:
-        logger.exception(f'Destination mailbox {message.dest} does not exist.')
-        return Response(
-            status=StatusCode.NOT_FOUND.value,
-            text='Unknown mailbox ID',
-        )
-    except MailboxTerminatedError:
-        logger.exception(f'Destination mailbox {message.dest} terminated.')
-        return Response(
-            status=StatusCode.TERMINATED.value,
-            text='Mailbox was closed',
-        )
-    except ForbiddenError:
-        logger.exception('Invalid permissions to send message to mailbox.')
-        return Response(
-            status=StatusCode.FORBIDDEN.value,
-            text='Incorrect permissions',
-        )
-    except MessageTooLargeError as e:
-        logger.exception(f'Message to mailbox {message.dest} too large.')
-        return Response(
-            status=StatusCode.TOO_LARGE.value,
-            text=f'Message of size {e.size} larger than limit {e.limit}.',
-        )
-
+    await manager.put(client, message)
     logger.info(
         (
             f'Placing message {message.tag} in mailbox '
@@ -449,49 +321,19 @@ async def _send_message_route(request: Request) -> Response:
     return Response(status=StatusCode.OKAY.value)
 
 
+@exception_to_response('listen')
 async def _listen_mailbox_route(
     request: Request,
 ) -> EventSourceResponse | Response:
-    try:
-        data = await request.json()
-    except ConnectionResetError:  # pragma: no cover
-        # This happens when the client cancel's it's listener task, which is
-        # waiting on recv, because the client is shutting down and closing
-        # its connection. In this case, we don't need to do anything
-        # because the client disconnected itself. If we don't catch this
-        # error, aiohttp will just log an error message each time this happens.
-        return Response(status=StatusCode.NO_RESPONSE.value)
-
+    data = await request.json()
     manager: MailboxBackend = request.app[MANAGER_KEY]
-
-    try:
-        raw_mailbox_id = data['mailbox']
-        mailbox_id: EntityId = TypeAdapter(EntityId).validate_json(
-            raw_mailbox_id,
-        )
-    except (KeyError, ValidationError):
-        logger.warning(
-            'Invalid or missing mailbox id in request.',
-            exc_info=True,
-        )
-        return Response(
-            status=StatusCode.BAD_REQUEST.value,
-            text='Missing or invalid mailbox ID',
-        )
-
+    raw_mailbox_id = data['mailbox']
+    mailbox_id: EntityId = TypeAdapter(EntityId).validate_json(
+        raw_mailbox_id,
+    )
     timeout = data.get('timeout', None)
     client = get_client_info(request)
-
-    try:
-        status = await manager.check_mailbox(client, mailbox_id)
-    except ForbiddenError:
-        logger.exception(
-            f'Incorrect permissions to receive from mailbox {mailbox_id}',
-        )
-        return Response(
-            status=StatusCode.FORBIDDEN.value,
-            text='Incorrect permissions',
-        )
+    status = await manager.check_mailbox(client, mailbox_id)
 
     if status == MailboxStatus.MISSING:
         logger.exception(f'Listening on unknown mailbox {mailbox_id}.')
@@ -539,58 +381,26 @@ async def _listen_mailbox_route(
     return response
 
 
-async def _recv_message_route(request: Request) -> Response:  # noqa: PLR0911
-    try:
-        data = await request.json()
-    except ConnectionResetError:  # pragma: no cover
-        # This happens when the client cancel's it's listener task, which is
-        # waiting on recv, because the client is shutting down and closing
-        # its connection. In this case, we don't need to do anything
-        # because the client disconnected itself. If we don't catch this
-        # error, aiohttp will just log an error message each time this happens.
-        return Response(status=StatusCode.NO_RESPONSE.value)
-
+@exception_to_response('recv')
+async def _recv_message_route(request: Request) -> Response:
+    data = await request.json()
     manager: MailboxBackend = request.app[MANAGER_KEY]
-
-    try:
-        raw_mailbox_id = data['mailbox']
-        mailbox_id: EntityId = TypeAdapter(EntityId).validate_json(
-            raw_mailbox_id,
-        )
-    except (KeyError, ValidationError):
-        logger.warning(
-            'Invalid or missing mailbox id in request.',
-            exc_info=True,
-        )
-        return Response(
-            status=StatusCode.BAD_REQUEST.value,
-            text='Missing or invalid mailbox ID',
-        )
-
+    raw_mailbox_id = data['mailbox']
+    mailbox_id: EntityId = TypeAdapter(EntityId).validate_json(
+        raw_mailbox_id,
+    )
     timeout = data.get('timeout', None)
-
+    client = get_client_info(request)
     try:
-        client = get_client_info(request)
         message = await manager.get(client, mailbox_id, timeout=timeout)
-    except BadEntityIdError:
-        logger.exception(f'Receive from unknown mailbox {mailbox_id}.')
-        return Response(
-            status=StatusCode.NOT_FOUND.value,
-            text='Unknown mailbox ID',
-        )
     except MailboxTerminatedError:
-        logger.error(f'Receive from terminated mailbox {mailbox_id}.')
+        # We catch this exception separate from above and log it at a lower
+        # level because this happens on an expected (if old) code path and
+        # we do not want to flood the logs with error messages.
+        logger.info(f'Receive from terminated mailbox {mailbox_id}.')
         return Response(
             status=StatusCode.TERMINATED.value,
             text='Mailbox was closed',
-        )
-    except ForbiddenError:
-        logger.exception(
-            f'Incorrect permissions to receive from mailbox {mailbox_id}',
-        )
-        return Response(
-            status=StatusCode.FORBIDDEN.value,
-            text='Incorrect permissions',
         )
     except TimeoutError:
         # Timeouts are part of expected behavior so log warning, not error

--- a/academy/exchange/cloud/app.py
+++ b/academy/exchange/cloud/app.py
@@ -155,7 +155,7 @@ def exception_to_response(request_name: str) -> Callable[..., Any]:
                 # This happens when the client cancels it's task, and
                 # closes its connection. In this case, we don't
                 # need to do anything because the client disconnected
-                # itself. error, If we don't catch this aiohttp will
+                # itself. If we don't catch this aiohttp will
                 # just log an error message each time this happens.
                 return Response(status=StatusCode.NO_RESPONSE.value)
 

--- a/tests/unit/exchange/cloud/app_test.py
+++ b/tests/unit/exchange/cloud/app_test.py
@@ -117,7 +117,7 @@ async def cli() -> AsyncGenerator[TestClient[Request, Application]]:
 async def test_create_mailbox_validation_error(cli) -> None:
     response = await cli.post('/mailbox', json={'mailbox': 'foo'})
     assert response.status == StatusCode.BAD_REQUEST.value
-    assert await response.text() == 'Missing or invalid mailbox ID'
+    assert 'Missing or invalid field' in (await response.text())
 
 
 @pytest.mark.asyncio
@@ -156,7 +156,7 @@ async def test_share_bad_mailbox(cli) -> None:
         },
     )
     assert response.status == StatusCode.BAD_REQUEST.value
-    assert await response.text() == 'Missing or invalid mailbox ID'
+    assert 'Missing or invalid field' in (await response.text())
 
 
 @pytest.mark.asyncio
@@ -166,7 +166,7 @@ async def test_get_shares_bad_mailbox(cli) -> None:
         json={'mailbox': 'foo'},
     )
     assert response.status == StatusCode.BAD_REQUEST.value
-    assert await response.text() == 'Missing or invalid mailbox ID'
+    assert 'Missing or invalid field' in (await response.text())
 
 
 @pytest.mark.asyncio
@@ -176,42 +176,42 @@ async def test_remove_shares_bad_mailbox(cli) -> None:
         json={'mailbox': 'foo'},
     )
     assert response.status == StatusCode.BAD_REQUEST.value
-    assert await response.text() == 'Missing or invalid mailbox ID'
+    assert 'Missing or invalid field' in (await response.text())
 
 
 @pytest.mark.asyncio
 async def test_terminate_validation_error(cli) -> None:
     response = await cli.delete('/mailbox', json={'mailbox': 'foo'})
     assert response.status == StatusCode.BAD_REQUEST.value
-    assert await response.text() == 'Missing or invalid mailbox ID'
+    assert 'Missing or invalid field' in (await response.text())
 
 
 @pytest.mark.asyncio
 async def test_discover_validation_error(cli) -> None:
     response = await cli.get('/discover', json={})
     assert response.status == StatusCode.BAD_REQUEST.value
-    assert await response.text() == 'Missing or invalid arguments'
+    assert 'Missing or invalid field' in (await response.text())
 
 
 @pytest.mark.asyncio
 async def test_check_mailbox_validation_error(cli) -> None:
     response = await cli.get('/mailbox', json={'mailbox': 'foo'})
     assert response.status == StatusCode.BAD_REQUEST.value
-    assert await response.text() == 'Missing or invalid mailbox ID'
+    assert 'Missing or invalid field' in (await response.text())
 
 
 @pytest.mark.asyncio
 async def test_send_mailbox_validation_error(cli) -> None:
     response = await cli.put('/message', json={'message': 'foo'})
     assert response.status == StatusCode.BAD_REQUEST.value
-    assert await response.text() == 'Missing or invalid message'
+    assert 'Missing or invalid field' in (await response.text())
 
 
 @pytest.mark.asyncio
 async def test_recv_mailbox_validation_error(cli) -> None:
     response = await cli.get('/message', json={'mailbox': 'foo'})
     assert response.status == StatusCode.BAD_REQUEST.value
-    assert await response.text() == 'Missing or invalid mailbox ID'
+    assert 'Missing or invalid field' in (await response.text())
 
     response = await cli.get(
         '/message',
@@ -225,7 +225,7 @@ async def test_recv_mailbox_validation_error(cli) -> None:
 async def test_listen_mailbox_validation_error(cli) -> None:
     response = await cli.get('/mailbox/listen', json={'mailbox': 'foo'})
     assert response.status == StatusCode.BAD_REQUEST.value
-    assert await response.text() == 'Missing or invalid mailbox ID'
+    assert 'Missing or invalid field' in (await response.text())
 
     response = await cli.get(
         '/mailbox/listen',
@@ -294,7 +294,7 @@ async def test_null_auth_client() -> None:
     async with TestClient(TestServer(app)) as client:
         response = await client.get('/message', json={'mailbox': 'foo'})
         assert response.status == StatusCode.BAD_REQUEST.value
-        assert await response.text() == 'Missing or invalid mailbox ID'
+        assert 'Missing or invalid field' in (await response.text())
 
         response = await client.get(
             '/message',


### PR DESCRIPTION
## Summary
<!--- Provide a summary of the changes --->
The code in each of the handler methods is a little repetitive catching the errors in each of the backend methods and translating them to responses. The only different between the instantiation of these `try...except...` handlers is the logging that accompanies them. We can refactor this out into a wrapper without loosing any important information.

## Related Issues
<!--- List any issue numbers above that this PR addresses --->
- Related to #390 (Ruff raised issues in that PR with the code in app.py becoming too complex. This should address that problem)

## Changes
<!--- Check which of the following changes were made --->

- [ ] Breaking (backwards incompatible changes to public interfaces)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (non-breaking change or feature addition)
- [x] Refactor (internal code or design clean up)
- [ ] Documentation (no changes to the code)
- [ ] Test (changes or additions to testing)
- [ ] Build (change to CI workflows or build processes)
- [ ] Package (changes to package metadata or dependency versions)

## Testing
<!--- Please describe the test ran to verify changes --->

N/A

## Pull Request Checklist

Please confirm the PR meets the following requirements.
- [x] Relevant tags are added based on the types of changes.
- [x] Code changes pass `pre-commit` (e.g., ruff, mypy, etc.).
- [x] Tests have been added to show the fix is effective or that the new feature works.
- [x] New and existing unit tests pass locally with the changes.
- [x] Docs have been updated and reviewed if relevant.
