### PR TITLE
Add `Manager.launch_batch()` for batched agent

### DIFF
--- a/academy/exchange/client.py
+++ b/academy/exchange/client.py
@@ -184,17 +184,36 @@ class ExchangeClient(abc.ABC, Generic[ExchangeTransportT]):
         batch_fn = getattr(self._transport, 'register_agents', None)
         if batch_fn is not None:
             registrations = await batch_fn(agents)
-        else:
-            registrations = [
-                await self.register_agent(agent, name=name)
-                for agent, name in agents
-            ]
-        for reg in registrations:
-            logger.info(
-                'Registered %s in exchange',
-                reg.agent_id,
-                extra={'academy.agent_id': reg.agent_id},
+            for reg in registrations:
+                logger.info(
+                    'Registered %s in exchange',
+                    reg.agent_id,
+                    extra={'academy.agent_id': reg.agent_id},
+                )
+            return registrations
+
+        # Sequential fallback
+        registrations = []
+        try:
+            for agent, name in agents:
+                registrations.append(
+                    await self.register_agent(agent, name=name),
+                )
+        except Exception:
+            results = await asyncio.gather(
+                *(self.terminate(reg.agent_id) for reg in registrations),
+                return_exceptions=True,
             )
+            for reg, result in zip(registrations, results, strict=True):
+                if isinstance(result, Exception):
+                    logger.error(
+                        'Failed to terminate partial registration %s '
+                        'during register_agents rollback.',
+                        reg.agent_id,
+                        exc_info=result,
+                        extra={'academy.agent_id': reg.agent_id},
+                    )
+            raise
         return registrations
 
     async def send(self, message: Message[Any]) -> None:

--- a/academy/exchange/client.py
+++ b/academy/exchange/client.py
@@ -173,8 +173,10 @@ class ExchangeClient(abc.ABC, Generic[ExchangeTransportT]):
     ) -> list[AgentRegistration[AgentT]]:
         """Register multiple agents, batching auth if supported.
 
-        Falls back to sequential :meth:`register_agent` calls when
-        the transport does not implement batch registration.
+        Falls back to sequential
+        [`register_agent`][academy.exchange.client.ExchangeClient.register_agent]
+        calls when the transport does not implement batch
+        registration.
 
         Args:
             agents: List of (agent_type, name) pairs to register.

--- a/academy/exchange/client.py
+++ b/academy/exchange/client.py
@@ -203,19 +203,9 @@ class ExchangeClient(abc.ABC, Generic[ExchangeTransportT]):
                     await self.register_agent(agent, name=name),
                 )
         except Exception:
-            results = await asyncio.gather(
+            await asyncio.gather(
                 *(self.terminate(reg.agent_id) for reg in registrations),
-                return_exceptions=True,
             )
-            for reg, result in zip(registrations, results, strict=True):
-                if isinstance(result, Exception):
-                    logger.error(
-                        'Failed to terminate partial registration %s '
-                        'during register_agents rollback.',
-                        reg.agent_id,
-                        exc_info=result,
-                        extra={'academy.agent_id': reg.agent_id},
-                    )
             raise
         return registrations
 

--- a/academy/exchange/cloud/globus.py
+++ b/academy/exchange/cloud/globus.py
@@ -504,8 +504,8 @@ class GlobusExchangeTransport(ExchangeTransportMixin, NoPickleMixin):
         entities but does **not** accumulate scope requirements or
         trigger user consent. The caller is responsible for adding
         the returned scope via
-        :meth:`GlobusApp.add_scope_requirements` and triggering
-        login before calling :meth:`_finalize_registration`.
+        ``GlobusApp.add_scope_requirements`` and triggering login
+        before calling ``_finalize_registration``.
         """
         # Create new resource server (auth entity)
         logger.info('Creating new auth client')

--- a/academy/handle.py
+++ b/academy/handle.py
@@ -95,6 +95,8 @@ class Handle(Generic[AgentT_co]):
         self._exchange = exchange
         self._registered_exchanges: WeakSet[ExchangeClient[Any]] = WeakSet()
         self.ignore_context = ignore_context
+        # Set by action/ping/shutdown; consulted by Manager._rebind_handle.
+        self._used_for_messaging = False
 
         if ignore_context and not exchange:
             raise ValueError(
@@ -208,6 +210,7 @@ class Handle(Generic[AgentT_co]):
                 (it self terminated or via another handle).
             Exception: Any exception raised by the action.
         """
+        self._used_for_messaging = True
         tag_id = uuid.uuid4()
         invocation_extra = {
             'academy.action': action,
@@ -331,6 +334,7 @@ class Handle(Generic[AgentT_co]):
                 (it self terminated or via another handle).
             TimeoutError: If the timeout is exceeded.
         """
+        self._used_for_messaging = True
         exchange = self.exchange
         self._register_with_exchange(exchange)
 
@@ -405,6 +409,7 @@ class Handle(Generic[AgentT_co]):
                 typically indicates the agent shutdown for another reason
                 (it self terminated or via another handle).
         """
+        self._used_for_messaging = True
         exchange = self.exchange
         self._register_with_exchange(exchange)
 

--- a/academy/handle.py
+++ b/academy/handle.py
@@ -74,7 +74,8 @@ class Handle(Generic[AgentT_co]):
         an exchange client.
 
     Args:
-        agent_id: ID of the remote agent.
+        agent_id: ID of the remote agent, or ``None`` to defer
+            binding (used by ``batch.queue()``).
         exchange: A default exchange client to be used if an exchange client
             is not configured in the current context.
         ignore_context: Ignore the current context and force use of `exchange`
@@ -86,17 +87,15 @@ class Handle(Generic[AgentT_co]):
 
     def __init__(
         self,
-        agent_id: AgentId[AgentT_co],
+        agent_id: AgentId[AgentT_co] | None = None,
         *,
         exchange: ExchangeClient[Any] | None = None,
         ignore_context: bool = False,
     ) -> None:
-        self.agent_id = agent_id
+        self._agent_id: AgentId[AgentT_co] | None = agent_id
         self._exchange = exchange
         self._registered_exchanges: WeakSet[ExchangeClient[Any]] = WeakSet()
         self.ignore_context = ignore_context
-        # Set by action/ping/shutdown; consulted by Manager._rebind_handle.
-        self._used_for_messaging = False
 
         if ignore_context and not exchange:
             raise ValueError(
@@ -114,6 +113,25 @@ class Handle(Generic[AgentT_co]):
 
         if self._exchange is not None:
             self._register_with_exchange(self._exchange)
+
+    @property
+    def agent_id(self) -> AgentId[AgentT_co]:
+        """ID of the remote agent.
+
+        Raises:
+            RuntimeError: If the handle is not bound.
+        """
+        if self._agent_id is None:
+            raise RuntimeError(
+                'Handle is not bound to a registered agent. '
+                'Submit the enclosing batch before reading '
+                'agent_id.',
+            )
+        return self._agent_id
+
+    @agent_id.setter
+    def agent_id(self, value: AgentId[AgentT_co]) -> None:
+        self._agent_id = value
 
     @property
     def exchange(self) -> ExchangeClient[Any]:
@@ -148,18 +166,20 @@ class Handle(Generic[AgentT_co]):
             raise PicklingError(
                 'Handle with ignore_context=True is not pickle-able',
             )
-        return (Handle, (self.agent_id,))
+        if self._agent_id is None:
+            raise PicklingError('Cannot pickle an unbound handle.')
+        return (Handle, (self._agent_id,))
 
     def __repr__(self) -> str:
         return (
-            f'{type(self).__name__}(agent_id={self.agent_id!r}, '
+            f'{type(self).__name__}(agent_id={self._agent_id!r}, '
             f'exchange={self._exchange!r}, '
             f'ignore_context={self.ignore_context!r})'
         )
 
     def __str__(self) -> str:
         name = type(self).__name__
-        return f'{name}<agent: {self.agent_id}>'
+        return f'{name}<agent: {self._agent_id}>'
 
     def __getattr__(self, name: str) -> Any:
         async def remote_method_call(*args: Any, **kwargs: Any) -> R:
@@ -210,7 +230,6 @@ class Handle(Generic[AgentT_co]):
                 (it self terminated or via another handle).
             Exception: Any exception raised by the action.
         """
-        self._used_for_messaging = True
         tag_id = uuid.uuid4()
         invocation_extra = {
             'academy.action': action,
@@ -334,7 +353,6 @@ class Handle(Generic[AgentT_co]):
                 (it self terminated or via another handle).
             TimeoutError: If the timeout is exceeded.
         """
-        self._used_for_messaging = True
         exchange = self.exchange
         self._register_with_exchange(exchange)
 
@@ -409,7 +427,6 @@ class Handle(Generic[AgentT_co]):
                 typically indicates the agent shutdown for another reason
                 (it self terminated or via another handle).
         """
-        self._used_for_messaging = True
         exchange = self.exchange
         self._register_with_exchange(exchange)
 

--- a/academy/handle.py
+++ b/academy/handle.py
@@ -131,6 +131,7 @@ class Handle(Generic[AgentT_co]):
 
     @agent_id.setter
     def agent_id(self, value: AgentId[AgentT_co]) -> None:
+        assert self._agent_id is None, 'Handle is already bound.'
         self._agent_id = value
 
     @property
@@ -463,7 +464,7 @@ class ProxyHandle(Handle[AgentT]):
 
     def __init__(self, agent: AgentT) -> None:
         self.agent = agent
-        self.agent_id: AgentId[AgentT] = AgentId.new()
+        self._agent_id: AgentId[AgentT] = AgentId.new()
         self._agent_closed = False
 
     def __repr__(self) -> str:

--- a/academy/manager.py
+++ b/academy/manager.py
@@ -275,8 +275,7 @@ class _BatchLauncher:
             orphan_registrations = registrations[launch_index:]
             handles = self._manager._handles
             for intent in orphan_intents:
-                if handles.get(intent.handle.agent_id) is intent.handle:
-                    del handles[intent.handle.agent_id]
+                handles.pop(intent.handle.agent_id, None)
             await self._terminate_orphans(orphan_registrations)
             raise
 
@@ -288,9 +287,6 @@ class _BatchLauncher:
 
         The original launch exception must not be masked.
         """
-        if not orphans:
-            return
-
         exchange = self._manager.exchange_client
         results = await asyncio.gather(
             *(exchange.terminate(reg.agent_id) for reg in orphans),
@@ -785,7 +781,7 @@ class Manager(Generic[ExchangeTransportT], NoPickleMixin):
                 f'Cannot rebind handle to {new_agent_id}: cache '
                 f'already holds a different handle for that ID.',
             )
-        if self._handles.get(old_agent_id) is handle:
+        if self._handles.get(old_agent_id) is handle:  # pragma: no branch
             del self._handles[old_agent_id]
         handle.agent_id = new_agent_id
         self._handles[new_agent_id] = handle

--- a/academy/manager.py
+++ b/academy/manager.py
@@ -758,29 +758,20 @@ class Manager(Generic[ExchangeTransportT], NoPickleMixin):
         be the real ID and this method (plus the
         ``_used_for_messaging`` guard on :class:`Handle`) could go
         away. Deferred because it changes the transport protocol.
-
-        Raises:
-            RuntimeError: If ``handle`` has already been used for
-                messaging, or if ``new_agent_id`` is already a cache
-                key for a different handle. Uses ``RuntimeError``
-                rather than ``assert`` so the check survives
-                ``python -O``.
         """
         old_agent_id = handle.agent_id
         if old_agent_id == new_agent_id:
             return
-        if getattr(handle, '_used_for_messaging', False):
-            raise RuntimeError(
-                f'Cannot rebind handle {old_agent_id}: already used '
-                'for messaging. Pass the Handle itself (not '
-                'handle.agent_id) as a sibling launch_batch argument.',
-            )
+        assert not handle._used_for_messaging, (
+            f'Cannot rebind handle {old_agent_id}: already used for '
+            'messaging. Pass the Handle itself (not handle.agent_id) '
+            'as a sibling launch_batch argument.'
+        )
         existing = self._handles.get(new_agent_id)
-        if existing is not None and existing is not handle:
-            raise RuntimeError(
-                f'Cannot rebind handle to {new_agent_id}: cache '
-                f'already holds a different handle for that ID.',
-            )
+        assert existing is None or existing is handle, (
+            f'Cannot rebind handle to {new_agent_id}: cache already '
+            'holds a different handle for that ID.'
+        )
         if self._handles.get(old_agent_id) is handle:  # pragma: no branch
             del self._handles[old_agent_id]
         handle.agent_id = new_agent_id

--- a/academy/manager.py
+++ b/academy/manager.py
@@ -100,6 +100,205 @@ class _ACB(Generic[AgentT]):
     task: asyncio.Task[None]
 
 
+@dataclasses.dataclass
+class _LaunchIntent(Generic[AgentT]):
+    # Fields mirror Manager.launch's parameters; a dict[str, Any]
+    # would drop static typing.
+    agent: AgentT | type[AgentT]
+    handle: Handle[AgentT]
+    name: str | None = None
+    args: tuple[Any, ...] | None = None
+    kwargs: dict[str, Any] | None = None
+    config: RuntimeConfig | None = None
+    executor: str | None = None
+    submit_kwargs: dict[str, Any] | None = None
+    log_config: LogConfig | None = None
+
+
+class _BatchLauncher:
+    """Context manager that batches multiple agent launches.
+
+    Returned by :meth:`Manager.launch_batch`. On context exit
+    without error, queued agents are registered together (one
+    auth consent prompt on transports that batch auth) and launched.
+
+    Args:
+        manager: Manager that owns this batch.
+    """
+
+    def __init__(self, manager: Manager[Any]) -> None:
+        self._manager = manager
+        self._intents: list[_LaunchIntent[Any]] = []
+        self._closed = False
+
+    async def __aenter__(self) -> Self:
+        return self
+
+    async def __aexit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_value: BaseException | None,
+        exc_traceback: TracebackType | None,
+    ) -> None:
+        self._closed = True
+        if exc_value is not None:
+            # Intents are retained for caller inspection on this path.
+            self._evict_placeholder_handles()
+            return
+        if not self._intents:
+            return
+        try:
+            await self._commit()
+        finally:
+            # Drop per-intent references; the batch object may outlive
+            # ``async with`` and the manager's caches own the state now.
+            self._intents.clear()
+
+    def _evict_placeholder_handles(self) -> None:
+        """Remove queued intents' handles from the manager cache."""
+        handles = self._manager._handles
+        for intent in self._intents:
+            if handles.get(intent.handle.agent_id) is intent.handle:
+                del handles[intent.handle.agent_id]
+
+    async def launch(  # noqa: PLR0913
+        self,
+        agent: AgentT | type[AgentT],
+        *,
+        args: tuple[Any, ...] | None = None,
+        kwargs: dict[str, Any] | None = None,
+        config: RuntimeConfig | None = None,
+        executor: str | None = None,
+        submit_kwargs: dict[str, Any] | None = None,
+        name: str | None = None,
+        log_config: LogConfig | None = None,
+    ) -> Handle[AgentT]:
+        """Queue an agent launch. Committed on context exit.
+
+        Parameters mirror :meth:`Manager.launch` exactly except for
+        ``registration`` (the batch manages registration itself).
+
+        Returns:
+            Handle to the agent. Usable as a sibling ``batch.launch``
+            argument; not messageable until the batch commits.
+
+        Warning:
+            Pass the :class:`Handle` itself to sibling launches,
+            not ``handle.agent_id``. The handle is rebound in place
+            at commit time; an ``agent_id`` captured into ``args``
+            before commit is a stale placeholder UUID.
+
+        Raises:
+            RuntimeError: If the batch has already exited.
+        """
+        if self._closed:
+            raise RuntimeError('batch is closed')
+
+        # Pre-mint so the returned handle can be a sibling-launch arg.
+        aid: AgentId[AgentT] = AgentId.new(name=name)
+        handle = self._manager.get_handle(aid)
+
+        self._intents.append(
+            _LaunchIntent(
+                agent=agent,
+                handle=handle,
+                name=name,
+                args=args,
+                kwargs=kwargs,
+                config=config,
+                executor=executor,
+                submit_kwargs=submit_kwargs,
+                log_config=log_config,
+            ),
+        )
+        return handle
+
+    async def _commit(self) -> None:
+        """Register queued intents together, then launch each.
+
+        On transports that implement
+        :meth:`ExchangeTransport.register_agents` (e.g. Globus), this
+        produces one auth consent prompt for the whole batch; other
+        transports fall back to sequential registration. Each
+        pre-minted handle is then rebound to the transport-minted ID
+        before launch.
+        """
+        specs: list[tuple[type[Any], str | None]] = [
+            (
+                intent.agent
+                if isinstance(intent.agent, type)
+                else type(intent.agent),
+                intent.name,
+            )
+            for intent in self._intents
+        ]
+        registrations = await self._manager.register_agents(specs)
+
+        launch_index = 0
+        try:
+            for intent, registration in zip(
+                self._intents,
+                registrations,
+                strict=True,
+            ):
+                self._manager._rebind_handle(
+                    intent.handle,
+                    registration.agent_id,
+                )
+                await self._manager.launch(
+                    intent.agent,
+                    args=intent.args,
+                    kwargs=intent.kwargs,
+                    config=intent.config,
+                    executor=intent.executor,
+                    submit_kwargs=intent.submit_kwargs,
+                    name=intent.name,
+                    registration=registration,
+                    log_config=intent.log_config,
+                )
+                launch_index += 1
+        except Exception:
+            # CancelledError deliberately excluded: registrations past
+            # ``launch_index`` will leak exchange-side, but awaiting
+            # cleanup inside a cancellation frame risks a hung shutdown.
+            orphan_intents = self._intents[launch_index:]
+            orphan_registrations = registrations[launch_index:]
+            handles = self._manager._handles
+            for intent in orphan_intents:
+                if handles.get(intent.handle.agent_id) is intent.handle:
+                    del handles[intent.handle.agent_id]
+            await self._terminate_orphans(orphan_registrations)
+            raise
+
+    async def _terminate_orphans(
+        self,
+        orphans: list[AgentRegistration[Any]],
+    ) -> None:
+        """Best-effort parallel termination; failures logged, never raised.
+
+        The original launch exception must not be masked.
+        """
+        if not orphans:
+            return
+
+        exchange = self._manager.exchange_client
+        results = await asyncio.gather(
+            *(exchange.terminate(reg.agent_id) for reg in orphans),
+            return_exceptions=True,
+        )
+        for registration, result in zip(orphans, results, strict=True):
+            if isinstance(result, Exception):
+                logger.error(
+                    'Failed to terminate orphan registration %s during '
+                    'launch_batch commit rollback.',
+                    registration.agent_id,
+                    exc_info=result,
+                    extra={
+                        'academy.agent_id': registration.agent_id,
+                    },
+                )
+
+
 class Manager(Generic[ExchangeTransportT], NoPickleMixin):
     """Launch and manage running agents.
 
@@ -436,6 +635,10 @@ class Manager(Generic[ExchangeTransportT], NoPickleMixin):
     ) -> Handle[AgentT]:
         """Launch a new agent with a specified agent.
 
+        Note:
+            Parameters are mirrored in :class:`_LaunchIntent` and
+            :meth:`_BatchLauncher.launch`; keep all three in sync.
+
         Args:
             agent: Agent instance the agent will implement or the
                 agent type that will be initialized on the worker using
@@ -529,6 +732,84 @@ class Manager(Generic[ExchangeTransportT], NoPickleMixin):
         handle = Handle(agent_id)
         self._handles[agent_id] = handle
         return handle
+
+    def _rebind_handle(
+        self,
+        handle: Handle[AgentT],
+        new_agent_id: AgentId[AgentT],
+    ) -> None:
+        """Rebind a cached handle to a new agent ID.
+
+        Reconciles pre-minted placeholder IDs with the
+        transport-minted IDs returned from :meth:`register_agents`.
+        The handle must not yet have been used for messaging —
+        mutating ``agent_id`` after it has been captured in log
+        extras, pickled snapshots, or user code is unsafe.
+
+        TODO: Rebinding is only needed because transports mint their
+        own IDs during registration. If ``register_agents`` accepted
+        pre-minted IDs from the caller, the placeholder would already
+        be the real ID and this method (plus the
+        ``_used_for_messaging`` guard on :class:`Handle`) could go
+        away. Deferred because it changes the transport protocol.
+
+        Raises:
+            RuntimeError: If ``handle`` has already been used for
+                messaging, or if ``new_agent_id`` is already a cache
+                key for a different handle. Uses ``RuntimeError``
+                rather than ``assert`` so the check survives
+                ``python -O``.
+        """
+        old_agent_id = handle.agent_id
+        if old_agent_id == new_agent_id:
+            return
+        if getattr(handle, '_used_for_messaging', False):
+            raise RuntimeError(
+                f'Cannot rebind handle {old_agent_id}: already used '
+                'for messaging. Pass the Handle itself (not '
+                'handle.agent_id) as a sibling launch_batch argument.',
+            )
+        existing = self._handles.get(new_agent_id)
+        if existing is not None and existing is not handle:
+            raise RuntimeError(
+                f'Cannot rebind handle to {new_agent_id}: cache '
+                f'already holds a different handle for that ID.',
+            )
+        if self._handles.get(old_agent_id) is handle:
+            del self._handles[old_agent_id]
+        handle.agent_id = new_agent_id
+        self._handles[new_agent_id] = handle
+
+    def launch_batch(self) -> _BatchLauncher:
+        """Open a batch context that joins multiple agent launches.
+
+        On transports that batch auth (notably
+        :class:`~academy.exchange.cloud.globus.GlobusExchangeFactory`),
+        every agent queued inside the ``async with`` block is
+        registered under a single auth consent prompt. Other
+        transports fall back to sequential registration.
+
+        Handles returned by ``batch.launch`` can be passed as
+        arguments to sibling ``batch.launch`` calls; they are not
+        messageable until the batch commits on exit.
+
+        Example:
+            .. code-block:: python
+
+                async with manager.launch_batch() as batch:
+                    greeter = await batch.launch(Greeter)
+                    shouter = await batch.launch(Shouter)
+                    coordinator = await batch.launch(
+                        Coordinator,
+                        args=(greeter, shouter),
+                    )
+
+        A convenience wrapper around :meth:`register_agents` and
+        :meth:`launch(registration=...) <launch>`; you can use the 
+        pair instead when registration and launch need to be 
+        separated in time.
+        """
+        return _BatchLauncher(self)
 
     async def register_agent(
         self,

--- a/academy/manager.py
+++ b/academy/manager.py
@@ -116,13 +116,10 @@ class _LaunchIntent(Generic[AgentT]):
 
 
 class _BatchLauncher:
-    """Context manager that batches multiple agent launches.
+    """Batches multiple agent launches into a single registration.
 
     Returned by
     [`Manager.launch_batch`][academy.manager.Manager.launch_batch].
-    On context exit without error, queued agents are registered
-    together (one auth consent prompt on transports that batch auth)
-    and launched.
 
     Args:
         manager: Manager that owns this batch.
@@ -142,21 +139,12 @@ class _BatchLauncher:
         exc_value: BaseException | None,
         exc_traceback: TracebackType | None,
     ) -> None:
-        self._closed = True
+        if self._closed:
+            return
         if exc_value is not None:
-            # Intents are retained for caller inspection on this path.
-            self._evict_placeholder_handles()
+            self.abort()
             return
-        if not self._intents:
-            return
-        try:
-            try:
-                await self._commit()
-            except BaseException:
-                self._evict_placeholder_handles()
-                raise
-        finally:
-            self._intents.clear()
+        await self.submit()
 
     def _evict_placeholder_handles(self) -> None:
         """Remove queued intents' placeholder handles from the cache.
@@ -171,7 +159,7 @@ class _BatchLauncher:
             if handles.get(pid) is intent.handle:
                 del handles[pid]
 
-    async def launch(  # noqa: PLR0913
+    async def queue(  # noqa: PLR0913
         self,
         agent: AgentT | type[AgentT],
         *,
@@ -183,7 +171,7 @@ class _BatchLauncher:
         name: str | None = None,
         log_config: LogConfig | None = None,
     ) -> Handle[AgentT]:
-        """Queue an agent launch. Committed on context exit.
+        """Queue an agent for launch on `submit()`.
 
         Parameters mirror
         [`Manager.launch`][academy.manager.Manager.launch] exactly
@@ -191,18 +179,17 @@ class _BatchLauncher:
         itself).
 
         Returns:
-            Handle to the agent. Usable as a sibling ``batch.launch``
-            argument; not messageable until the batch commits.
+            Handle to the agent. Usable as a sibling ``batch.queue``
+            argument; not messageable until the batch is submitted.
 
         Warning:
             Pass the [`Handle`][academy.handle.Handle] itself to
             sibling launches, not ``handle.agent_id``. The handle is
-            rebound in place
-            at commit time; an ``agent_id`` captured into ``args``
-            before commit is a stale placeholder UUID.
+            rebound in place at submit time; an ``agent_id`` captured
+            into ``args`` before submit is a stale placeholder UUID.
 
         Raises:
-            RuntimeError: If the batch has already exited.
+            RuntimeError: If the batch has already been closed.
         """
         if self._closed:
             raise RuntimeError('batch is closed')
@@ -227,17 +214,27 @@ class _BatchLauncher:
         )
         return handle
 
-    async def _commit(self) -> None:
-        """Register queued intents together, then launch each.
+    async def submit(self) -> None:
+        """Register and launch all queued intents.
 
         On transports that implement
         [`ExchangeTransport.register_agents`][academy.exchange.transport.ExchangeTransport.register_agents]
-        (e.g. Globus), this produces one auth consent prompt
-        for the whole batch; other transports fall back to
-        sequential registration. Each pre-minted handle is then
-        rebound to the transport-minted ID
-        before launch.
+        (e.g. Globus), this produces one auth consent prompt for the
+        whole batch; other transports fall back to sequential
+        registration.
+
+        A failed launch mid-batch terminates later intents as
+        orphans; earlier intents keep running.
+
+        Raises:
+            RuntimeError: If the batch has already been closed.
         """
+        if self._closed:
+            raise RuntimeError('batch is closed')
+        self._closed = True
+        if not self._intents:
+            return
+
         specs: list[tuple[type[Any], str | None]] = [
             (
                 intent.agent
@@ -247,42 +244,58 @@ class _BatchLauncher:
             )
             for intent in self._intents
         ]
-        registrations = await self._manager.register_agents(specs)
 
-        launch_index = 0
         try:
-            for intent, registration in zip(
-                self._intents,
-                registrations,
-                strict=True,
-            ):
-                self._manager._rebind_handle(
-                    intent.handle,
-                    registration.agent_id,
-                )
-                await self._manager.launch(
-                    intent.agent,
-                    args=intent.args,
-                    kwargs=intent.kwargs,
-                    config=intent.config,
-                    executor=intent.executor,
-                    submit_kwargs=intent.submit_kwargs,
-                    name=intent.name,
-                    registration=registration,
-                    log_config=intent.log_config,
-                )
-                launch_index += 1
-        except Exception:
-            # CancelledError deliberately excluded: registrations past
-            # ``launch_index`` will leak exchange-side, but awaiting
-            # cleanup inside a cancellation frame risks a hung shutdown.
-            orphan_intents = self._intents[launch_index:]
-            orphan_registrations = registrations[launch_index:]
-            handles = self._manager._handles
-            for intent in orphan_intents:
-                handles.pop(intent.handle.agent_id, None)
-            await self._terminate_orphans(orphan_registrations)
+            registrations = await self._manager.register_agents(specs)
+
+            launch_index = 0
+            try:
+                for intent, registration in zip(
+                    self._intents,
+                    registrations,
+                    strict=True,
+                ):
+                    self._manager._rebind_handle(
+                        intent.handle,
+                        registration.agent_id,
+                    )
+                    await self._manager.launch(
+                        intent.agent,
+                        args=intent.args,
+                        kwargs=intent.kwargs,
+                        config=intent.config,
+                        executor=intent.executor,
+                        submit_kwargs=intent.submit_kwargs,
+                        name=intent.name,
+                        registration=registration,
+                        log_config=intent.log_config,
+                    )
+                    launch_index += 1
+            except Exception:
+                # CancelledError deliberately excluded: registrations
+                # past ``launch_index`` will leak exchange-side, but
+                # awaiting cleanup inside a cancellation frame risks a
+                # hung shutdown.
+                orphan_intents = self._intents[launch_index:]
+                orphan_registrations = registrations[launch_index:]
+                handles = self._manager._handles
+                for intent in orphan_intents:
+                    handles.pop(intent.handle.agent_id, None)
+                await self._terminate_orphans(orphan_registrations)
+                raise
+        except BaseException:
+            self._evict_placeholder_handles()
             raise
+        finally:
+            self._intents.clear()
+
+    def abort(self) -> None:
+        """Discard queued intents. Idempotent."""
+        if self._closed:
+            return
+        self._closed = True
+        self._evict_placeholder_handles()
+        self._intents.clear()
 
     async def _terminate_orphans(
         self,
@@ -301,7 +314,7 @@ class _BatchLauncher:
             if isinstance(result, Exception):
                 logger.error(
                     'Failed to terminate orphan registration %s during '
-                    'launch_batch commit rollback.',
+                    'launch_batch submit rollback.',
                     registration.agent_id,
                     exc_info=result,
                     extra={
@@ -784,17 +797,17 @@ class Manager(Generic[ExchangeTransportT], NoPickleMixin):
         registered under a single auth consent prompt. Other
         transports fall back to sequential registration.
 
-        Handles returned by ``batch.launch`` can be passed as
-        arguments to sibling ``batch.launch`` calls; they are not
-        messageable until the batch commits on exit.
+        Handles returned by ``batch.queue`` can be passed as
+        arguments to sibling ``batch.queue`` calls; they are not
+        messageable until the batch is submitted on exit.
 
         Example:
             .. code-block:: python
 
                 async with manager.launch_batch() as batch:
-                    greeter = await batch.launch(Greeter)
-                    shouter = await batch.launch(Shouter)
-                    coordinator = await batch.launch(
+                    greeter = await batch.queue(Greeter)
+                    shouter = await batch.queue(Shouter)
+                    coordinator = await batch.queue(
                         Coordinator,
                         args=(greeter, shouter),
                     )

--- a/academy/manager.py
+++ b/academy/manager.py
@@ -105,7 +105,6 @@ class _LaunchIntent(Generic[AgentT]):
     # would drop static typing.
     agent: AgentT | type[AgentT]
     handle: Handle[AgentT]
-    placeholder_agent_id: AgentId[AgentT]
     name: str | None = None
     args: tuple[Any, ...] | None = None
     kwargs: dict[str, Any] | None = None
@@ -146,19 +145,6 @@ class _BatchLauncher:
             return
         await self.submit()
 
-    def _evict_placeholder_handles(self) -> None:
-        """Remove queued intents' placeholder handles from the cache.
-
-        Safe to call after partial rebinds: rebound intents no longer
-        have their placeholder id in the cache, so the ``is`` check
-        skips them.
-        """
-        handles = self._manager._handles
-        for intent in self._intents:
-            pid = intent.placeholder_agent_id
-            if handles.get(pid) is intent.handle:
-                del handles[pid]
-
     async def queue(  # noqa: PLR0913
         self,
         agent: AgentT | type[AgentT],
@@ -179,14 +165,8 @@ class _BatchLauncher:
         itself).
 
         Returns:
-            Handle to the agent. Usable as a sibling ``batch.queue``
-            argument; not messageable until the batch is submitted.
-
-        Warning:
-            Pass the [`Handle`][academy.handle.Handle] itself to
-            sibling launches, not ``handle.agent_id``. The handle is
-            rebound in place at submit time; an ``agent_id`` captured
-            into ``args`` before submit is a stale placeholder UUID.
+            Unbound handle. Pass to sibling ``batch.queue``
+            calls as needed.
 
         Raises:
             RuntimeError: If the batch has already been closed.
@@ -194,15 +174,12 @@ class _BatchLauncher:
         if self._closed:
             raise RuntimeError('batch is closed')
 
-        # Pre-mint so the returned handle can be a sibling-launch arg.
-        aid: AgentId[AgentT] = AgentId.new(name=name)
-        handle = self._manager.get_handle(aid)
+        handle: Handle[AgentT] = Handle()
 
         self._intents.append(
             _LaunchIntent(
                 agent=agent,
                 handle=handle,
-                placeholder_agent_id=aid,
                 name=name,
                 args=args,
                 kwargs=kwargs,
@@ -255,9 +232,9 @@ class _BatchLauncher:
                     registrations,
                     strict=True,
                 ):
-                    self._manager._rebind_handle(
-                        intent.handle,
-                        registration.agent_id,
+                    intent.handle.agent_id = registration.agent_id
+                    self._manager._handles[registration.agent_id] = (
+                        intent.handle
                     )
                     await self._manager.launch(
                         intent.agent,
@@ -280,12 +257,10 @@ class _BatchLauncher:
                 orphan_registrations = registrations[launch_index:]
                 handles = self._manager._handles
                 for intent in orphan_intents:
-                    handles.pop(intent.handle.agent_id, None)
+                    if intent.handle._agent_id is not None:
+                        handles.pop(intent.handle._agent_id, None)
                 await self._terminate_orphans(orphan_registrations)
                 raise
-        except BaseException:
-            self._evict_placeholder_handles()
-            raise
         finally:
             self._intents.clear()
 
@@ -294,7 +269,6 @@ class _BatchLauncher:
         if self._closed:
             return
         self._closed = True
-        self._evict_placeholder_handles()
         self._intents.clear()
 
     async def _terminate_orphans(
@@ -755,38 +729,6 @@ class Manager(Generic[ExchangeTransportT], NoPickleMixin):
         handle = Handle(agent_id)
         self._handles[agent_id] = handle
         return handle
-
-    def _rebind_handle(
-        self,
-        handle: Handle[AgentT],
-        new_agent_id: AgentId[AgentT],
-    ) -> None:
-        """Rebind a cached handle to a new agent ID.
-
-        Reconciles pre-minted placeholder IDs with the
-        transport-minted IDs returned from
-        [`register_agents`][academy.manager.Manager.register_agents].
-        The handle must not yet have been used for messaging —
-        mutating ``agent_id`` after it has been captured in log
-        extras, pickled snapshots, or user code is unsafe.
-        """
-        old_agent_id = handle.agent_id
-        if old_agent_id == new_agent_id:
-            return
-        assert not handle._used_for_messaging, (
-            f'Cannot rebind handle {old_agent_id}: already used for '
-            'messaging. Pass the Handle itself (not handle.agent_id) '
-            'as a sibling launch_batch argument.'
-        )
-        existing = self._handles.get(new_agent_id)
-        assert existing is None or existing is handle, (
-            f'Cannot rebind handle to {new_agent_id}: cache already '
-            'holds a different handle for that ID.'
-        )
-        if self._handles.get(old_agent_id) is handle:  # pragma: no branch
-            del self._handles[old_agent_id]
-        handle.agent_id = new_agent_id
-        self._handles[new_agent_id] = handle
 
     def launch_batch(self) -> _BatchLauncher:
         """Open a batch context that joins multiple agent launches.

--- a/academy/manager.py
+++ b/academy/manager.py
@@ -106,6 +106,7 @@ class _LaunchIntent(Generic[AgentT]):
     # would drop static typing.
     agent: AgentT | type[AgentT]
     handle: Handle[AgentT]
+    placeholder_agent_id: AgentId[AgentT]
     name: str | None = None
     args: tuple[Any, ...] | None = None
     kwargs: dict[str, Any] | None = None
@@ -148,18 +149,26 @@ class _BatchLauncher:
         if not self._intents:
             return
         try:
-            await self._commit()
+            try:
+                await self._commit()
+            except BaseException:
+                self._evict_placeholder_handles()
+                raise
         finally:
-            # Drop per-intent references; the batch object may outlive
-            # ``async with`` and the manager's caches own the state now.
             self._intents.clear()
 
     def _evict_placeholder_handles(self) -> None:
-        """Remove queued intents' handles from the manager cache."""
+        """Remove queued intents' placeholder handles from the cache.
+
+        Safe to call after partial rebinds: rebound intents no longer
+        have their placeholder id in the cache, so the ``is`` check
+        skips them.
+        """
         handles = self._manager._handles
         for intent in self._intents:
-            if handles.get(intent.handle.agent_id) is intent.handle:
-                del handles[intent.handle.agent_id]
+            pid = intent.placeholder_agent_id
+            if handles.get(pid) is intent.handle:
+                del handles[pid]
 
     async def launch(  # noqa: PLR0913
         self,
@@ -202,6 +211,7 @@ class _BatchLauncher:
             _LaunchIntent(
                 agent=agent,
                 handle=handle,
+                placeholder_agent_id=aid,
                 name=name,
                 args=args,
                 kwargs=kwargs,
@@ -805,8 +815,8 @@ class Manager(Generic[ExchangeTransportT], NoPickleMixin):
                     )
 
         A convenience wrapper around :meth:`register_agents` and
-        :meth:`launch(registration=...) <launch>`; you can use the 
-        pair instead when registration and launch need to be 
+        :meth:`launch(registration=...) <launch>`; you can use the
+        pair instead when registration and launch need to be
         separated in time.
         """
         return _BatchLauncher(self)

--- a/academy/manager.py
+++ b/academy/manager.py
@@ -118,9 +118,11 @@ class _LaunchIntent(Generic[AgentT]):
 class _BatchLauncher:
     """Context manager that batches multiple agent launches.
 
-    Returned by :meth:`Manager.launch_batch`. On context exit
-    without error, queued agents are registered together (one
-    auth consent prompt on transports that batch auth) and launched.
+    Returned by
+    [`Manager.launch_batch`][academy.manager.Manager.launch_batch].
+    On context exit without error, queued agents are registered
+    together (one auth consent prompt on transports that batch auth)
+    and launched.
 
     Args:
         manager: Manager that owns this batch.
@@ -183,16 +185,19 @@ class _BatchLauncher:
     ) -> Handle[AgentT]:
         """Queue an agent launch. Committed on context exit.
 
-        Parameters mirror :meth:`Manager.launch` exactly except for
-        ``registration`` (the batch manages registration itself).
+        Parameters mirror
+        [`Manager.launch`][academy.manager.Manager.launch] exactly
+        except for ``registration`` (the batch manages registration
+        itself).
 
         Returns:
             Handle to the agent. Usable as a sibling ``batch.launch``
             argument; not messageable until the batch commits.
 
         Warning:
-            Pass the :class:`Handle` itself to sibling launches,
-            not ``handle.agent_id``. The handle is rebound in place
+            Pass the [`Handle`][academy.handle.Handle] itself to
+            sibling launches, not ``handle.agent_id``. The handle is
+            rebound in place
             at commit time; an ``agent_id`` captured into ``args``
             before commit is a stale placeholder UUID.
 
@@ -226,10 +231,11 @@ class _BatchLauncher:
         """Register queued intents together, then launch each.
 
         On transports that implement
-        :meth:`ExchangeTransport.register_agents` (e.g. Globus), this
-        produces one auth consent prompt for the whole batch; other
-        transports fall back to sequential registration. Each
-        pre-minted handle is then rebound to the transport-minted ID
+        [`ExchangeTransport.register_agents`][academy.exchange.transport.ExchangeTransport.register_agents]
+        (e.g. Globus), this produces one auth consent prompt
+        for the whole batch; other transports fall back to
+        sequential registration. Each pre-minted handle is then
+        rebound to the transport-minted ID
         before launch.
         """
         specs: list[tuple[type[Any], str | None]] = [
@@ -640,8 +646,8 @@ class Manager(Generic[ExchangeTransportT], NoPickleMixin):
         """Launch a new agent with a specified agent.
 
         Note:
-            Parameters are mirrored in :class:`_LaunchIntent` and
-            :meth:`_BatchLauncher.launch`; keep all three in sync.
+            Parameters are mirrored in `_LaunchIntent` and
+            `_BatchLauncher.launch`; keep all three in sync.
 
         Args:
             agent: Agent instance the agent will implement or the
@@ -745,17 +751,11 @@ class Manager(Generic[ExchangeTransportT], NoPickleMixin):
         """Rebind a cached handle to a new agent ID.
 
         Reconciles pre-minted placeholder IDs with the
-        transport-minted IDs returned from :meth:`register_agents`.
+        transport-minted IDs returned from
+        [`register_agents`][academy.manager.Manager.register_agents].
         The handle must not yet have been used for messaging —
         mutating ``agent_id`` after it has been captured in log
         extras, pickled snapshots, or user code is unsafe.
-
-        TODO: Rebinding is only needed because transports mint their
-        own IDs during registration. If ``register_agents`` accepted
-        pre-minted IDs from the caller, the placeholder would already
-        be the real ID and this method (plus the
-        ``_used_for_messaging`` guard on :class:`Handle`) could go
-        away. Deferred because it changes the transport protocol.
         """
         old_agent_id = handle.agent_id
         if old_agent_id == new_agent_id:
@@ -779,7 +779,7 @@ class Manager(Generic[ExchangeTransportT], NoPickleMixin):
         """Open a batch context that joins multiple agent launches.
 
         On transports that batch auth (notably
-        :class:`~academy.exchange.cloud.globus.GlobusExchangeFactory`),
+        [`GlobusExchangeFactory`][academy.exchange.cloud.globus.GlobusExchangeFactory]),
         every agent queued inside the ``async with`` block is
         registered under a single auth consent prompt. Other
         transports fall back to sequential registration.
@@ -799,10 +799,12 @@ class Manager(Generic[ExchangeTransportT], NoPickleMixin):
                         args=(greeter, shouter),
                     )
 
-        A convenience wrapper around :meth:`register_agents` and
-        :meth:`launch(registration=...) <launch>`; you can use the
-        pair instead when registration and launch need to be
-        separated in time.
+        A convenience wrapper around
+        [`register_agents`][academy.manager.Manager.register_agents]
+        and
+        [`launch(registration=...)`][academy.manager.Manager.launch];
+        you can use the pair instead when registration and launch
+        need to be separated in time.
         """
         return _BatchLauncher(self)
 
@@ -835,7 +837,7 @@ class Manager(Generic[ExchangeTransportT], NoPickleMixin):
         other transports this falls back to sequential registration.
 
         Use the returned registrations with
-        :meth:`launch(registration=...) <launch>`.
+        [`launch(registration=...)`][academy.manager.Manager.launch].
 
         Args:
             agents: List of (agent_type, name) pairs to register.

--- a/academy/manager.py
+++ b/academy/manager.py
@@ -141,7 +141,8 @@ class _BatchLauncher:
         if self._closed:
             return
         if exc_value is not None:
-            self.abort()
+            self._closed = True
+            self._intents.clear()
             return
         await self.submit()
 
@@ -263,13 +264,6 @@ class _BatchLauncher:
                 raise
         finally:
             self._intents.clear()
-
-    def abort(self) -> None:
-        """Discard queued intents. Idempotent."""
-        if self._closed:
-            return
-        self._closed = True
-        self._intents.clear()
 
     async def _terminate_orphans(
         self,

--- a/academy/manager.py
+++ b/academy/manager.py
@@ -254,41 +254,15 @@ class _BatchLauncher:
                 # past ``launch_index`` will leak exchange-side, but
                 # awaiting cleanup inside a cancellation frame risks a
                 # hung shutdown.
-                self._manager._handles.pop(
-                    registrations[launch_index].agent_id,
-                    None,
-                )
-                await self._terminate_orphans(
-                    registrations[launch_index:],
+                exchange = self._manager.exchange_client
+                orphans = registrations[launch_index:]
+                self._manager._handles.pop(orphans[0].agent_id, None)
+                await asyncio.gather(
+                    *(exchange.terminate(reg.agent_id) for reg in orphans),
                 )
                 raise
         finally:
             self._intents.clear()
-
-    async def _terminate_orphans(
-        self,
-        orphans: list[AgentRegistration[Any]],
-    ) -> None:
-        """Best-effort parallel termination; failures logged, never raised.
-
-        The original launch exception must not be masked.
-        """
-        exchange = self._manager.exchange_client
-        results = await asyncio.gather(
-            *(exchange.terminate(reg.agent_id) for reg in orphans),
-            return_exceptions=True,
-        )
-        for registration, result in zip(orphans, results, strict=True):
-            if isinstance(result, Exception):
-                logger.error(
-                    'Failed to terminate orphan registration %s during '
-                    'launch_batch submit rollback.',
-                    registration.agent_id,
-                    exc_info=result,
-                    extra={
-                        'academy.agent_id': registration.agent_id,
-                    },
-                )
 
 
 class Manager(Generic[ExchangeTransportT], NoPickleMixin):

--- a/academy/manager.py
+++ b/academy/manager.py
@@ -254,13 +254,13 @@ class _BatchLauncher:
                 # past ``launch_index`` will leak exchange-side, but
                 # awaiting cleanup inside a cancellation frame risks a
                 # hung shutdown.
-                orphan_intents = self._intents[launch_index:]
-                orphan_registrations = registrations[launch_index:]
-                handles = self._manager._handles
-                for intent in orphan_intents:
-                    if intent.handle._agent_id is not None:
-                        handles.pop(intent.handle._agent_id, None)
-                await self._terminate_orphans(orphan_registrations)
+                self._manager._handles.pop(
+                    registrations[launch_index].agent_id,
+                    None,
+                )
+                await self._terminate_orphans(
+                    registrations[launch_index:],
+                )
                 raise
         finally:
             self._intents.clear()

--- a/academy/manager.py
+++ b/academy/manager.py
@@ -602,7 +602,7 @@ class Manager(Generic[ExchangeTransportT], NoPickleMixin):
 
         Note:
             Parameters are mirrored in `_LaunchIntent` and
-            `_BatchLauncher.launch`; keep all three in sync.
+            `_BatchLauncher.queue`; keep all three in sync.
 
         Args:
             agent: Agent instance the agent will implement or the
@@ -699,7 +699,7 @@ class Manager(Generic[ExchangeTransportT], NoPickleMixin):
         return handle
 
     def launch_batch(self) -> _BatchLauncher:
-        """Open a batch context that joins multiple agent launches.
+        """Open a batch context that performs multiple simultaneous launches.
 
         On transports that batch auth (notably
         [`GlobusExchangeFactory`][academy.exchange.cloud.globus.GlobusExchangeFactory]),
@@ -712,15 +712,15 @@ class Manager(Generic[ExchangeTransportT], NoPickleMixin):
         messageable until the batch is submitted on exit.
 
         Example:
-            .. code-block:: python
-
-                async with manager.launch_batch() as batch:
-                    greeter = await batch.queue(Greeter)
-                    shouter = await batch.queue(Shouter)
-                    coordinator = await batch.queue(
-                        Coordinator,
-                        args=(greeter, shouter),
-                    )
+            ```python
+            async with manager.launch_batch() as batch:
+                greeter = await batch.queue(Greeter)
+                shouter = await batch.queue(Shouter)
+                coordinator = await batch.queue(
+                    Coordinator,
+                    args=(greeter, shouter),
+                )
+            ```
 
         A convenience wrapper around
         [`register_agents`][academy.manager.Manager.register_agents]

--- a/docs/guides/persistent.md
+++ b/docs/guides/persistent.md
@@ -117,6 +117,39 @@ Once you have created you unit file, you can start the service:
 systemctl --user start <service_name>
 ```
 
+## Launching Multiple Agents at Once
+
+When launching multiple agents from a manager, Academy provides [`launch_batch()`][academy.manager.Manager.launch_batch]. This method works with any exchange, but on the [Globus exchange][academy.exchange.cloud.globus.GlobusExchangeFactory] all agents within the batch are registered under a single consent prompt instead of one per agent.
+
+```
+async with manager.launch_batch() as batch:
+    greeter = await batch.queue(Greeter)
+    shouter = await batch.queue(Shouter)
+    coordinator = await batch.queue(
+        Coordinator,
+        args=(greeter, shouter),
+    )
+```
+
+Handles returned by `batch.queue()` are unbound until the batch is submitted. They can be passed as arguments to other agents *within* same batch (as the coordinator does above), but reading `handle.agent_id` or pickling the handle will raise a `RuntimeError` until submission.
+
+To drive a batch outside of a context manager you call `submit()`:
+
+```
+batch = manager.launch_batch()
+greeter = await batch.queue(Greeter)
+shouter = await batch.queue(Shouter)
+coordinator = await batch.queue(
+    Coordinator,
+    args=(greeter, shouter),
+)
+await batch.submit()
+```
+
+Multiple batches can be used during the lifecycle of a manager.
+
+See `examples/12-globus-exchange/` for working examples of both patterns.
+
 ## Finding and Communicating with Running Agents
 
 ### Creating a handle with AgentId

--- a/docs/guides/persistent.md
+++ b/docs/guides/persistent.md
@@ -131,7 +131,7 @@ async with manager.launch_batch() as batch:
     )
 ```
 
-Handles returned by `batch.queue()` are unbound until the batch is submitted. They can be passed as arguments to other agents *within* same batch (as the coordinator does above), but reading `handle.agent_id` or pickling the handle will raise a `RuntimeError` until submission.
+Handles returned by `batch.queue()` are unbound until the batch is submitted. They can be passed as arguments to other agents *within* the same batch (as the coordinator does above), but reading `handle.agent_id` or pickling the handle will raise a `RuntimeError` until submission.
 
 To drive a batch outside of a context manager you call `submit()`:
 

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -29,6 +29,19 @@ Multiple log contexts can be active in a process at any one time - for example, 
 
 Academy comes with three ways of configuring logging: to the console, to a log file, and to a shared home directory JSON logfile store. Developers can implement new logging configurations by subclassing the LogConfig class.
 
+#### New: `Manager.launch_batch()`
+
+Small ergonomics addition for the Globus transport: launches queued inside a `launch_batch()` block are registered under a single auth consent prompt instead of one per agent. Other transports behave identically to separate `Manager.launch()` calls.
+
+```python
+async with manager.launch_batch() as batch:
+    greeter = await batch.launch(Greeter)
+    coordinator = await batch.launch(
+        Coordinator,
+        args=(greeter,),
+    )
+```
+
 ## Academy v0.4
 
 ## Globus SDK version has been updated

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -193,4 +193,3 @@ Summary:
 - [`Manager`][academy.manager.Manager] exposes [`get_handle()`][academy.manager.Manager.get_handle] and [`register_agent()`][academy.manager.Manager.register_agent].
 - [`Manager.launch()`][academy.manager.Manager.launch] now optionally takes an [`Agent`][academy.agent.Agent] type and args/kwargs and will defer agent initialization to on worker.
 - [`Manager.wait()`][academy.manager.Manager] now takes an iterable of agent IDs or handles.
-

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -33,7 +33,7 @@ Academy comes with three ways of configuring logging: to the console, to a log f
 
 #### New: `Manager.launch_batch()`
 
-Batch launch ergonomics for the Globus transport: launches queued inside a `launch_batch()` block are registered under a single auth consent prompt instead of one per agent. Other transports behave identically to separate `Manager.launch()` calls.
+Batch launch ergonomics for the Globus transport: launches queued inside a [`launch_batch()`][academy.manager.Manager.launch_batch] block are registered under a single auth consent prompt instead of one per agent. Other transports behave identically to separate [`Manager.launch()`][academy.manager.Manager.launch] calls.
 
 ```python
 async with manager.launch_batch() as batch:
@@ -43,6 +43,8 @@ async with manager.launch_batch() as batch:
         args=(greeter,),
     )
 ```
+
+`batch.queue` returns an unbound [`Handle`][academy.handle.Handle]. Reading [`handle.agent_id`][academy.handle.Handle.agent_id] (or pickling the handle) raises `RuntimeError` until the batch is submitted.
 
 ## Agent Registration are Pydantic Models
 

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -1,8 +1,8 @@
 This guide helps users adapt to breaking changes introduced during the v0.X development cycle, such as:
 
-- Changes to APIs, behavior, or configuration that require user action
-- Deprecated or removed features
-- Recommended steps for upgrading between versions
+* Changes to APIs, behavior, or configuration that require user action
+* Deprecated or removed features
+* Recommended steps for upgrading between versions
 
 We provide migration notes for each v0.X release to make upgrades easier during this early phase of development.
 After v1.0, this guide will be retired.
@@ -17,6 +17,7 @@ Please refer to our [Version Policy](version-policy.md) for more details on when
 This version of Academy introduces new logging configuration which is intended to help users configure logging across multiple processes, and to provide a base for development of other log-oriented features (such as provenance tracking, and distributed/cloud based logging)
 
 The once-per-process `init_logging` helper function has been removed. Instead pass log configs when creating managers.
+
 
 ```python
   from academy.logging.helpers import recommended_logging, log_context
@@ -42,6 +43,7 @@ async with manager.launch_batch() as batch:
         args=(greeter,),
     )
 ```
+
 ## Agent Registration are Pydantic Models
 
 The `AgentRegistration` protocol is used to match new agents with previously created mailboxes --- a different implementation of the protocol is used for each exchange type. These classes are now `pydantic` models instead of dataclasses.  Previously created registrations will not work with the new version of Academy.
@@ -78,7 +80,6 @@ This approach resulted in many edge cases where handles would not be discovered 
 Now, a [`Handle`][academy.handle.Handle] determines the correct [`ExchangeClient`][academy.exchange.ExchangeClient] from [context variables][contextvars].
 This exchange context variable is set when running an agent, or on the user-side when using the [`Manager`][academy.manager.Manager] or [`ExchangeClient`][academy.exchange.ExchangeClient] context managers.
 As a result, it is now safe to instantiate new handles directly inside an agent using only the ID of the peer agent.
-
 ```python
 from academy.agent import Agent, action
 from academy.handle import Handle
@@ -98,7 +99,6 @@ In very specific cases, `ignore_context=True` can be used to force the handle to
 
 Previously, invoking an action on a [`Handle`][academy.handle.Handle.action] returned a [`Future`][asyncio.Future] to the result.
 This resulted in verbose syntax when the result was immediately needed:
-
 ```python
 future = await handle.get_count()
 result = await future
@@ -107,20 +107,16 @@ result = await (await handle.get_count())
 ```
 
 Now, action requests block and return the final result of the action:
-
 ```python
 result = await handle.get_count()
 ```
-
 Code that wants to submit the request and later block on it can create a [`Task`][asyncio.create_task].
-
 ```python
 task = asyncio.create_task(handle.get_count())
 # ... do other work ...
 await task
 print(task.result())
 ```
-
 Using tasks is especially useful when launching multiple long-running actions concurrently and waiting for them in a flexible manner.
 For example, instead of waiting for each action sequentially, you can start them all at once and then wait for them to complete using [`asyncio.wait()`][asyncio.wait] or [`asyncio.as_completed()`][asyncio.as_completed].
 
@@ -145,17 +141,17 @@ Agents are now derived from [`Agent`][academy.agent.Agent] (previously, `Behavio
 
 Summary:
 
-- `academy.agent.Agent` is renamed [`academy.runtime.Runtime`][academy.runtime.Runtime].
-- `academy.behavior.Behavior` is renamed [`academy.agent.Agent`][academy.agent.Agent].
-- `academy.identifier.ClientId` is renamed [`academy.identifier.UserId`][academy.identifier.UserId].
+* `academy.agent.Agent` is renamed [`academy.runtime.Runtime`][academy.runtime.Runtime].
+* `academy.behavior.Behavior` is renamed [`academy.agent.Agent`][academy.agent.Agent].
+* `academy.identifier.ClientId` is renamed [`academy.identifier.UserId`][academy.identifier.UserId].
 
 ### Changes to agents
 
 All special methods provided by [`Agent`][academy.agent.Agent] are named `agent_.*`.
 For example, the startup and shutdown callbacks have been renamed:
 
-- `Agent.on_setup` is renamed `Agent.agent_on_startup`
-- `Agent.on_shutdown` is renamed `Agent.agent_on_shutdown`
+* `Agent.on_setup` is renamed `Agent.agent_on_startup`
+* `Agent.on_shutdown` is renamed `Agent.agent_on_shutdown`
 
 Runtime context is now available via additional methods.
 
@@ -163,22 +159,22 @@ Runtime context is now available via additional methods.
 
 The `Exchange` and `Mailbox` protocols have been merged into a single [`ExchangeClient`][academy.exchange.ExchangeClient] which comes in two forms:
 
-- [`AgentExchangeClient`][academy.exchange.AgentExchangeClient]
-- [`UserExchangeClient`][academy.exchange.UserExchangeClient]
+* [`AgentExchangeClient`][academy.exchange.AgentExchangeClient]
+* [`UserExchangeClient`][academy.exchange.UserExchangeClient]
 
 Thus, an [`ExchangeClient`][academy.exchange.ExchangeClient] has a 1:1 relationship with the mailbox of a single entity.
 Each [`ExchangeClient`][academy.exchange.ExchangeClient] is initialized using a [`ExchangeTransport`][academy.exchange.transport.ExchangeTransport].
 This protocol defines low-level client interaction with the exchange.
 Some of the exchange operations have have been changed:
 
-- `register_client()` has been removed
-- [`send()`][academy.exchange.transport.ExchangeTransport.send] no longer takes a `dest` parameter
-- [`status()`][academy.exchange.transport.ExchangeTransport.status] has been added
+* `register_client()` has been removed
+* [`send()`][academy.exchange.transport.ExchangeTransport.send] no longer takes a `dest` parameter
+* [`status()`][academy.exchange.transport.ExchangeTransport.status] has been added
 
 Exchange clients are created using a factory pattern:
 
-- [`ExchangeFactory.create_agent_client()`][academy.exchange.ExchangeFactory.create_agent_client]
-- [`ExchangeFactory.create_user_client()`][academy.exchange.ExchangeFactory.create_user_client]
+* [`ExchangeFactory.create_agent_client()`][academy.exchange.ExchangeFactory.create_agent_client]
+* [`ExchangeFactory.create_user_client()`][academy.exchange.ExchangeFactory.create_user_client]
 
 All exchange implementations have been updated to provide a custom transport and factory implementation.
 The "thread" exchange has been renamed to "local" now that Academy is async.
@@ -186,15 +182,16 @@ The "thread" exchange has been renamed to "local" now that Academy is async.
 All exchange related errors derive from [`ExchangeError`][academy.exception.ExchangeError].
 `MailboxClosedError` is renamed [`MailboxTerminatedError`][academy.exception.MailboxTerminatedError] with derived types for [`AgentTerminatedError`][academy.exception.AgentTerminatedError] and [`UserTerminatedError`][academy.exception.UserTerminatedError].
 
+
 ### Changes to the manager and launchers
 
 The `Launcher` protocol and implementations have been removed, with their functionality incorporated directly into the [`Manager`][academy.manager.Manager].
 
 Summary:
 
-- [`Manager`][academy.manager.Manager] is now initialized with one or more [`Executors`][concurrent.futures.Executor].
-- Added the [`Manager.from_exchange_factory()`][academy.manager.Manager.from_exchange_factory] class method.
-- `Manager.set_default_launcher()` and `Manager.add_launcher()` are renamed [`set_default_executor()`][academy.manager.Manager.set_default_executor] and [`add_executor()`][academy.manager.Manager.add_executor], respectively.
-- [`Manager`][academy.manager.Manager] exposes [`get_handle()`][academy.manager.Manager.get_handle] and [`register_agent()`][academy.manager.Manager.register_agent].
-- [`Manager.launch()`][academy.manager.Manager.launch] now optionally takes an [`Agent`][academy.agent.Agent] type and args/kwargs and will defer agent initialization to on worker.
-- [`Manager.wait()`][academy.manager.Manager] now takes an iterable of agent IDs or handles.
+* [`Manager`][academy.manager.Manager] is now initialized with one or more [`Executors`][concurrent.futures.Executor].
+* Added the [`Manager.from_exchange_factory()`][academy.manager.Manager.from_exchange_factory] class method.
+* `Manager.set_default_launcher()` and `Manager.add_launcher()` are renamed [`set_default_executor()`][academy.manager.Manager.set_default_executor] and [`add_executor()`][academy.manager.Manager.add_executor], respectively.
+* [`Manager`][academy.manager.Manager] exposes [`get_handle()`][academy.manager.Manager.get_handle] and [`register_agent()`][academy.manager.Manager.register_agent].
+* [`Manager.launch()`][academy.manager.Manager.launch] now optionally takes an [`Agent`][academy.agent.Agent] type and args/kwargs and will defer agent initialization to on worker.
+* [`Manager.wait()`][academy.manager.Manager] now takes an iterable of agent IDs or handles.

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -1,8 +1,8 @@
 This guide helps users adapt to breaking changes introduced during the v0.X development cycle, such as:
 
-* Changes to APIs, behavior, or configuration that require user action
-* Deprecated or removed features
-* Recommended steps for upgrading between versions
+- Changes to APIs, behavior, or configuration that require user action
+- Deprecated or removed features
+- Recommended steps for upgrading between versions
 
 We provide migration notes for each v0.X release to make upgrades easier during this early phase of development.
 After v1.0, this guide will be retired.
@@ -15,7 +15,6 @@ Please refer to our [Version Policy](version-policy.md) for more details on when
 This version of Academy introduces new logging configuration which is intended to help users configure logging across multiple processes, and to provide a base for development of other log-oriented features (such as provenance tracking, and distributed/cloud based logging)
 
 The once-per-process `init_logging` helper function has been removed. Instead pass log configs when creating managers.
-
 
 ```python
   from academy.logging.helpers import recommended_logging, log_context
@@ -31,7 +30,7 @@ Academy comes with three ways of configuring logging: to the console, to a log f
 
 #### New: `Manager.launch_batch()`
 
-Small ergonomics addition for the Globus transport: launches queued inside a `launch_batch()` block are registered under a single auth consent prompt instead of one per agent. Other transports behave identically to separate `Manager.launch()` calls.
+Batch launch ergonomics for the Globus transport: launches queued inside a `launch_batch()` block are registered under a single auth consent prompt instead of one per agent. Other transports behave identically to separate `Manager.launch()` calls.
 
 ```python
 async with manager.launch_batch() as batch:
@@ -74,6 +73,7 @@ This approach resulted in many edge cases where handles would not be discovered 
 Now, a [`Handle`][academy.handle.Handle] determines the correct [`ExchangeClient`][academy.exchange.ExchangeClient] from [context variables][contextvars].
 This exchange context variable is set when running an agent, or on the user-side when using the [`Manager`][academy.manager.Manager] or [`ExchangeClient`][academy.exchange.ExchangeClient] context managers.
 As a result, it is now safe to instantiate new handles directly inside an agent using only the ID of the peer agent.
+
 ```python
 from academy.agent import Agent, action
 from academy.handle import Handle
@@ -93,6 +93,7 @@ In very specific cases, `ignore_context=True` can be used to force the handle to
 
 Previously, invoking an action on a [`Handle`][academy.handle.Handle.action] returned a [`Future`][asyncio.Future] to the result.
 This resulted in verbose syntax when the result was immediately needed:
+
 ```python
 future = await handle.get_count()
 result = await future
@@ -101,16 +102,20 @@ result = await (await handle.get_count())
 ```
 
 Now, action requests block and return the final result of the action:
+
 ```python
 result = await handle.get_count()
 ```
+
 Code that wants to submit the request and later block on it can create a [`Task`][asyncio.create_task].
+
 ```python
 task = asyncio.create_task(handle.get_count())
 # ... do other work ...
 await task
 print(task.result())
 ```
+
 Using tasks is especially useful when launching multiple long-running actions concurrently and waiting for them in a flexible manner.
 For example, instead of waiting for each action sequentially, you can start them all at once and then wait for them to complete using [`asyncio.wait()`][asyncio.wait] or [`asyncio.as_completed()`][asyncio.as_completed].
 
@@ -135,17 +140,17 @@ Agents are now derived from [`Agent`][academy.agent.Agent] (previously, `Behavio
 
 Summary:
 
-* `academy.agent.Agent` is renamed [`academy.runtime.Runtime`][academy.runtime.Runtime].
-* `academy.behavior.Behavior` is renamed [`academy.agent.Agent`][academy.agent.Agent].
-* `academy.identifier.ClientId` is renamed [`academy.identifier.UserId`][academy.identifier.UserId].
+- `academy.agent.Agent` is renamed [`academy.runtime.Runtime`][academy.runtime.Runtime].
+- `academy.behavior.Behavior` is renamed [`academy.agent.Agent`][academy.agent.Agent].
+- `academy.identifier.ClientId` is renamed [`academy.identifier.UserId`][academy.identifier.UserId].
 
 ### Changes to agents
 
 All special methods provided by [`Agent`][academy.agent.Agent] are named `agent_.*`.
 For example, the startup and shutdown callbacks have been renamed:
 
-* `Agent.on_setup` is renamed `Agent.agent_on_startup`
-* `Agent.on_shutdown` is renamed `Agent.agent_on_shutdown`
+- `Agent.on_setup` is renamed `Agent.agent_on_startup`
+- `Agent.on_shutdown` is renamed `Agent.agent_on_shutdown`
 
 Runtime context is now available via additional methods.
 
@@ -153,22 +158,22 @@ Runtime context is now available via additional methods.
 
 The `Exchange` and `Mailbox` protocols have been merged into a single [`ExchangeClient`][academy.exchange.ExchangeClient] which comes in two forms:
 
-* [`AgentExchangeClient`][academy.exchange.AgentExchangeClient]
-* [`UserExchangeClient`][academy.exchange.UserExchangeClient]
+- [`AgentExchangeClient`][academy.exchange.AgentExchangeClient]
+- [`UserExchangeClient`][academy.exchange.UserExchangeClient]
 
 Thus, an [`ExchangeClient`][academy.exchange.ExchangeClient] has a 1:1 relationship with the mailbox of a single entity.
 Each [`ExchangeClient`][academy.exchange.ExchangeClient] is initialized using a [`ExchangeTransport`][academy.exchange.transport.ExchangeTransport].
 This protocol defines low-level client interaction with the exchange.
 Some of the exchange operations have have been changed:
 
-* `register_client()` has been removed
-* [`send()`][academy.exchange.transport.ExchangeTransport.send] no longer takes a `dest` parameter
-* [`status()`][academy.exchange.transport.ExchangeTransport.status] has been added
+- `register_client()` has been removed
+- [`send()`][academy.exchange.transport.ExchangeTransport.send] no longer takes a `dest` parameter
+- [`status()`][academy.exchange.transport.ExchangeTransport.status] has been added
 
 Exchange clients are created using a factory pattern:
 
-* [`ExchangeFactory.create_agent_client()`][academy.exchange.ExchangeFactory.create_agent_client]
-* [`ExchangeFactory.create_user_client()`][academy.exchange.ExchangeFactory.create_user_client]
+- [`ExchangeFactory.create_agent_client()`][academy.exchange.ExchangeFactory.create_agent_client]
+- [`ExchangeFactory.create_user_client()`][academy.exchange.ExchangeFactory.create_user_client]
 
 All exchange implementations have been updated to provide a custom transport and factory implementation.
 The "thread" exchange has been renamed to "local" now that Academy is async.
@@ -176,16 +181,16 @@ The "thread" exchange has been renamed to "local" now that Academy is async.
 All exchange related errors derive from [`ExchangeError`][academy.exception.ExchangeError].
 `MailboxClosedError` is renamed [`MailboxTerminatedError`][academy.exception.MailboxTerminatedError] with derived types for [`AgentTerminatedError`][academy.exception.AgentTerminatedError] and [`UserTerminatedError`][academy.exception.UserTerminatedError].
 
-
 ### Changes to the manager and launchers
 
 The `Launcher` protocol and implementations have been removed, with their functionality incorporated directly into the [`Manager`][academy.manager.Manager].
 
 Summary:
 
-* [`Manager`][academy.manager.Manager] is now initialized with one or more [`Executors`][concurrent.futures.Executor].
-* Added the [`Manager.from_exchange_factory()`][academy.manager.Manager.from_exchange_factory] class method.
-* `Manager.set_default_launcher()` and `Manager.add_launcher()` are renamed [`set_default_executor()`][academy.manager.Manager.set_default_executor] and [`add_executor()`][academy.manager.Manager.add_executor], respectively.
-* [`Manager`][academy.manager.Manager] exposes [`get_handle()`][academy.manager.Manager.get_handle] and [`register_agent()`][academy.manager.Manager.register_agent].
-* [`Manager.launch()`][academy.manager.Manager.launch] now optionally takes an [`Agent`][academy.agent.Agent] type and args/kwargs and will defer agent initialization to on worker.
-* [`Manager.wait()`][academy.manager.Manager] now takes an iterable of agent IDs or handles.
+- [`Manager`][academy.manager.Manager] is now initialized with one or more [`Executors`][concurrent.futures.Executor].
+- Added the [`Manager.from_exchange_factory()`][academy.manager.Manager.from_exchange_factory] class method.
+- `Manager.set_default_launcher()` and `Manager.add_launcher()` are renamed [`set_default_executor()`][academy.manager.Manager.set_default_executor] and [`add_executor()`][academy.manager.Manager.add_executor], respectively.
+- [`Manager`][academy.manager.Manager] exposes [`get_handle()`][academy.manager.Manager.get_handle] and [`register_agent()`][academy.manager.Manager.register_agent].
+- [`Manager.launch()`][academy.manager.Manager.launch] now optionally takes an [`Agent`][academy.agent.Agent] type and args/kwargs and will defer agent initialization to on worker.
+- [`Manager.wait()`][academy.manager.Manager] now takes an iterable of agent IDs or handles.
+

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -37,8 +37,8 @@ Batch launch ergonomics for the Globus transport: launches queued inside a `laun
 
 ```python
 async with manager.launch_batch() as batch:
-    greeter = await batch.launch(Greeter)
-    coordinator = await batch.launch(
+    greeter = await batch.queue(Greeter)
+    coordinator = await batch.queue(
         Coordinator,
         args=(greeter,),
     )

--- a/examples/12-globus-exchange/run-12-explicit.py
+++ b/examples/12-globus-exchange/run-12-explicit.py
@@ -1,21 +1,12 @@
-"""Globus exchange example.
+"""Explicit-driving variant of run-12.py.
 
-Uses GlobusExchangeFactory against the hosted exchange at
-exchange.academy-agents.org. Each agent gets its own Globus Auth
-client, credentials, and delegated token.
-
-Agents are launched inside ``async with manager.launch_batch() as
-batch:``, which coalesces all of the per-agent auth flows into a
-single consent prompt. This is ergonomic sugar over the underlying
-``manager.register_agents(...)`` + ``manager.launch(registration=...)``
-pattern, which is still supported for pre-warming or register-elsewhere
-workflows.
+Same scenario, using batch.submit() instead of `async with`.
 
 Requires:
     export ACADEMY_TEST_PROJECT_ID=<project-uuid>
 
 Usage:
-    PYTHONPATH=. python examples/12-globus-exchange/run-12.py
+    PYTHONPATH=. python examples/12-globus-exchange/run-12-explicit.py
 """
 
 from __future__ import annotations
@@ -83,13 +74,18 @@ async def main() -> int:
         factory=factory,
         log_config=recommended_logging(),
     ) as manager:
-        async with manager.launch_batch() as batch:
+        batch = manager.launch_batch()
+        try:
             greeter = await batch.queue(Greeter)
             shouter = await batch.queue(Shouter)
             coordinator = await batch.queue(
                 Coordinator,
                 args=(greeter, shouter),
             )
+            await batch.submit()
+        except Exception:
+            batch.abort()
+            raise
 
         result = await coordinator.greet_loudly('Academy')
         logger.info(f'Result: {result!r}')

--- a/examples/12-globus-exchange/run-12-explicit.py
+++ b/examples/12-globus-exchange/run-12-explicit.py
@@ -75,17 +75,13 @@ async def main() -> int:
         log_config=recommended_logging(),
     ) as manager:
         batch = manager.launch_batch()
-        try:
-            greeter = await batch.queue(Greeter)
-            shouter = await batch.queue(Shouter)
-            coordinator = await batch.queue(
-                Coordinator,
-                args=(greeter, shouter),
-            )
-            await batch.submit()
-        except Exception:
-            batch.abort()
-            raise
+        greeter = await batch.queue(Greeter)
+        shouter = await batch.queue(Shouter)
+        coordinator = await batch.queue(
+            Coordinator,
+            args=(greeter, shouter),
+        )
+        await batch.submit()
 
         result = await coordinator.greet_loudly('Academy')
         logger.info(f'Result: {result!r}')

--- a/examples/12-globus-exchange/run-12.py
+++ b/examples/12-globus-exchange/run-12.py
@@ -4,6 +4,13 @@ Uses GlobusExchangeFactory against the hosted exchange at
 exchange.academy-agents.org. Each agent gets its own Globus Auth
 client, credentials, and delegated token.
 
+Agents are launched inside ``async with manager.launch_batch() as
+batch:``, which coalesces all of the per-agent auth flows into a
+single consent prompt. This is ergonomic sugar over the underlying
+``manager.register_agents(...)`` + ``manager.launch(registration=...)``
+pattern, which is still supported for pre-warming or register-elsewhere
+workflows.
+
 Requires:
     export ACADEMY_TEST_PROJECT_ID=<project-uuid>
 
@@ -17,12 +24,10 @@ import asyncio
 import logging
 import os
 import uuid
-from typing import Any
 
 from academy.agent import action
 from academy.agent import Agent
 from academy.exchange.cloud.globus import GlobusExchangeFactory
-from academy.exchange.transport import AgentRegistration
 from academy.handle import Handle
 from academy.logging.recommended import recommended_logging
 from academy.manager import Manager
@@ -78,21 +83,13 @@ async def main() -> int:
         factory=factory,
         log_config=recommended_logging(),
     ) as manager:
-        regs: list[AgentRegistration[Any]] = await manager.register_agents(
-            [
-                (Greeter, None),
-                (Shouter, None),
-                (Coordinator, None),
-            ],
-        )
-
-        greeter = await manager.launch(Greeter, registration=regs[0])
-        shouter = await manager.launch(Shouter, registration=regs[1])
-        coordinator = await manager.launch(
-            Coordinator,
-            args=(greeter, shouter),
-            registration=regs[2],
-        )
+        async with manager.launch_batch() as batch:
+            greeter = await batch.launch(Greeter)
+            shouter = await batch.launch(Shouter)
+            coordinator = await batch.launch(
+                Coordinator,
+                args=(greeter, shouter),
+            )
 
         result = await coordinator.greet_loudly('Academy')
         logger.info(f'Result: {result!r}')

--- a/tests/unit/exchange/client_test.py
+++ b/tests/unit/exchange/client_test.py
@@ -120,29 +120,30 @@ async def test_register_agents_empty(
 @pytest.mark.asyncio
 async def test_register_agents_fallback_rolls_back(
     client: UserExchangeClient[Any],
-    monkeypatch: pytest.MonkeyPatch,
     caplog: pytest.LogCaptureFixture,
 ) -> None:
-    monkeypatch.delattr(
-        type(client._transport),
-        'register_agents',
-        raising=False,
-    )
-    first = await client.register_agent(EmptyAgent)
-    second = await client.register_agent(EmptyAgent)
+    agent_1 = await client.register_agent(EmptyAgent)
+    agent_2 = await client.register_agent(EmptyAgent)
     register = mock.AsyncMock(
-        side_effect=[first, second, RuntimeError('boom')],
+        side_effect=[agent_1, agent_2, RuntimeError('boom')],
     )
     terminate = mock.AsyncMock(side_effect=[None, RuntimeError('t-fail')])
-    monkeypatch.setattr(client, 'register_agent', register)
-    monkeypatch.setattr(client, 'terminate', terminate)
 
     with (
+        mock.patch.object(
+            type(client._transport),
+            'register_agents',
+            None,
+            create=True,
+        ),
+        mock.patch.object(client, 'register_agent', new=register),
+        mock.patch.object(client, 'terminate', new=terminate),
         caplog.at_level(logging.ERROR, logger='academy.exchange.client'),
         pytest.raises(RuntimeError, match='boom'),
     ):
         await client.register_agents([(EmptyAgent, None)] * 3)
 
+    assert register.await_count == 3  # noqa: PLR2004
     assert terminate.await_count == 2  # noqa: PLR2004
     assert any('Failed to terminate' in r.message for r in caplog.records)
 

--- a/tests/unit/exchange/client_test.py
+++ b/tests/unit/exchange/client_test.py
@@ -115,6 +115,36 @@ async def test_register_agents_empty(
 
 
 @pytest.mark.asyncio
+async def test_register_agents_fallback_rolls_back(
+    client: UserExchangeClient[Any],
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    monkeypatch.delattr(
+        type(client._transport),
+        'register_agents',
+        raising=False,
+    )
+    first = await client.register_agent(EmptyAgent)
+    second = await client.register_agent(EmptyAgent)
+    register = mock.AsyncMock(
+        side_effect=[first, second, RuntimeError('boom')],
+    )
+    terminate = mock.AsyncMock(side_effect=[None, RuntimeError('t-fail')])
+    monkeypatch.setattr(client, 'register_agent', register)
+    monkeypatch.setattr(client, 'terminate', terminate)
+
+    with (
+        caplog.at_level(logging.ERROR, logger='academy.exchange.client'),
+        pytest.raises(RuntimeError, match='boom'),
+    ):
+        await client.register_agents([(EmptyAgent, None)] * 3)
+
+    assert terminate.await_count == 2  # noqa: PLR2004
+    assert any('Failed to terminate' in r.message for r in caplog.records)
+
+
+@pytest.mark.asyncio
 async def test_client_discover(client: UserExchangeClient[Any]) -> None:
     registration = await client.register_agent(EmptyAgent)
     assert await client.discover(EmptyAgent) == (registration.agent_id,)

--- a/tests/unit/exchange/client_test.py
+++ b/tests/unit/exchange/client_test.py
@@ -120,14 +120,19 @@ async def test_register_agents_empty(
 @pytest.mark.asyncio
 async def test_register_agents_fallback_rolls_back(
     client: UserExchangeClient[Any],
-    caplog: pytest.LogCaptureFixture,
 ) -> None:
     agent_1 = await client.register_agent(EmptyAgent)
     agent_2 = await client.register_agent(EmptyAgent)
     register = mock.AsyncMock(
-        side_effect=[agent_1, agent_2, RuntimeError('boom')],
+        side_effect=[
+            agent_1,
+            agent_2,
+            RuntimeError('injected register failure'),
+        ],
     )
-    terminate = mock.AsyncMock(side_effect=[None, RuntimeError('t-fail')])
+    terminate = mock.AsyncMock(
+        side_effect=[None, RuntimeError('injected terminate failure')],
+    )
 
     with (
         mock.patch.object(
@@ -138,14 +143,16 @@ async def test_register_agents_fallback_rolls_back(
         ),
         mock.patch.object(client, 'register_agent', new=register),
         mock.patch.object(client, 'terminate', new=terminate),
-        caplog.at_level(logging.ERROR, logger='academy.exchange.client'),
-        pytest.raises(RuntimeError, match='boom'),
+        pytest.raises(
+            RuntimeError,
+            match='injected terminate failure',
+        ) as exc_info,
     ):
         await client.register_agents([(EmptyAgent, None)] * 3)
 
-    assert register.await_count == 3  # noqa: PLR2004
     assert terminate.await_count == 2  # noqa: PLR2004
-    assert any('Failed to terminate' in r.message for r in caplog.records)
+    assert isinstance(exc_info.value.__context__, RuntimeError)
+    assert 'injected register failure' in str(exc_info.value.__context__)
 
 
 @pytest.mark.asyncio

--- a/tests/unit/handle_test.py
+++ b/tests/unit/handle_test.py
@@ -121,6 +121,12 @@ async def test_agent_handle_serialize(
     assert repr(reconstructed) == repr(handle)
 
 
+def test_handle_pickle_unbound_raises() -> None:
+    handle: Handle[Any] = Handle()
+    with pytest.raises(pickle.PicklingError, match='unbound'):
+        pickle.dumps(handle)
+
+
 @pytest.mark.asyncio
 async def test_agent_handle_context() -> None:
     # We cannot use the fixture here because the fixture will create context

--- a/tests/unit/manager_test.py
+++ b/tests/unit/manager_test.py
@@ -227,7 +227,7 @@ async def test_rebind_handle_rejects_conflicting_cached_handle(
     handle_a = manager.get_handle(aid_a)
     manager.get_handle(aid_b)  # cached under aid_b
     with pytest.raises(
-        RuntimeError,
+        AssertionError,
         match='already holds a different handle',
     ):
         manager._rebind_handle(handle_a, aid_b)
@@ -584,7 +584,7 @@ async def test_launch_batch_rejects_rebind_of_used_handle(
             handle = await batch.launch(EmptyAgent)
             handle._used_for_messaging = True
 
-    with pytest.raises(RuntimeError, match='used for messaging'):
+    with pytest.raises(AssertionError, match='used for messaging'):
         await body()
 
 

--- a/tests/unit/manager_test.py
+++ b/tests/unit/manager_test.py
@@ -3,8 +3,8 @@ from __future__ import annotations
 import asyncio
 import multiprocessing
 import pathlib
+import pickle
 import time
-import uuid
 from collections.abc import Callable
 from concurrent.futures import Future
 from concurrent.futures import ProcessPoolExecutor
@@ -24,7 +24,7 @@ from academy.exchange import HttpExchangeFactory
 from academy.exchange import LocalExchangeFactory
 from academy.exchange import LocalExchangeTransport
 from academy.exchange import UserExchangeClient
-from academy.identifier import AgentId
+from academy.handle import Handle
 from academy.logging.configs.file import FileLogging
 from academy.manager import Manager
 from testing.agents import EmptyAgent
@@ -171,69 +171,6 @@ async def test_register_agents_and_launch(
 
 
 @pytest.mark.asyncio
-async def test_rebind_handle_rekeys_cache(
-    manager: Manager[LocalExchangeTransport],
-) -> None:
-    original_id: AgentId[Any] = AgentId.new()
-    new_id: AgentId[Any] = AgentId.new()
-    handle = manager.get_handle(original_id)
-    assert manager._handles[original_id] is handle
-
-    manager._rebind_handle(handle, new_id)
-
-    assert handle.agent_id == new_id
-    assert original_id not in manager._handles
-    assert manager._handles[new_id] is handle
-
-
-@pytest.mark.asyncio
-async def test_rebind_handle_same_id_is_noop(
-    manager: Manager[LocalExchangeTransport],
-) -> None:
-    agent_id: AgentId[Any] = AgentId.new()
-    handle = manager.get_handle(agent_id)
-
-    manager._rebind_handle(handle, agent_id)
-
-    assert handle.agent_id == agent_id
-    assert manager._handles[agent_id] is handle
-
-
-@pytest.mark.asyncio
-async def test_rebind_handle_equal_but_distinct_id_is_noop(
-    manager: Manager[LocalExchangeTransport],
-) -> None:
-    # Same UUID in two AgentId objects exercises the `==` short-circuit
-    # rather than `is`.
-    shared_uid = uuid.uuid4()
-    aid1: AgentId[Any] = AgentId(uid=shared_uid)
-    aid2: AgentId[Any] = AgentId(uid=shared_uid)
-    assert aid1 == aid2
-    assert aid1 is not aid2
-
-    handle = manager.get_handle(aid1)
-    manager._rebind_handle(handle, aid2)
-
-    assert handle.agent_id == aid1
-    assert manager._handles[aid1] is handle
-
-
-@pytest.mark.asyncio
-async def test_rebind_handle_rejects_conflicting_cached_handle(
-    manager: Manager[LocalExchangeTransport],
-) -> None:
-    aid_a: AgentId[Any] = AgentId.new()
-    aid_b: AgentId[Any] = AgentId.new()
-    handle_a = manager.get_handle(aid_a)
-    manager.get_handle(aid_b)  # cached under aid_b
-    with pytest.raises(
-        AssertionError,
-        match='already holds a different handle',
-    ):
-        manager._rebind_handle(handle_a, aid_b)
-
-
-@pytest.mark.asyncio
 async def test_launch_batch_empty_is_noop(
     manager: Manager[LocalExchangeTransport],
 ) -> None:
@@ -270,13 +207,12 @@ async def test_launch_batch_queues_and_returns_handle(
 ) -> None:
     async with manager.launch_batch() as batch:
         handle = await batch.queue(EmptyAgent)
-        pre_submit_id = handle.agent_id
-        assert manager._handles[pre_submit_id] is handle
+        with pytest.raises(RuntimeError, match='not bound'):
+            _ = handle.agent_id
         assert len(batch._intents) == 1
         intent = batch._intents[0]
         assert intent.agent is EmptyAgent
         assert intent.handle is handle
-    # Same handle object is cached under the post-submit id.
     assert manager._handles[handle.agent_id] is handle
 
 
@@ -286,8 +222,8 @@ async def test_launch_batch_name_flows_into_agent_id(
 ) -> None:
     async with manager.launch_batch() as batch:
         handle = await batch.queue(EmptyAgent, name='worker-1')
-        assert handle.agent_id.name == 'worker-1'
         assert batch._intents[0].name == 'worker-1'
+    assert handle.agent_id.name == 'worker-1'
 
 
 @pytest.mark.asyncio
@@ -344,44 +280,35 @@ async def test_launch_batch_submits_on_exit(
 
 
 @pytest.mark.asyncio
-async def test_launch_batch_submit_rebinds_handle_ids(
+async def test_launch_batch_submit_binds_handle(
     manager: Manager[LocalExchangeTransport],
 ) -> None:
-    # Local has no transport-level ``register_agents``; the client
-    # falls back to sequential ``register_agent`` which mints a fresh
-    # id. The batch launcher must rebind the pre-minted handle and
-    # re-key ``manager._handles``.
+    # Pre-submit the handle is unbound. Submit registers an agent
+    # and binds the handle to the transport-minted id.
     async with manager.launch_batch() as batch:
         handle = await batch.queue(EmptyAgent)
-        pre_minted_id = handle.agent_id
-        assert manager._handles[pre_minted_id] is handle
-    # After submit, the same Handle object is cached under its
-    # post-submit id, and the placeholder id is gone from the cache.
+        assert handle._agent_id is None
     assert manager._handles[handle.agent_id] is handle
-    assert pre_minted_id not in manager._handles
 
 
 @pytest.mark.asyncio
 async def test_launch_batch_body_exception_skips_submit(
     manager: Manager[LocalExchangeTransport],
 ) -> None:
-    captured: list[Any] = []
+    handles: list[Any] = []
 
     async def body() -> None:
         async with manager.launch_batch() as batch:
-            captured.append(batch)
-            await batch.queue(EmptyAgent)
-            await batch.queue(IdentityAgent)
+            handles.append(await batch.queue(EmptyAgent))
+            handles.append(await batch.queue(IdentityAgent))
             raise ValueError('from body')
 
     with pytest.raises(ValueError, match='from body'):
         await body()
     assert len(manager.running()) == 0
-    # Placeholder handles are evicted so they don't linger pointing at
-    # mailboxes that were never created.
-    batch = captured[0]
-    for intent in batch._intents:
-        assert intent.handle.agent_id not in manager._handles
+    # Body raised before submit; handles were never bound.
+    for handle in handles:
+        assert handle._agent_id is None
 
 
 @pytest.mark.asyncio
@@ -425,14 +352,12 @@ async def test_launch_batch_evicts_on_register_failure(
     failing_register = mock.AsyncMock(
         side_effect=RuntimeError('injected register_agents failure'),
     )
-
-    placeholder_ids: list[Any] = []
+    handles: list[Any] = []
 
     async def body() -> None:
         async with manager.launch_batch() as batch:
-            handle_1 = await batch.queue(EmptyAgent)
-            handle_2 = await batch.queue(EmptyAgent)
-            placeholder_ids.extend([handle_1.agent_id, handle_2.agent_id])
+            handles.append(await batch.queue(EmptyAgent))
+            handles.append(await batch.queue(EmptyAgent))
 
     with (
         mock.patch.object(
@@ -446,8 +371,10 @@ async def test_launch_batch_evicts_on_register_failure(
 
     failing_register.assert_awaited_once()
     assert len(manager.running()) == 0
-    for handle_id in placeholder_ids:
-        assert handle_id not in manager._handles
+    # Register failed before any rebind happened, so the handles
+    # remain unbound and were never inserted into the cache.
+    for handle in handles:
+        assert handle._agent_id is None
 
 
 @pytest.mark.asyncio
@@ -524,12 +451,14 @@ async def test_launch_batch_evicts_on_launch_failure(
 
     assert failing_launch.await_count == 2  # noqa: PLR2004
     running, failed, orphaned = handles
-    # first launch succeeds, id cached
+    # First launch succeeded: bound and cached.
     assert manager._handles.get(running.agent_id) is running
-    # second launch fails and is evicted under its rebound id
-    assert failed.agent_id not in manager._handles
-    # third launch is orphaned and evicted under its placeholder id
-    assert orphaned.agent_id not in manager._handles
+    # Second launch's handle was bound (agent_id was set) but the
+    # launch call failed; the cache entry was popped during rollback.
+    assert failed._agent_id is not None
+    assert failed._agent_id not in manager._handles
+    # Third launch was never reached: the handle is still unbound.
+    assert orphaned._agent_id is None
 
 
 @pytest.mark.asyncio
@@ -572,19 +501,6 @@ async def test_launch_batch_orphan_termination_failure_does_not_mask(
     # Rollback is run once for the orphaned agent left by
     # the failing launch.
     assert failing_terminate.await_count == 1
-
-
-@pytest.mark.asyncio
-async def test_launch_batch_rejects_rebind_of_used_handle(
-    manager: Manager[LocalExchangeTransport],
-) -> None:
-    async def body() -> None:
-        async with manager.launch_batch() as batch:
-            handle = await batch.queue(EmptyAgent)
-            handle._used_for_messaging = True
-
-    with pytest.raises(AssertionError, match='used for messaging'):
-        await body()
 
 
 @pytest.mark.asyncio
@@ -634,18 +550,17 @@ async def test_launch_batch_explicit_submit(
 
 
 @pytest.mark.asyncio
-async def test_launch_batch_abort_evicts_placeholders(
+async def test_launch_batch_abort_discards_intents(
     manager: Manager[LocalExchangeTransport],
 ) -> None:
     batch = manager.launch_batch()
     h1 = await batch.queue(EmptyAgent)
     h2 = await batch.queue(EmptyAgent)
-    placeholder_ids = [h1.agent_id, h2.agent_id]
     batch.abort()
 
     assert len(manager.running()) == 0
-    for pid in placeholder_ids:
-        assert pid not in manager._handles
+    assert h1._agent_id is None
+    assert h2._agent_id is None
 
 
 @pytest.mark.asyncio
@@ -657,6 +572,32 @@ async def test_launch_batch_submit_after_close_raises(
     await batch.submit()
     with pytest.raises(RuntimeError, match='batch is closed'):
         await batch.submit()
+
+
+@pytest.mark.asyncio
+async def test_launch_batch_aexit_skips_after_explicit_submit(
+    manager: Manager[LocalExchangeTransport],
+) -> None:
+    async with manager.launch_batch() as batch:
+        handle = await batch.queue(EmptyAgent)
+        await batch.submit()
+    assert manager._handles[handle.agent_id] is handle
+
+
+@pytest.mark.asyncio
+async def test_launch_batch_abort_is_idempotent(
+    manager: Manager[LocalExchangeTransport],
+) -> None:
+    batch = manager.launch_batch()
+    await batch.queue(EmptyAgent)
+    batch.abort()
+    batch.abort()
+
+
+def test_handle_pickle_unbound_raises() -> None:
+    handle: Handle[Any] = Handle()
+    with pytest.raises(pickle.PicklingError, match='unbound'):
+        pickle.dumps(handle)
 
 
 @pytest.mark.asyncio

--- a/tests/unit/manager_test.py
+++ b/tests/unit/manager_test.py
@@ -434,15 +434,20 @@ async def test_launch_batch_register_agents_failure_skips_launches(
         failing_register,
     )
 
+    placeholder_ids: list[Any] = []
+
     async def body() -> None:
         async with manager.launch_batch() as batch:
-            await batch.launch(EmptyAgent)
-            await batch.launch(EmptyAgent)
+            h1 = await batch.launch(EmptyAgent)
+            h2 = await batch.launch(EmptyAgent)
+            placeholder_ids.extend([h1.agent_id, h2.agent_id])
 
     with pytest.raises(RuntimeError, match='injected register_agents'):
         await body()
 
     assert len(manager.running()) == 0
+    for pid in placeholder_ids:
+        assert pid not in manager._handles
 
 
 @pytest.mark.asyncio

--- a/tests/unit/manager_test.py
+++ b/tests/unit/manager_test.py
@@ -250,7 +250,7 @@ async def test_launch_batch_launch_after_close_raises(
     async with batch:
         pass
     with pytest.raises(RuntimeError, match='batch is closed'):
-        await batch.launch(EmptyAgent)
+        await batch.queue(EmptyAgent)
 
 
 @pytest.mark.asyncio
@@ -259,7 +259,7 @@ async def test_launch_batch_accepts_instance(
 ) -> None:
     instance = EmptyAgent()
     async with manager.launch_batch() as batch:
-        handle = await batch.launch(instance)
+        handle = await batch.queue(instance)
         assert batch._intents[0].agent is instance
     assert handle.agent_id in manager.running()
 
@@ -269,14 +269,14 @@ async def test_launch_batch_queues_and_returns_handle(
     manager: Manager[LocalExchangeTransport],
 ) -> None:
     async with manager.launch_batch() as batch:
-        handle = await batch.launch(EmptyAgent)
-        pre_commit_id = handle.agent_id
-        assert manager._handles[pre_commit_id] is handle
+        handle = await batch.queue(EmptyAgent)
+        pre_submit_id = handle.agent_id
+        assert manager._handles[pre_submit_id] is handle
         assert len(batch._intents) == 1
         intent = batch._intents[0]
         assert intent.agent is EmptyAgent
         assert intent.handle is handle
-    # Same handle object is cached under the post-commit id.
+    # Same handle object is cached under the post-submit id.
     assert manager._handles[handle.agent_id] is handle
 
 
@@ -285,7 +285,7 @@ async def test_launch_batch_name_flows_into_agent_id(
     manager: Manager[LocalExchangeTransport],
 ) -> None:
     async with manager.launch_batch() as batch:
-        handle = await batch.launch(EmptyAgent, name='worker-1')
+        handle = await batch.queue(EmptyAgent, name='worker-1')
         assert handle.agent_id.name == 'worker-1'
         assert batch._intents[0].name == 'worker-1'
 
@@ -295,9 +295,9 @@ async def test_launch_batch_multiple_launches_preserve_order(
     manager: Manager[LocalExchangeTransport],
 ) -> None:
     async with manager.launch_batch() as batch:
-        h1 = await batch.launch(EmptyAgent, name='a')
-        h2 = await batch.launch(IdentityAgent, name='b')
-        h3 = await batch.launch(EmptyAgent, name='c')
+        h1 = await batch.queue(EmptyAgent, name='a')
+        h2 = await batch.queue(IdentityAgent, name='b')
+        h3 = await batch.queue(EmptyAgent, name='c')
         assert batch._intents[0].agent is EmptyAgent
         assert batch._intents[1].agent is IdentityAgent
         assert batch._intents[2].agent is EmptyAgent
@@ -313,14 +313,14 @@ async def test_launch_batch_handle_usable_as_sibling_arg(
     manager: Manager[LocalExchangeTransport],
 ) -> None:
     async with manager.launch_batch() as batch:
-        parent = await batch.launch(EmptyAgent)
-        await batch.launch(
+        parent = await batch.queue(EmptyAgent)
+        await batch.queue(
             _FlexAgent,
             args=(parent,),
             kwargs={'peer': parent},
         )
         # Sibling intent captures the parent handle by reference so
-        # that commit-time rebinding is visible to siblings.
+        # that submit-time rebinding is visible to siblings.
         sibling_intent = batch._intents[1]
         assert sibling_intent.args is not None
         assert sibling_intent.kwargs is not None
@@ -329,12 +329,12 @@ async def test_launch_batch_handle_usable_as_sibling_arg(
 
 
 @pytest.mark.asyncio
-async def test_launch_batch_commits_on_exit(
+async def test_launch_batch_submits_on_exit(
     manager: Manager[LocalExchangeTransport],
 ) -> None:
     async with manager.launch_batch() as batch:
-        h1 = await batch.launch(EmptyAgent)
-        h2 = await batch.launch(IdentityAgent)
+        h1 = await batch.queue(EmptyAgent)
+        h2 = await batch.queue(IdentityAgent)
     assert len(manager.running()) == 2  # noqa: PLR2004
     assert manager._handles[h1.agent_id] is h1
     assert manager._handles[h2.agent_id] is h2
@@ -344,7 +344,7 @@ async def test_launch_batch_commits_on_exit(
 
 
 @pytest.mark.asyncio
-async def test_launch_batch_commit_rebinds_handle_ids(
+async def test_launch_batch_submit_rebinds_handle_ids(
     manager: Manager[LocalExchangeTransport],
 ) -> None:
     # Local has no transport-level ``register_agents``; the client
@@ -352,17 +352,17 @@ async def test_launch_batch_commit_rebinds_handle_ids(
     # id. The batch launcher must rebind the pre-minted handle and
     # re-key ``manager._handles``.
     async with manager.launch_batch() as batch:
-        handle = await batch.launch(EmptyAgent)
+        handle = await batch.queue(EmptyAgent)
         pre_minted_id = handle.agent_id
         assert manager._handles[pre_minted_id] is handle
-    # After commit, the same Handle object is cached under its
-    # post-commit id, and the placeholder id is gone from the cache.
+    # After submit, the same Handle object is cached under its
+    # post-submit id, and the placeholder id is gone from the cache.
     assert manager._handles[handle.agent_id] is handle
     assert pre_minted_id not in manager._handles
 
 
 @pytest.mark.asyncio
-async def test_launch_batch_body_exception_skips_commit(
+async def test_launch_batch_body_exception_skips_submit(
     manager: Manager[LocalExchangeTransport],
 ) -> None:
     captured: list[Any] = []
@@ -370,8 +370,8 @@ async def test_launch_batch_body_exception_skips_commit(
     async def body() -> None:
         async with manager.launch_batch() as batch:
             captured.append(batch)
-            await batch.launch(EmptyAgent)
-            await batch.launch(IdentityAgent)
+            await batch.queue(EmptyAgent)
+            await batch.queue(IdentityAgent)
             raise ValueError('from body')
 
     with pytest.raises(ValueError, match='from body'):
@@ -399,13 +399,13 @@ async def test_launch_batch_empty_body_does_not_call_register_agents(
 
 
 @pytest.mark.asyncio
-async def test_launch_batch_sibling_handle_resolved_after_commit(
+async def test_launch_batch_sibling_handle_resolved_after_submit(
     manager: Manager[LocalExchangeTransport],
 ) -> None:
     captured_sibling_args: list[Any] = []
     async with manager.launch_batch() as batch:
-        parent = await batch.launch(EmptyAgent)
-        await batch.launch(_FlexAgent, args=(parent,))
+        parent = await batch.queue(EmptyAgent)
+        await batch.queue(_FlexAgent, args=(parent,))
         sibling_args = batch._intents[1].args
         assert sibling_args is not None
         captured_sibling_args.append(sibling_args)
@@ -430,8 +430,8 @@ async def test_launch_batch_evicts_on_register_failure(
 
     async def body() -> None:
         async with manager.launch_batch() as batch:
-            handle_1 = await batch.launch(EmptyAgent)
-            handle_2 = await batch.launch(EmptyAgent)
+            handle_1 = await batch.queue(EmptyAgent)
+            handle_2 = await batch.queue(EmptyAgent)
             placeholder_ids.extend([handle_1.agent_id, handle_2.agent_id])
 
     with (
@@ -470,9 +470,9 @@ async def test_launch_batch_terminates_on_launch_failure(
 
     async def body() -> None:
         async with manager.launch_batch() as batch:
-            await batch.launch(EmptyAgent)  # Launches
-            await batch.launch(EmptyAgent)  # Fails to launch
-            await batch.launch(EmptyAgent)  # Orphaned
+            await batch.queue(EmptyAgent)  # Launches
+            await batch.queue(EmptyAgent)  # Fails to launch
+            await batch.queue(EmptyAgent)  # Orphaned
 
     with (
         mock.patch.object(manager, 'launch', new=failing_launch),
@@ -512,9 +512,9 @@ async def test_launch_batch_evicts_on_launch_failure(
 
     async def body() -> None:
         async with manager.launch_batch() as batch:
-            handles.append(await batch.launch(EmptyAgent))  # Launches
-            handles.append(await batch.launch(EmptyAgent))  # Fails to launch
-            handles.append(await batch.launch(EmptyAgent))  # Orphaned
+            handles.append(await batch.queue(EmptyAgent))  # Launches
+            handles.append(await batch.queue(EmptyAgent))  # Fails to launch
+            handles.append(await batch.queue(EmptyAgent))  # Orphaned
 
     with (
         mock.patch.object(manager, 'launch', new=failing_launch),
@@ -552,8 +552,8 @@ async def test_launch_batch_orphan_termination_failure_does_not_mask(
 
     async def body() -> None:
         async with manager.launch_batch() as batch:
-            await batch.launch(EmptyAgent)
-            await batch.launch(EmptyAgent)
+            await batch.queue(EmptyAgent)
+            await batch.queue(EmptyAgent)
 
     with (
         mock.patch.object(manager, 'launch', new=failing_launch),
@@ -580,7 +580,7 @@ async def test_launch_batch_rejects_rebind_of_used_handle(
 ) -> None:
     async def body() -> None:
         async with manager.launch_batch() as batch:
-            handle = await batch.launch(EmptyAgent)
+            handle = await batch.queue(EmptyAgent)
             handle._used_for_messaging = True
 
     with pytest.raises(AssertionError, match='used for messaging'):
@@ -606,8 +606,8 @@ async def test_launch_batch_propagates_cancellation(
 
     async def body() -> None:
         async with manager.launch_batch() as batch:
-            await batch.launch(EmptyAgent)
-            await batch.launch(EmptyAgent)
+            await batch.queue(EmptyAgent)
+            await batch.queue(EmptyAgent)
 
     with (
         mock.patch.object(manager, 'launch', new=launch_then_cancel),
@@ -621,13 +621,52 @@ async def test_launch_batch_propagates_cancellation(
 
 
 @pytest.mark.asyncio
+async def test_launch_batch_explicit_submit(
+    manager: Manager[LocalExchangeTransport],
+) -> None:
+    batch = manager.launch_batch()
+    h1 = await batch.queue(EmptyAgent)
+    h2 = await batch.queue(EmptyAgent)
+    await batch.submit()
+
+    assert h1.agent_id in manager.running()
+    assert h2.agent_id in manager.running()
+
+
+@pytest.mark.asyncio
+async def test_launch_batch_abort_evicts_placeholders(
+    manager: Manager[LocalExchangeTransport],
+) -> None:
+    batch = manager.launch_batch()
+    h1 = await batch.queue(EmptyAgent)
+    h2 = await batch.queue(EmptyAgent)
+    placeholder_ids = [h1.agent_id, h2.agent_id]
+    batch.abort()
+
+    assert len(manager.running()) == 0
+    for pid in placeholder_ids:
+        assert pid not in manager._handles
+
+
+@pytest.mark.asyncio
+async def test_launch_batch_submit_after_close_raises(
+    manager: Manager[LocalExchangeTransport],
+) -> None:
+    batch = manager.launch_batch()
+    await batch.queue(EmptyAgent)
+    await batch.submit()
+    with pytest.raises(RuntimeError, match='batch is closed'):
+        await batch.submit()
+
+
+@pytest.mark.asyncio
 async def test_launch_batch_fan_out_sibling_handle(
     manager: Manager[LocalExchangeTransport],
 ) -> None:
     async with manager.launch_batch() as batch:
-        parent = await batch.launch(EmptyAgent)
-        await batch.launch(_FlexAgent, args=(parent,))
-        await batch.launch(_FlexAgent, kwargs={'peer': parent})
+        parent = await batch.queue(EmptyAgent)
+        await batch.queue(_FlexAgent, args=(parent,))
+        await batch.queue(_FlexAgent, kwargs={'peer': parent})
     running = manager.running()
     assert len(running) == 3  # noqa: PLR2004
     assert parent.agent_id in running
@@ -640,9 +679,9 @@ async def test_launch_batch_diamond_sibling_handles(
 ) -> None:
     captured: list[Any] = []
     async with manager.launch_batch() as batch:
-        parent_a = await batch.launch(EmptyAgent, name='a')
-        parent_b = await batch.launch(EmptyAgent, name='b')
-        await batch.launch(
+        parent_a = await batch.queue(EmptyAgent, name='a')
+        parent_b = await batch.queue(EmptyAgent, name='b')
+        await batch.queue(
             _FlexAgent,
             args=(parent_a, parent_b),
         )

--- a/tests/unit/manager_test.py
+++ b/tests/unit/manager_test.py
@@ -419,151 +419,135 @@ async def test_launch_batch_sibling_handle_resolved_after_commit(
 
 
 @pytest.mark.asyncio
-async def test_launch_batch_register_agents_failure_skips_launches(
+async def test_launch_batch_evicts_on_register_failure(
     manager: Manager[LocalExchangeTransport],
-    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    async def failing_register(
-        agents: Any,
-    ) -> Any:
-        raise RuntimeError('injected register_agents failure')
-
-    monkeypatch.setattr(
-        manager.exchange_client,
-        'register_agents',
-        failing_register,
+    failing_register = mock.AsyncMock(
+        side_effect=RuntimeError('injected register_agents failure'),
     )
 
     placeholder_ids: list[Any] = []
 
     async def body() -> None:
         async with manager.launch_batch() as batch:
-            h1 = await batch.launch(EmptyAgent)
-            h2 = await batch.launch(EmptyAgent)
-            placeholder_ids.extend([h1.agent_id, h2.agent_id])
+            handle_1 = await batch.launch(EmptyAgent)
+            handle_2 = await batch.launch(EmptyAgent)
+            placeholder_ids.extend([handle_1.agent_id, handle_2.agent_id])
 
-    with pytest.raises(RuntimeError, match='injected register_agents'):
+    with (
+        mock.patch.object(
+            manager.exchange_client,
+            'register_agents',
+            new=failing_register,
+        ),
+        pytest.raises(RuntimeError, match='injected register_agents failure'),
+    ):
         await body()
 
+    failing_register.assert_awaited_once()
     assert len(manager.running()) == 0
-    for pid in placeholder_ids:
-        assert pid not in manager._handles
+    for handle_id in placeholder_ids:
+        assert handle_id not in manager._handles
 
 
 @pytest.mark.asyncio
-async def test_launch_batch_launch_failure_terminates_orphans(
+async def test_launch_batch_terminates_on_launch_failure(
     manager: Manager[LocalExchangeTransport],
-    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     original_launch = manager.launch
     launch_calls: dict[str, int] = {'n': 0}
 
-    async def failing_launch(
-        *args: Any,
-        **kwargs: Any,
-    ) -> Any:
+    async def _failing_launch(*args: Any, **kwargs: Any) -> Any:
         launch_calls['n'] += 1
         if launch_calls['n'] == 2:  # noqa: PLR2004
             raise RuntimeError('injected launch failure')
         return await original_launch(*args, **kwargs)
 
-    monkeypatch.setattr(manager, 'launch', failing_launch)
-
-    original_terminate = manager.exchange_client.terminate
-    terminated: list[Any] = []
-
-    async def wrapped_terminate(agent_id: Any) -> None:
-        terminated.append(agent_id)
-        await original_terminate(agent_id)
-
-    monkeypatch.setattr(
-        manager.exchange_client,
-        'terminate',
-        wrapped_terminate,
+    failing_launch = mock.AsyncMock(side_effect=_failing_launch)
+    wrapped_terminate = mock.AsyncMock(
+        wraps=manager.exchange_client.terminate,
     )
 
     async def body() -> None:
         async with manager.launch_batch() as batch:
-            await batch.launch(EmptyAgent)  # intent 0 — launches
-            await batch.launch(EmptyAgent)  # intent 1 — launch fails
-            await batch.launch(EmptyAgent)  # intent 2 — orphaned
+            await batch.launch(EmptyAgent)  # Launches
+            await batch.launch(EmptyAgent)  # Fails to launch
+            await batch.launch(EmptyAgent)  # Orphaned
 
-    with pytest.raises(RuntimeError, match='injected launch failure'):
+    with (
+        mock.patch.object(manager, 'launch', new=failing_launch),
+        mock.patch.object(
+            manager.exchange_client,
+            'terminate',
+            new=wrapped_terminate,
+        ),
+        pytest.raises(RuntimeError, match='injected launch failure'),
+    ):
         await body()
 
-    # Intent 0's agent is still running; intents 1 and 2 were
-    # registered but never successfully launched, so they are
-    # terminated via exchange_client.terminate.
+    # First launch succeeds
+    # Second launch fails to launch
+    # Third launch is orphaned
+    assert failing_launch.await_count == 2  # noqa: PLR2004
+    assert wrapped_terminate.await_count == 2  # noqa: PLR2004
     assert len(manager.running()) == 1
-    assert len(terminated) == 2  # noqa: PLR2004
 
 
 @pytest.mark.asyncio
-async def test_launch_batch_launch_failure_evicts_stale_handles(
+async def test_launch_batch_evicts_on_launch_failure(
     manager: Manager[LocalExchangeTransport],
-    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     original_launch = manager.launch
     launch_calls: dict[str, int] = {'n': 0}
 
-    async def failing_launch(
-        *args: Any,
-        **kwargs: Any,
-    ) -> Any:
+    async def _failing_launch(*args: Any, **kwargs: Any) -> Any:
         launch_calls['n'] += 1
         if launch_calls['n'] == 2:  # noqa: PLR2004
             raise RuntimeError('injected launch failure')
         return await original_launch(*args, **kwargs)
 
-    monkeypatch.setattr(manager, 'launch', failing_launch)
+    failing_launch = mock.AsyncMock(side_effect=_failing_launch)
 
     handles: list[Any] = []
 
     async def body() -> None:
         async with manager.launch_batch() as batch:
-            handles.append(await batch.launch(EmptyAgent))
-            handles.append(await batch.launch(EmptyAgent))
-            handles.append(await batch.launch(EmptyAgent))
+            handles.append(await batch.launch(EmptyAgent))  # Launches
+            handles.append(await batch.launch(EmptyAgent))  # Fails to launch
+            handles.append(await batch.launch(EmptyAgent))  # Orphaned
 
-    with pytest.raises(RuntimeError, match='injected launch failure'):
+    with (
+        mock.patch.object(manager, 'launch', new=failing_launch),
+        pytest.raises(RuntimeError, match='injected launch failure'),
+    ):
         await body()
 
-    running_handle, orphan_rebound, orphan_placeholder = handles
-    # Intent 0 launched successfully: handle stays cached.
-    assert manager._handles.get(running_handle.agent_id) is running_handle
-    # Intent 1 rebound but then the launch failed: evicted under its
-    # rebound (real) id.
-    assert orphan_rebound.agent_id not in manager._handles
-    # Intent 2 never reached the loop: evicted under its placeholder id.
-    assert orphan_placeholder.agent_id not in manager._handles
+    assert failing_launch.await_count == 2  # noqa: PLR2004
+    running, failed, orphaned = handles
+    # first launch succeeds, id cached
+    assert manager._handles.get(running.agent_id) is running
+    # second launch fails and is evicted under its rebound id
+    assert failed.agent_id not in manager._handles
+    # third launch is orphaned and evicted under its placeholder id
+    assert orphaned.agent_id not in manager._handles
 
 
 @pytest.mark.asyncio
 async def test_launch_batch_orphan_termination_failure_does_not_mask(
     manager: Manager[LocalExchangeTransport],
-    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     # The original launch exception must surface even when orphan
     # cleanup raises.
     original_launch = manager.launch
 
-    async def failing_launch(
-        *args: Any,
-        **kwargs: Any,
-    ) -> Any:
+    async def _failing_launch(*args: Any, **kwargs: Any) -> Any:
         if not manager.running():
             return await original_launch(*args, **kwargs)
         raise RuntimeError('injected launch failure')
 
-    monkeypatch.setattr(manager, 'launch', failing_launch)
-
-    async def failing_terminate(agent_id: Any) -> None:
-        raise RuntimeError('injected terminate failure')
-
-    monkeypatch.setattr(
-        manager.exchange_client,
-        'terminate',
-        failing_terminate,
+    failing_launch = mock.AsyncMock(side_effect=_failing_launch)
+    failing_terminate = mock.AsyncMock(
+        side_effect=RuntimeError('injected terminate failure'),
     )
 
     async def body() -> None:
@@ -571,8 +555,23 @@ async def test_launch_batch_orphan_termination_failure_does_not_mask(
             await batch.launch(EmptyAgent)
             await batch.launch(EmptyAgent)
 
-    with pytest.raises(RuntimeError, match='injected launch failure'):
+    with (
+        mock.patch.object(manager, 'launch', new=failing_launch),
+        mock.patch.object(
+            manager.exchange_client,
+            'terminate',
+            new=failing_terminate,
+        ),
+        pytest.raises(RuntimeError, match='injected launch failure'),
+    ):
         await body()
+
+    # intent to launch first agent succeeds
+    # intent to launch second agent fails to launch
+    assert failing_launch.await_count == 2  # noqa: PLR2004
+    # Rollback is run once for the orphaned agent left by
+    # the failing launch.
+    assert failing_terminate.await_count == 1
 
 
 @pytest.mark.asyncio
@@ -589,31 +588,36 @@ async def test_launch_batch_rejects_rebind_of_used_handle(
 
 
 @pytest.mark.asyncio
-async def test_launch_batch_mid_commit_cancellation_propagates(
+async def test_launch_batch_propagates_cancellation(
     manager: Manager[LocalExchangeTransport],
-    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    # Un-launched registrations leak exchange-side on cancellation —
-    # documented limitation, not asserted against here.
+    # Un-launched registrations leak exchange-side on cancellation.
+    # This is expected & not asserted against here.
     original_launch = manager.launch
     first_call = {'seen': False}
 
-    async def launch_then_cancel(*args: Any, **kwargs: Any) -> Any:
+    async def _launch_then_cancel(*args: Any, **kwargs: Any) -> Any:
         if not first_call['seen']:
             first_call['seen'] = True
             return await original_launch(*args, **kwargs)
         raise asyncio.CancelledError
 
-    monkeypatch.setattr(manager, 'launch', launch_then_cancel)
+    launch_then_cancel = mock.AsyncMock(side_effect=_launch_then_cancel)
 
     async def body() -> None:
         async with manager.launch_batch() as batch:
             await batch.launch(EmptyAgent)
             await batch.launch(EmptyAgent)
 
-    with pytest.raises(asyncio.CancelledError):
+    with (
+        mock.patch.object(manager, 'launch', new=launch_then_cancel),
+        pytest.raises(asyncio.CancelledError),
+    ):
         await body()
-    assert len(manager.running()) == 1
+
+    # The first launch intent launched. Second intent was
+    # cancelled before it could be launched.
+    assert launch_then_cancel.await_count == 2  # noqa: PLR2004
 
 
 @pytest.mark.asyncio

--- a/tests/unit/manager_test.py
+++ b/tests/unit/manager_test.py
@@ -4,12 +4,14 @@ import asyncio
 import multiprocessing
 import pathlib
 import time
+import uuid
 from collections.abc import Callable
 from concurrent.futures import Future
 from concurrent.futures import ProcessPoolExecutor
 from concurrent.futures import ThreadPoolExecutor
 from typing import Any
 from typing import ParamSpec
+from unittest import mock
 
 import pytest
 
@@ -22,6 +24,7 @@ from academy.exchange import HttpExchangeFactory
 from academy.exchange import LocalExchangeFactory
 from academy.exchange import LocalExchangeTransport
 from academy.exchange import UserExchangeClient
+from academy.identifier import AgentId
 from academy.logging.configs.file import FileLogging
 from academy.manager import Manager
 from testing.agents import EmptyAgent
@@ -32,6 +35,11 @@ from testing.constant import TEST_SLEEP_INTERVAL
 from testing.constant import TEST_WAIT_TIMEOUT
 
 P = ParamSpec('P')
+
+
+class _FlexAgent(Agent):
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        super().__init__()
 
 
 @pytest.mark.asyncio
@@ -160,6 +168,483 @@ async def test_register_agents_and_launch(
         registration=registrations[1],
     )
     assert len(manager.running()) == 2  # noqa: PLR2004
+
+
+@pytest.mark.asyncio
+async def test_rebind_handle_rekeys_cache(
+    manager: Manager[LocalExchangeTransport],
+) -> None:
+    original_id: AgentId[Any] = AgentId.new()
+    new_id: AgentId[Any] = AgentId.new()
+    handle = manager.get_handle(original_id)
+    assert manager._handles[original_id] is handle
+
+    manager._rebind_handle(handle, new_id)
+
+    assert handle.agent_id == new_id
+    assert original_id not in manager._handles
+    assert manager._handles[new_id] is handle
+
+
+@pytest.mark.asyncio
+async def test_rebind_handle_same_id_is_noop(
+    manager: Manager[LocalExchangeTransport],
+) -> None:
+    agent_id: AgentId[Any] = AgentId.new()
+    handle = manager.get_handle(agent_id)
+
+    manager._rebind_handle(handle, agent_id)
+
+    assert handle.agent_id == agent_id
+    assert manager._handles[agent_id] is handle
+
+
+@pytest.mark.asyncio
+async def test_rebind_handle_equal_but_distinct_id_is_noop(
+    manager: Manager[LocalExchangeTransport],
+) -> None:
+    # Same UUID in two AgentId objects exercises the `==` short-circuit
+    # rather than `is`.
+    shared_uid = uuid.uuid4()
+    aid1: AgentId[Any] = AgentId(uid=shared_uid)
+    aid2: AgentId[Any] = AgentId(uid=shared_uid)
+    assert aid1 == aid2
+    assert aid1 is not aid2
+
+    handle = manager.get_handle(aid1)
+    manager._rebind_handle(handle, aid2)
+
+    assert handle.agent_id == aid1
+    assert manager._handles[aid1] is handle
+
+
+@pytest.mark.asyncio
+async def test_rebind_handle_rejects_conflicting_cached_handle(
+    manager: Manager[LocalExchangeTransport],
+) -> None:
+    aid_a: AgentId[Any] = AgentId.new()
+    aid_b: AgentId[Any] = AgentId.new()
+    handle_a = manager.get_handle(aid_a)
+    manager.get_handle(aid_b)  # cached under aid_b
+    with pytest.raises(
+        RuntimeError,
+        match='already holds a different handle',
+    ):
+        manager._rebind_handle(handle_a, aid_b)
+
+
+@pytest.mark.asyncio
+async def test_launch_batch_empty_is_noop(
+    manager: Manager[LocalExchangeTransport],
+) -> None:
+    async with manager.launch_batch():
+        pass
+    assert len(manager.running()) == 0
+
+
+@pytest.mark.asyncio
+async def test_launch_batch_launch_after_close_raises(
+    manager: Manager[LocalExchangeTransport],
+) -> None:
+    batch = manager.launch_batch()
+    async with batch:
+        pass
+    with pytest.raises(RuntimeError, match='batch is closed'):
+        await batch.launch(EmptyAgent)
+
+
+@pytest.mark.asyncio
+async def test_launch_batch_accepts_instance(
+    manager: Manager[LocalExchangeTransport],
+) -> None:
+    instance = EmptyAgent()
+    async with manager.launch_batch() as batch:
+        handle = await batch.launch(instance)
+        assert batch._intents[0].agent is instance
+    assert handle.agent_id in manager.running()
+
+
+@pytest.mark.asyncio
+async def test_launch_batch_queues_and_returns_handle(
+    manager: Manager[LocalExchangeTransport],
+) -> None:
+    async with manager.launch_batch() as batch:
+        handle = await batch.launch(EmptyAgent)
+        pre_commit_id = handle.agent_id
+        assert manager._handles[pre_commit_id] is handle
+        assert len(batch._intents) == 1
+        intent = batch._intents[0]
+        assert intent.agent is EmptyAgent
+        assert intent.handle is handle
+    # Same handle object is cached under the post-commit id.
+    assert manager._handles[handle.agent_id] is handle
+
+
+@pytest.mark.asyncio
+async def test_launch_batch_name_flows_into_agent_id(
+    manager: Manager[LocalExchangeTransport],
+) -> None:
+    async with manager.launch_batch() as batch:
+        handle = await batch.launch(EmptyAgent, name='worker-1')
+        assert handle.agent_id.name == 'worker-1'
+        assert batch._intents[0].name == 'worker-1'
+
+
+@pytest.mark.asyncio
+async def test_launch_batch_multiple_launches_preserve_order(
+    manager: Manager[LocalExchangeTransport],
+) -> None:
+    async with manager.launch_batch() as batch:
+        h1 = await batch.launch(EmptyAgent, name='a')
+        h2 = await batch.launch(IdentityAgent, name='b')
+        h3 = await batch.launch(EmptyAgent, name='c')
+        assert batch._intents[0].agent is EmptyAgent
+        assert batch._intents[1].agent is IdentityAgent
+        assert batch._intents[2].agent is EmptyAgent
+        assert batch._intents[0].name == 'a'
+        assert batch._intents[1].name == 'b'
+        assert batch._intents[2].name == 'c'
+    ids = {h1.agent_id, h2.agent_id, h3.agent_id}
+    assert len(ids) == 3  # noqa: PLR2004
+
+
+@pytest.mark.asyncio
+async def test_launch_batch_handle_usable_as_sibling_arg(
+    manager: Manager[LocalExchangeTransport],
+) -> None:
+    async with manager.launch_batch() as batch:
+        parent = await batch.launch(EmptyAgent)
+        await batch.launch(
+            _FlexAgent,
+            args=(parent,),
+            kwargs={'peer': parent},
+        )
+        # Sibling intent captures the parent handle by reference so
+        # that commit-time rebinding is visible to siblings.
+        sibling_intent = batch._intents[1]
+        assert sibling_intent.args is not None
+        assert sibling_intent.kwargs is not None
+        assert sibling_intent.args[0] is parent
+        assert sibling_intent.kwargs['peer'] is parent
+
+
+@pytest.mark.asyncio
+async def test_launch_batch_commits_on_exit(
+    manager: Manager[LocalExchangeTransport],
+) -> None:
+    async with manager.launch_batch() as batch:
+        h1 = await batch.launch(EmptyAgent)
+        h2 = await batch.launch(IdentityAgent)
+    assert len(manager.running()) == 2  # noqa: PLR2004
+    assert manager._handles[h1.agent_id] is h1
+    assert manager._handles[h2.agent_id] is h2
+    running_ids = manager.running()
+    assert h1.agent_id in running_ids
+    assert h2.agent_id in running_ids
+
+
+@pytest.mark.asyncio
+async def test_launch_batch_commit_rebinds_handle_ids(
+    manager: Manager[LocalExchangeTransport],
+) -> None:
+    # Local has no transport-level ``register_agents``; the client
+    # falls back to sequential ``register_agent`` which mints a fresh
+    # id. The batch launcher must rebind the pre-minted handle and
+    # re-key ``manager._handles``.
+    async with manager.launch_batch() as batch:
+        handle = await batch.launch(EmptyAgent)
+        pre_minted_id = handle.agent_id
+        assert manager._handles[pre_minted_id] is handle
+    # After commit, the same Handle object is cached under its
+    # post-commit id, and the placeholder id is gone from the cache.
+    assert manager._handles[handle.agent_id] is handle
+    assert pre_minted_id not in manager._handles
+
+
+@pytest.mark.asyncio
+async def test_launch_batch_body_exception_skips_commit(
+    manager: Manager[LocalExchangeTransport],
+) -> None:
+    captured: list[Any] = []
+
+    async def body() -> None:
+        async with manager.launch_batch() as batch:
+            captured.append(batch)
+            await batch.launch(EmptyAgent)
+            await batch.launch(IdentityAgent)
+            raise ValueError('from body')
+
+    with pytest.raises(ValueError, match='from body'):
+        await body()
+    assert len(manager.running()) == 0
+    # Placeholder handles are evicted so they don't linger pointing at
+    # mailboxes that were never created.
+    batch = captured[0]
+    for intent in batch._intents:
+        assert intent.handle.agent_id not in manager._handles
+
+
+@pytest.mark.asyncio
+async def test_launch_batch_empty_body_does_not_call_register_agents(
+    manager: Manager[LocalExchangeTransport],
+) -> None:
+    with mock.patch.object(
+        manager.exchange_client,
+        'register_agents',
+        new_callable=mock.AsyncMock,
+    ) as register_agents:
+        async with manager.launch_batch():
+            pass
+    assert register_agents.call_count == 0
+
+
+@pytest.mark.asyncio
+async def test_launch_batch_sibling_handle_resolved_after_commit(
+    manager: Manager[LocalExchangeTransport],
+) -> None:
+    captured_sibling_args: list[Any] = []
+    async with manager.launch_batch() as batch:
+        parent = await batch.launch(EmptyAgent)
+        await batch.launch(_FlexAgent, args=(parent,))
+        sibling_args = batch._intents[1].args
+        assert sibling_args is not None
+        captured_sibling_args.append(sibling_args)
+    assert len(manager.running()) == 2  # noqa: PLR2004
+    # The captured parent handle has been mutated in-place to carry
+    # the transport-minted id, so a worker that pickles it now will
+    # send messages to the running parent.
+    sibling_parent_ref = captured_sibling_args[0][0]
+    assert sibling_parent_ref is parent
+    assert sibling_parent_ref.agent_id in manager.running()
+
+
+@pytest.mark.asyncio
+async def test_launch_batch_register_agents_failure_skips_launches(
+    manager: Manager[LocalExchangeTransport],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def failing_register(
+        agents: Any,
+    ) -> Any:
+        raise RuntimeError('injected register_agents failure')
+
+    monkeypatch.setattr(
+        manager.exchange_client,
+        'register_agents',
+        failing_register,
+    )
+
+    async def body() -> None:
+        async with manager.launch_batch() as batch:
+            await batch.launch(EmptyAgent)
+            await batch.launch(EmptyAgent)
+
+    with pytest.raises(RuntimeError, match='injected register_agents'):
+        await body()
+
+    assert len(manager.running()) == 0
+
+
+@pytest.mark.asyncio
+async def test_launch_batch_launch_failure_terminates_orphans(
+    manager: Manager[LocalExchangeTransport],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    original_launch = manager.launch
+    launch_calls: dict[str, int] = {'n': 0}
+
+    async def failing_launch(
+        *args: Any,
+        **kwargs: Any,
+    ) -> Any:
+        launch_calls['n'] += 1
+        if launch_calls['n'] == 2:  # noqa: PLR2004
+            raise RuntimeError('injected launch failure')
+        return await original_launch(*args, **kwargs)
+
+    monkeypatch.setattr(manager, 'launch', failing_launch)
+
+    original_terminate = manager.exchange_client.terminate
+    terminated: list[Any] = []
+
+    async def wrapped_terminate(agent_id: Any) -> None:
+        terminated.append(agent_id)
+        await original_terminate(agent_id)
+
+    monkeypatch.setattr(
+        manager.exchange_client,
+        'terminate',
+        wrapped_terminate,
+    )
+
+    async def body() -> None:
+        async with manager.launch_batch() as batch:
+            await batch.launch(EmptyAgent)  # intent 0 — launches
+            await batch.launch(EmptyAgent)  # intent 1 — launch fails
+            await batch.launch(EmptyAgent)  # intent 2 — orphaned
+
+    with pytest.raises(RuntimeError, match='injected launch failure'):
+        await body()
+
+    # Intent 0's agent is still running; intents 1 and 2 were
+    # registered but never successfully launched, so they are
+    # terminated via exchange_client.terminate.
+    assert len(manager.running()) == 1
+    assert len(terminated) == 2  # noqa: PLR2004
+
+
+@pytest.mark.asyncio
+async def test_launch_batch_launch_failure_evicts_stale_handles(
+    manager: Manager[LocalExchangeTransport],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    original_launch = manager.launch
+    launch_calls: dict[str, int] = {'n': 0}
+
+    async def failing_launch(
+        *args: Any,
+        **kwargs: Any,
+    ) -> Any:
+        launch_calls['n'] += 1
+        if launch_calls['n'] == 2:  # noqa: PLR2004
+            raise RuntimeError('injected launch failure')
+        return await original_launch(*args, **kwargs)
+
+    monkeypatch.setattr(manager, 'launch', failing_launch)
+
+    handles: list[Any] = []
+
+    async def body() -> None:
+        async with manager.launch_batch() as batch:
+            handles.append(await batch.launch(EmptyAgent))
+            handles.append(await batch.launch(EmptyAgent))
+            handles.append(await batch.launch(EmptyAgent))
+
+    with pytest.raises(RuntimeError, match='injected launch failure'):
+        await body()
+
+    running_handle, orphan_rebound, orphan_placeholder = handles
+    # Intent 0 launched successfully: handle stays cached.
+    assert manager._handles.get(running_handle.agent_id) is running_handle
+    # Intent 1 rebound but then the launch failed: evicted under its
+    # rebound (real) id.
+    assert orphan_rebound.agent_id not in manager._handles
+    # Intent 2 never reached the loop: evicted under its placeholder id.
+    assert orphan_placeholder.agent_id not in manager._handles
+
+
+@pytest.mark.asyncio
+async def test_launch_batch_orphan_termination_failure_does_not_mask(
+    manager: Manager[LocalExchangeTransport],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # The original launch exception must surface even when orphan
+    # cleanup raises.
+    original_launch = manager.launch
+
+    async def failing_launch(
+        *args: Any,
+        **kwargs: Any,
+    ) -> Any:
+        if not manager.running():
+            return await original_launch(*args, **kwargs)
+        raise RuntimeError('injected launch failure')
+
+    monkeypatch.setattr(manager, 'launch', failing_launch)
+
+    async def failing_terminate(agent_id: Any) -> None:
+        raise RuntimeError('injected terminate failure')
+
+    monkeypatch.setattr(
+        manager.exchange_client,
+        'terminate',
+        failing_terminate,
+    )
+
+    async def body() -> None:
+        async with manager.launch_batch() as batch:
+            await batch.launch(EmptyAgent)
+            await batch.launch(EmptyAgent)
+
+    with pytest.raises(RuntimeError, match='injected launch failure'):
+        await body()
+
+
+@pytest.mark.asyncio
+async def test_launch_batch_rejects_rebind_of_used_handle(
+    manager: Manager[LocalExchangeTransport],
+) -> None:
+    async def body() -> None:
+        async with manager.launch_batch() as batch:
+            handle = await batch.launch(EmptyAgent)
+            handle._used_for_messaging = True
+
+    with pytest.raises(RuntimeError, match='used for messaging'):
+        await body()
+
+
+@pytest.mark.asyncio
+async def test_launch_batch_mid_commit_cancellation_propagates(
+    manager: Manager[LocalExchangeTransport],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Un-launched registrations leak exchange-side on cancellation —
+    # documented limitation, not asserted against here.
+    original_launch = manager.launch
+    first_call = {'seen': False}
+
+    async def launch_then_cancel(*args: Any, **kwargs: Any) -> Any:
+        if not first_call['seen']:
+            first_call['seen'] = True
+            return await original_launch(*args, **kwargs)
+        raise asyncio.CancelledError
+
+    monkeypatch.setattr(manager, 'launch', launch_then_cancel)
+
+    async def body() -> None:
+        async with manager.launch_batch() as batch:
+            await batch.launch(EmptyAgent)
+            await batch.launch(EmptyAgent)
+
+    with pytest.raises(asyncio.CancelledError):
+        await body()
+    assert len(manager.running()) == 1
+
+
+@pytest.mark.asyncio
+async def test_launch_batch_fan_out_sibling_handle(
+    manager: Manager[LocalExchangeTransport],
+) -> None:
+    async with manager.launch_batch() as batch:
+        parent = await batch.launch(EmptyAgent)
+        await batch.launch(_FlexAgent, args=(parent,))
+        await batch.launch(_FlexAgent, kwargs={'peer': parent})
+    running = manager.running()
+    assert len(running) == 3  # noqa: PLR2004
+    assert parent.agent_id in running
+    assert manager._handles[parent.agent_id] is parent
+
+
+@pytest.mark.asyncio
+async def test_launch_batch_diamond_sibling_handles(
+    manager: Manager[LocalExchangeTransport],
+) -> None:
+    captured: list[Any] = []
+    async with manager.launch_batch() as batch:
+        parent_a = await batch.launch(EmptyAgent, name='a')
+        parent_b = await batch.launch(EmptyAgent, name='b')
+        await batch.launch(
+            _FlexAgent,
+            args=(parent_a, parent_b),
+        )
+        captured.append(batch._intents[2].args)
+    running = manager.running()
+    assert len(running) == 3  # noqa: PLR2004
+    assert parent_a.agent_id in running
+    assert parent_b.agent_id in running
+    child_args = captured[0]
+    assert child_args[0] is parent_a
+    assert child_args[1] is parent_b
 
 
 @pytest.mark.asyncio

--- a/tests/unit/manager_test.py
+++ b/tests/unit/manager_test.py
@@ -215,10 +215,6 @@ async def test_launch_batch_queues_and_returns_handle(
         handle = await batch.queue(EmptyAgent)
         with pytest.raises(RuntimeError, match='not bound'):
             _ = handle.agent_id
-        assert len(batch._intents) == 1
-        intent = batch._intents[0]
-        assert intent.agent is EmptyAgent
-        assert intent.handle is handle
     assert manager._handles[handle.agent_id] is handle
 
 
@@ -228,7 +224,6 @@ async def test_launch_batch_name_flows_into_agent_id(
 ) -> None:
     async with manager.launch_batch() as batch:
         handle = await batch.queue(EmptyAgent, name='worker-1')
-        assert batch._intents[0].name == 'worker-1'
     assert handle.agent_id.name == 'worker-1'
 
 
@@ -262,7 +257,6 @@ async def test_launch_batch_body_exception_skips_submit(
     with pytest.raises(ValueError, match='from body'):
         await body()
     assert len(manager.running()) == 0
-    # Body raised before submit; handles were never bound.
     for handle in handles:
         assert handle._agent_id is None
 
@@ -279,9 +273,6 @@ async def test_launch_batch_sibling_handle_resolved_after_submit(
         assert sibling_args is not None
         captured_sibling_args.append(sibling_args)
     assert len(manager.running()) == 2  # noqa: PLR2004
-    # The captured parent handle has been mutated in-place to carry
-    # the transport-minted id, so a worker that pickles it now will
-    # send messages to the running parent.
     sibling_parent_ref = captured_sibling_args[0][0]
     assert sibling_parent_ref is parent
     assert sibling_parent_ref.agent_id in manager.running()

--- a/tests/unit/manager_test.py
+++ b/tests/unit/manager_test.py
@@ -550,20 +550,6 @@ async def test_launch_batch_explicit_submit(
 
 
 @pytest.mark.asyncio
-async def test_launch_batch_abort_discards_intents(
-    manager: Manager[LocalExchangeTransport],
-) -> None:
-    batch = manager.launch_batch()
-    h1 = await batch.queue(EmptyAgent)
-    h2 = await batch.queue(EmptyAgent)
-    batch.abort()
-
-    assert len(manager.running()) == 0
-    assert h1._agent_id is None
-    assert h2._agent_id is None
-
-
-@pytest.mark.asyncio
 async def test_launch_batch_submit_after_close_raises(
     manager: Manager[LocalExchangeTransport],
 ) -> None:
@@ -582,16 +568,6 @@ async def test_launch_batch_aexit_skips_after_explicit_submit(
         handle = await batch.queue(EmptyAgent)
         await batch.submit()
     assert manager._handles[handle.agent_id] is handle
-
-
-@pytest.mark.asyncio
-async def test_launch_batch_abort_is_idempotent(
-    manager: Manager[LocalExchangeTransport],
-) -> None:
-    batch = manager.launch_batch()
-    await batch.queue(EmptyAgent)
-    batch.abort()
-    batch.abort()
 
 
 def test_handle_pickle_unbound_raises() -> None:

--- a/tests/unit/manager_test.py
+++ b/tests/unit/manager_test.py
@@ -462,19 +462,19 @@ async def test_launch_batch_evicts_on_launch_failure(
 
 
 @pytest.mark.asyncio
-async def test_launch_batch_orphan_termination_failure_does_not_mask(
+async def test_launch_batch_terminate_failure_propagates(
     manager: Manager[LocalExchangeTransport],
 ) -> None:
-    # The original launch exception must surface even when orphan
-    # cleanup raises.
     original_launch = manager.launch
+    call_count = 0
 
     async def _failing_launch(*args: Any, **kwargs: Any) -> Any:
-        if not manager.running():
-            return await original_launch(*args, **kwargs)
-        raise RuntimeError('injected launch failure')
+        nonlocal call_count
+        call_count += 1
+        if call_count == 2:  # noqa: PLR2004
+            raise RuntimeError('injected launch failure')
+        return await original_launch(*args, **kwargs)
 
-    failing_launch = mock.AsyncMock(side_effect=_failing_launch)
     failing_terminate = mock.AsyncMock(
         side_effect=RuntimeError('injected terminate failure'),
     )
@@ -483,24 +483,24 @@ async def test_launch_batch_orphan_termination_failure_does_not_mask(
         async with manager.launch_batch() as batch:
             await batch.queue(EmptyAgent)
             await batch.queue(EmptyAgent)
+            await batch.queue(EmptyAgent)
 
     with (
-        mock.patch.object(manager, 'launch', new=failing_launch),
+        mock.patch.object(manager, 'launch', new=_failing_launch),
         mock.patch.object(
             manager.exchange_client,
             'terminate',
             new=failing_terminate,
         ),
-        pytest.raises(RuntimeError, match='injected launch failure'),
+        pytest.raises(
+            RuntimeError,
+            match='injected terminate failure',
+        ) as exc_info,
     ):
         await body()
 
-    # intent to launch first agent succeeds
-    # intent to launch second agent fails to launch
-    assert failing_launch.await_count == 2  # noqa: PLR2004
-    # Rollback is run once for the orphaned agent left by
-    # the failing launch.
-    assert failing_terminate.await_count == 1
+    assert isinstance(exc_info.value.__context__, RuntimeError)
+    assert 'injected launch failure' in str(exc_info.value.__context__)
 
 
 @pytest.mark.asyncio

--- a/tests/unit/manager_test.py
+++ b/tests/unit/manager_test.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import asyncio
 import multiprocessing
 import pathlib
-import pickle
 import time
 from collections.abc import Callable
 from concurrent.futures import Future
@@ -24,7 +23,6 @@ from academy.exchange import HttpExchangeFactory
 from academy.exchange import LocalExchangeFactory
 from academy.exchange import LocalExchangeTransport
 from academy.exchange import UserExchangeClient
-from academy.handle import Handle
 from academy.logging.configs.file import FileLogging
 from academy.manager import Manager
 from testing.agents import EmptyAgent
@@ -174,13 +172,19 @@ async def test_register_agents_and_launch(
 async def test_launch_batch_empty_is_noop(
     manager: Manager[LocalExchangeTransport],
 ) -> None:
-    async with manager.launch_batch():
-        pass
+    with mock.patch.object(
+        manager.exchange_client,
+        'register_agents',
+        new_callable=mock.AsyncMock,
+    ) as register_agents:
+        async with manager.launch_batch():
+            pass
     assert len(manager.running()) == 0
+    assert register_agents.await_count == 0
 
 
 @pytest.mark.asyncio
-async def test_launch_batch_launch_after_close_raises(
+async def test_launch_batch_methods_raise_after_close(
     manager: Manager[LocalExchangeTransport],
 ) -> None:
     batch = manager.launch_batch()
@@ -188,6 +192,8 @@ async def test_launch_batch_launch_after_close_raises(
         pass
     with pytest.raises(RuntimeError, match='batch is closed'):
         await batch.queue(EmptyAgent)
+    with pytest.raises(RuntimeError, match='batch is closed'):
+        await batch.submit()
 
 
 @pytest.mark.asyncio
@@ -471,12 +477,6 @@ async def test_launch_batch_aexit_skips_after_explicit_submit(
         handle = await batch.queue(EmptyAgent)
         await batch.submit()
     assert manager._handles[handle.agent_id] is handle
-
-
-def test_handle_pickle_unbound_raises() -> None:
-    handle: Handle[Any] = Handle()
-    with pytest.raises(pickle.PicklingError, match='unbound'):
-        pickle.dumps(handle)
 
 
 @pytest.mark.asyncio

--- a/tests/unit/manager_test.py
+++ b/tests/unit/manager_test.py
@@ -227,44 +227,6 @@ async def test_launch_batch_name_flows_into_agent_id(
 
 
 @pytest.mark.asyncio
-async def test_launch_batch_multiple_launches_preserve_order(
-    manager: Manager[LocalExchangeTransport],
-) -> None:
-    async with manager.launch_batch() as batch:
-        h1 = await batch.queue(EmptyAgent, name='a')
-        h2 = await batch.queue(IdentityAgent, name='b')
-        h3 = await batch.queue(EmptyAgent, name='c')
-        assert batch._intents[0].agent is EmptyAgent
-        assert batch._intents[1].agent is IdentityAgent
-        assert batch._intents[2].agent is EmptyAgent
-        assert batch._intents[0].name == 'a'
-        assert batch._intents[1].name == 'b'
-        assert batch._intents[2].name == 'c'
-    ids = {h1.agent_id, h2.agent_id, h3.agent_id}
-    assert len(ids) == 3  # noqa: PLR2004
-
-
-@pytest.mark.asyncio
-async def test_launch_batch_handle_usable_as_sibling_arg(
-    manager: Manager[LocalExchangeTransport],
-) -> None:
-    async with manager.launch_batch() as batch:
-        parent = await batch.queue(EmptyAgent)
-        await batch.queue(
-            _FlexAgent,
-            args=(parent,),
-            kwargs={'peer': parent},
-        )
-        # Sibling intent captures the parent handle by reference so
-        # that submit-time rebinding is visible to siblings.
-        sibling_intent = batch._intents[1]
-        assert sibling_intent.args is not None
-        assert sibling_intent.kwargs is not None
-        assert sibling_intent.args[0] is parent
-        assert sibling_intent.kwargs['peer'] is parent
-
-
-@pytest.mark.asyncio
 async def test_launch_batch_submits_on_exit(
     manager: Manager[LocalExchangeTransport],
 ) -> None:
@@ -277,18 +239,6 @@ async def test_launch_batch_submits_on_exit(
     running_ids = manager.running()
     assert h1.agent_id in running_ids
     assert h2.agent_id in running_ids
-
-
-@pytest.mark.asyncio
-async def test_launch_batch_submit_binds_handle(
-    manager: Manager[LocalExchangeTransport],
-) -> None:
-    # Pre-submit the handle is unbound. Submit registers an agent
-    # and binds the handle to the transport-minted id.
-    async with manager.launch_batch() as batch:
-        handle = await batch.queue(EmptyAgent)
-        assert handle._agent_id is None
-    assert manager._handles[handle.agent_id] is handle
 
 
 @pytest.mark.asyncio
@@ -309,20 +259,6 @@ async def test_launch_batch_body_exception_skips_submit(
     # Body raised before submit; handles were never bound.
     for handle in handles:
         assert handle._agent_id is None
-
-
-@pytest.mark.asyncio
-async def test_launch_batch_empty_body_does_not_call_register_agents(
-    manager: Manager[LocalExchangeTransport],
-) -> None:
-    with mock.patch.object(
-        manager.exchange_client,
-        'register_agents',
-        new_callable=mock.AsyncMock,
-    ) as register_agents:
-        async with manager.launch_batch():
-            pass
-    assert register_agents.call_count == 0
 
 
 @pytest.mark.asyncio
@@ -504,39 +440,6 @@ async def test_launch_batch_terminate_failure_propagates(
 
 
 @pytest.mark.asyncio
-async def test_launch_batch_propagates_cancellation(
-    manager: Manager[LocalExchangeTransport],
-) -> None:
-    # Un-launched registrations leak exchange-side on cancellation.
-    # This is expected & not asserted against here.
-    original_launch = manager.launch
-    first_call = {'seen': False}
-
-    async def _launch_then_cancel(*args: Any, **kwargs: Any) -> Any:
-        if not first_call['seen']:
-            first_call['seen'] = True
-            return await original_launch(*args, **kwargs)
-        raise asyncio.CancelledError
-
-    launch_then_cancel = mock.AsyncMock(side_effect=_launch_then_cancel)
-
-    async def body() -> None:
-        async with manager.launch_batch() as batch:
-            await batch.queue(EmptyAgent)
-            await batch.queue(EmptyAgent)
-
-    with (
-        mock.patch.object(manager, 'launch', new=launch_then_cancel),
-        pytest.raises(asyncio.CancelledError),
-    ):
-        await body()
-
-    # The first launch intent launched. Second intent was
-    # cancelled before it could be launched.
-    assert launch_then_cancel.await_count == 2  # noqa: PLR2004
-
-
-@pytest.mark.asyncio
 async def test_launch_batch_explicit_submit(
     manager: Manager[LocalExchangeTransport],
 ) -> None:
@@ -574,42 +477,6 @@ def test_handle_pickle_unbound_raises() -> None:
     handle: Handle[Any] = Handle()
     with pytest.raises(pickle.PicklingError, match='unbound'):
         pickle.dumps(handle)
-
-
-@pytest.mark.asyncio
-async def test_launch_batch_fan_out_sibling_handle(
-    manager: Manager[LocalExchangeTransport],
-) -> None:
-    async with manager.launch_batch() as batch:
-        parent = await batch.queue(EmptyAgent)
-        await batch.queue(_FlexAgent, args=(parent,))
-        await batch.queue(_FlexAgent, kwargs={'peer': parent})
-    running = manager.running()
-    assert len(running) == 3  # noqa: PLR2004
-    assert parent.agent_id in running
-    assert manager._handles[parent.agent_id] is parent
-
-
-@pytest.mark.asyncio
-async def test_launch_batch_diamond_sibling_handles(
-    manager: Manager[LocalExchangeTransport],
-) -> None:
-    captured: list[Any] = []
-    async with manager.launch_batch() as batch:
-        parent_a = await batch.queue(EmptyAgent, name='a')
-        parent_b = await batch.queue(EmptyAgent, name='b')
-        await batch.queue(
-            _FlexAgent,
-            args=(parent_a, parent_b),
-        )
-        captured.append(batch._intents[2].args)
-    running = manager.running()
-    assert len(running) == 3  # noqa: PLR2004
-    assert parent_a.agent_id in running
-    assert parent_b.agent_id in running
-    child_args = captured[0]
-    assert child_args[0] is parent_a
-    assert child_args[1] is parent_b
 
 
 @pytest.mark.asyncio

--- a/tests/unit/manager_test.py
+++ b/tests/unit/manager_test.py
@@ -324,11 +324,12 @@ async def test_launch_batch_terminates_on_launch_failure(
     manager: Manager[LocalExchangeTransport],
 ) -> None:
     original_launch = manager.launch
-    launch_calls: dict[str, int] = {'n': 0}
+    call_count = 0
 
     async def _failing_launch(*args: Any, **kwargs: Any) -> Any:
-        launch_calls['n'] += 1
-        if launch_calls['n'] == 2:  # noqa: PLR2004
+        nonlocal call_count
+        call_count += 1
+        if call_count == 2:  # noqa: PLR2004
             raise RuntimeError('injected launch failure')
         return await original_launch(*args, **kwargs)
 
@@ -367,11 +368,12 @@ async def test_launch_batch_evicts_on_launch_failure(
     manager: Manager[LocalExchangeTransport],
 ) -> None:
     original_launch = manager.launch
-    launch_calls: dict[str, int] = {'n': 0}
+    call_count = 0
 
     async def _failing_launch(*args: Any, **kwargs: Any) -> Any:
-        launch_calls['n'] += 1
-        if launch_calls['n'] == 2:  # noqa: PLR2004
+        nonlocal call_count
+        call_count += 1
+        if call_count == 2:  # noqa: PLR2004
             raise RuntimeError('injected launch failure')
         return await original_launch(*args, **kwargs)
 


### PR DESCRIPTION
## Summary

This PR improves the UX around user-facing auth prompts on the Globus Exchange. The underlying logic for batching auth was added in [a previous PR](https://github.com/academy-agents/academy/pull/387#issue-4257618820); this PR introduces the public API for it.

Before this PR, batching auth across a set of agents required driving `register_agents` and `launch` separately:

```
async with await Manager.from_exchange_factory(
        factory=factory,
        log_config=recommended_logging(),
    ) as manager:
        regs: list[AgentRegistration[Any]] = await manager.register_agents(
            [
                (Greeter, None),
                (Shouter, None),
                (Coordinator, None),
            ],
        )

        greeter = await manager.launch(Greeter, registration=regs[0])
        shouter = await manager.launch(Shouter, registration=regs[1])
        coordinator = await manager.launch(
            Coordinator,
            args=(greeter, shouter),
            registration=regs[2],
        )
```

After this PR, the same flow uses `Manager.launch_batch()`:

```
async with await Manager.from_exchange_factory(
        factory=factory,
        log_config=recommended_logging(),
    ) as manager:
        async with manager.launch_batch() as batch:
            greeter = await batch.queue(Greeter)
            shouter = await batch.queue(Shouter)
            coordinator = await batch.queue(
                Coordinator,
                args=(greeter, shouter),
            )
```

`batch.queue()` returns an unbound `Handle`; registration and launch happen on context-exit. On the Globus exchange, all queued agents are registered under a single consent prompt; other transports register sequentially. The batch can also be driven explicitly without a context manager via `await batch.submit()` -- see `examples/12-globus-exchange/run-12-explicit.py`.

- Builds on [#387](https://github.com/academy-agents/academy/pull/387#issue-4257618820)

## Changes

- [ ] Breaking (backwards incompatible changes to public interfaces)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Enhancement (non-breaking change or feature addition)
- [ ] Refactor (internal code or design clean up)
- [x] Documentation (no changes to the code)
- [x] Test (changes or additions to testing)
- [ ] Build (change to CI workflows or build processes)
- [ ] Package (changes to package metadata or dependency versions)

## Testing

Unit coverage in `tests/unit/manager_test.py`, `tests/unit/handle_test.py`, and `tests/unit/exchange/client_test.py`:

## Pull Request Checklist

Please confirm the PR meets the following requirements.
- [X] Relevant tags are added based on the types of changes.
- [x] Code changes pass `pre-commit` (e.g., ruff, mypy, etc.).
- [X] Tests have been added to show the fix is effective or that the new feature works.
- [X] New and existing unit tests pass locally with the changes.
- [X] Docs have been updated and reviewed if relevant.
