### PR TITLE
Adding Custom Serialization Methods

### DIFF
--- a/academy/exception.py
+++ b/academy/exception.py
@@ -189,8 +189,8 @@ class ExchangeClientNotFoundError(Exception):
 class DeserializationMethodProhibitedError(Exception):
     """Deserialization prohibited.
 
-    Request argument or results are serialized in a method that is prohibtted
-    from being deserialized in the current context.
+    Request argument or results are serialized using a method that is
+    prohibtted from being deserialized in the current context.
     """
 
     def __reduce__(self) -> Any:
@@ -200,7 +200,7 @@ class DeserializationMethodProhibitedError(Exception):
 class ExceptionSerializationError(Exception):
     """Error when serializing an exception.
 
-    An action attempted to return a exception, but that exception could not be
+    An action attempted to return an exception, but that exception could not be
     serialized using the method provided.
     """
 
@@ -221,7 +221,7 @@ class ExceptionSerializationError(Exception):
 class AcademyRemoteError(Exception):
     """Generalized exception for serializing remote exceptions.
 
-    Any exception raised but is then JSON serialized loses its type.
+    Any exception raised that is JSON serialized loses its type.
     To raise the original exception, change `exception_serialization` in the
     action invocation.
     """

--- a/academy/exception.py
+++ b/academy/exception.py
@@ -19,12 +19,11 @@ class ActionCancelledError(Exception):
     configured to cancel running actions.
     """
 
-    def __init__(self, name: str) -> None:
-        super().__init__(f'Action "{name}" was cancelled by the agent.')
-        self.name = name
+    def __init__(self) -> None:
+        super().__init__(f'Action was cancelled by the agent.')
 
     def __reduce__(self) -> Any:
-        return type(self), (self.name,)
+        return type(self), ()
 
 
 class ActionInvalidStateError(Exception):
@@ -186,6 +185,45 @@ class ExchangeClientNotFoundError(Exception):
     def __reduce__(self) -> Any:
         return type(self), (self.aid,)
 
+class DeserializationMethodProhibited(Exception):
+    """Deserialization prohibitted.
+
+    Request argument or results are serialized in a method that is prohibtted
+    from being deserialized in the current context. 
+    """
+
+    def __reduce__(self) -> Any:
+        return type(self), ()
+    
+
+class ExceptionSerializationError(Exception):
+    """Error when serializing an exception.
+
+    An action attepted to return a exception, but that exception could not be
+    serialized using the method provided.
+    """
+
+    def __init__(self, exception_name: str, serializer: str) -> None:
+        super().__init__(
+            f'Exception {exception_name} could not be serialized using '
+            f'method {serializer}. Either change `exception_serialization` in'
+            'the action invocation, or ensure the exception can be '
+            'serialized.'
+        )
+        self.exception_name = exception_name
+        self.serializer = serializer
+
+    def __reduce__(self) -> Any:
+        return type(self), (self.exception_name, self.serializer)
+    
+
+class RemoteException(Exception):
+    """Generalized exception for serializing remote exceptions.
+
+    Any exception raised but is then JSON serialized loses its type. 
+    To raise the original exception, change `exception_serialization` in the
+    action invocation.
+    """
 
 def raise_exceptions(
     exceptions: Iterable[BaseException],

--- a/academy/exception.py
+++ b/academy/exception.py
@@ -20,7 +20,7 @@ class ActionCancelledError(Exception):
     """
 
     def __init__(self) -> None:
-        super().__init__(f'Action was cancelled by the agent.')
+        super().__init__('Action was cancelled by the agent.')
 
     def __reduce__(self) -> Any:
         return type(self), ()
@@ -185,21 +185,22 @@ class ExchangeClientNotFoundError(Exception):
     def __reduce__(self) -> Any:
         return type(self), (self.aid,)
 
-class DeserializationMethodProhibited(Exception):
-    """Deserialization prohibitted.
+
+class DeserializationMethodProhibitedError(Exception):
+    """Deserialization prohibited.
 
     Request argument or results are serialized in a method that is prohibtted
-    from being deserialized in the current context. 
+    from being deserialized in the current context.
     """
 
     def __reduce__(self) -> Any:
         return type(self), ()
-    
+
 
 class ExceptionSerializationError(Exception):
     """Error when serializing an exception.
 
-    An action attepted to return a exception, but that exception could not be
+    An action attempted to return a exception, but that exception could not be
     serialized using the method provided.
     """
 
@@ -208,22 +209,23 @@ class ExceptionSerializationError(Exception):
             f'Exception {exception_name} could not be serialized using '
             f'method {serializer}. Either change `exception_serialization` in'
             'the action invocation, or ensure the exception can be '
-            'serialized.'
+            'serialized.',
         )
         self.exception_name = exception_name
         self.serializer = serializer
 
     def __reduce__(self) -> Any:
         return type(self), (self.exception_name, self.serializer)
-    
 
-class RemoteException(Exception):
+
+class AcademyRemoteError(Exception):
     """Generalized exception for serializing remote exceptions.
 
-    Any exception raised but is then JSON serialized loses its type. 
+    Any exception raised but is then JSON serialized loses its type.
     To raise the original exception, change `exception_serialization` in the
     action invocation.
     """
+
 
 def raise_exceptions(
     exceptions: Iterable[BaseException],

--- a/academy/exchange/client.py
+++ b/academy/exchange/client.py
@@ -30,7 +30,7 @@ from academy.handle import Handle
 from academy.identifier import AgentId
 from academy.identifier import EntityId
 from academy.identifier import UserId
-from academy.message import ErrorResponse
+from academy.message import ACADEMY_ERROR_CODE, AcademyErrorResponse
 from academy.message import Message
 from academy.message import RequestT_co
 from academy.task import spawn_guarded_background_task
@@ -461,8 +461,12 @@ class UserExchangeClient(ExchangeClient[ExchangeTransportT]):
 
     async def _handle_message(self, message: Message[Any]) -> None:
         if message.is_request():
-            error = TypeError(f'{self.client_id} cannot fulfill requests.')
-            response = message.create_response(ErrorResponse(exception=error))
+            response = message.create_response(
+                AcademyErrorResponse(
+                    error_code=ACADEMY_ERROR_CODE.INVALID_CLIENT,
+                    mailbox_id=self.client_id,
+                )
+            )
             await self._transport.send(response)
             logger.warning(
                 'Exchange client for %s received unexpected request message '

--- a/academy/exchange/client.py
+++ b/academy/exchange/client.py
@@ -30,8 +30,8 @@ from academy.handle import Handle
 from academy.identifier import AgentId
 from academy.identifier import EntityId
 from academy.identifier import UserId
-from academy.message import AcademyErrorCode
 from academy.message import AcademyErrorResponse
+from academy.message import ErrorCode
 from academy.message import Message
 from academy.message import RequestT_co
 from academy.task import spawn_guarded_background_task
@@ -464,7 +464,7 @@ class UserExchangeClient(ExchangeClient[ExchangeTransportT]):
         if message.is_request():
             response = message.create_response(
                 AcademyErrorResponse(
-                    error_code=AcademyErrorCode.INVALID_CLIENT,
+                    error_code=ErrorCode.INVALID_CLIENT,
                     mailbox_id=self.client_id,
                 ),
             )

--- a/academy/exchange/client.py
+++ b/academy/exchange/client.py
@@ -30,7 +30,8 @@ from academy.handle import Handle
 from academy.identifier import AgentId
 from academy.identifier import EntityId
 from academy.identifier import UserId
-from academy.message import ACADEMY_ERROR_CODE, AcademyErrorResponse
+from academy.message import AcademyErrorCode
+from academy.message import AcademyErrorResponse
 from academy.message import Message
 from academy.message import RequestT_co
 from academy.task import spawn_guarded_background_task
@@ -463,9 +464,9 @@ class UserExchangeClient(ExchangeClient[ExchangeTransportT]):
         if message.is_request():
             response = message.create_response(
                 AcademyErrorResponse(
-                    error_code=ACADEMY_ERROR_CODE.INVALID_CLIENT,
+                    error_code=AcademyErrorCode.INVALID_CLIENT,
                     mailbox_id=self.client_id,
-                )
+                ),
             )
             await self._transport.send(response)
             logger.warning(

--- a/academy/exchange/transport.py
+++ b/academy/exchange/transport.py
@@ -21,7 +21,8 @@ else:  # pragma: <3.11 cover
 from academy.exception import MailboxTerminatedError
 from academy.identifier import AgentId
 from academy.identifier import EntityId
-from academy.message import ACADEMY_ERROR_CODE, AcademyErrorResponse
+from academy.message import AcademyErrorCode
+from academy.message import AcademyErrorResponse
 from academy.message import Header
 from academy.message import Message
 
@@ -278,8 +279,8 @@ async def _respond_pending_requests_on_terminate(
         response: Message[AcademyErrorResponse] = Message(
             header=response_header,
             body=AcademyErrorResponse(
-                error_code=ACADEMY_ERROR_CODE.MAILBOX_TERMINATED,
-                mailbox_id=message.dest
+                error_code=AcademyErrorCode.MAILBOX_TERMINATED,
+                mailbox_id=message.dest,
             ),
         )
         # If the requester's mailbox was also terminated then they

--- a/academy/exchange/transport.py
+++ b/academy/exchange/transport.py
@@ -21,8 +21,8 @@ else:  # pragma: <3.11 cover
 from academy.exception import MailboxTerminatedError
 from academy.identifier import AgentId
 from academy.identifier import EntityId
-from academy.message import AcademyErrorCode
 from academy.message import AcademyErrorResponse
+from academy.message import ErrorCode
 from academy.message import Header
 from academy.message import Message
 
@@ -279,7 +279,7 @@ async def _respond_pending_requests_on_terminate(
         response: Message[AcademyErrorResponse] = Message(
             header=response_header,
             body=AcademyErrorResponse(
-                error_code=AcademyErrorCode.MAILBOX_TERMINATED,
+                error_code=ErrorCode.MAILBOX_TERMINATED,
                 mailbox_id=message.dest,
             ),
         )

--- a/academy/exchange/transport.py
+++ b/academy/exchange/transport.py
@@ -21,7 +21,7 @@ else:  # pragma: <3.11 cover
 from academy.exception import MailboxTerminatedError
 from academy.identifier import AgentId
 from academy.identifier import EntityId
-from academy.message import ErrorResponse
+from academy.message import ACADEMY_ERROR_CODE, AcademyErrorResponse
 from academy.message import Header
 from academy.message import Message
 
@@ -274,11 +274,13 @@ async def _respond_pending_requests_on_terminate(
     send: Callable[[Message[Any]], Awaitable[None]],
 ) -> None:
     for message in messages:
-        error = MailboxTerminatedError(message.dest)
         response_header = message.create_response_header()
-        response: Message[ErrorResponse] = Message(
+        response: Message[AcademyErrorResponse] = Message(
             header=response_header,
-            body=ErrorResponse(exception=error),
+            body=AcademyErrorResponse(
+                error_code=ACADEMY_ERROR_CODE.MAILBOX_TERMINATED,
+                mailbox_id=message.dest
+            ),
         )
         # If the requester's mailbox was also terminated then they
         # don't need to get a response.

--- a/academy/handle.py
+++ b/academy/handle.py
@@ -27,7 +27,7 @@ from academy.message import Response
 from academy.message import ResponseT
 from academy.message import ShutdownRequest
 from academy.serialize import default_serializer
-from academy.serialize import SerializationStrategies
+from academy.serialize import SerializationStrategy
 
 if TYPE_CHECKING:
     from academy.agent import Agent
@@ -82,8 +82,13 @@ class Handle(Generic[AgentT_co]):
             is not configured in the current context.
         ignore_context: Ignore the current context and force use of `exchange`
             for communication.
-        serializer: Strategy used to serialize arguments. If None, use the
+        request_serializer: Strategy used to serialize arguments. If None,
+            use the
             [`academy.serialize.default_serializer`][academy.serialize.default_serializer]
+        result_serializer: Strategy used to serialize results. If false-y, use
+            the same strategy as the request serializer.
+        exception_serializer: Strategy used to serialize results. If false-y,
+            use the same strategy as the result serializer.
 
     Raises:
         ValueError: If `ignore_context=True` but `exchange` is not provided.
@@ -95,13 +100,13 @@ class Handle(Generic[AgentT_co]):
         *,
         exchange: ExchangeClient[Any] | None = None,
         ignore_context: bool = False,
-        serializer: SerializationStrategies | None = None,
-        result_serializer: SerializationStrategies | None = None,
-        exception_serializer: SerializationStrategies | None = None,
+        request_serializer: SerializationStrategy | None = None,
+        result_serializer: SerializationStrategy | None = None,
+        exception_serializer: SerializationStrategy | None = None,
     ) -> None:
         self._agent_id: AgentId[AgentT_co] | None = agent_id
         self._exchange = exchange
-        self.serialization = serializer
+        self.request_serializer = request_serializer
         self.result_serializer = result_serializer
         self.exception_serializer = exception_serializer
         self._registered_exchanges: WeakSet[ExchangeClient[Any]] = WeakSet()
@@ -186,7 +191,7 @@ class Handle(Generic[AgentT_co]):
             Handle,
             (self._agent_id,),
             {
-                'serialization': self.serialization,
+                'request_serializer': self.request_serializer,
                 'result_serializer': self.result_serializer,
                 'exception_serializer': self.exception_serializer,
             },
@@ -272,7 +277,7 @@ class Handle(Generic[AgentT_co]):
         )
         exchange = self.exchange
         self._register_with_exchange(exchange)
-        serialization = self.serialization or default_serializer.get()
+        serialization = self.request_serializer or default_serializer.get()
 
         request = Message.create(
             src=exchange.client_id,

--- a/academy/handle.py
+++ b/academy/handle.py
@@ -26,6 +26,8 @@ from academy.message import PingRequest
 from academy.message import ResponseT
 from academy.message import ShutdownRequest
 from academy.message import SuccessResponse
+from academy.serialize import SerializationStrategies
+from academy.serialize import default_serializer
 
 if TYPE_CHECKING:
     from academy.agent import Agent
@@ -80,6 +82,8 @@ class Handle(Generic[AgentT_co]):
             is not configured in the current context.
         ignore_context: Ignore the current context and force use of `exchange`
             for communication.
+        serializer: Strategy used to serialize arguments. If None, use the
+            [`academy.serialize.default_serializer`][academy.serialize.default_serializer]
 
     Raises:
         ValueError: If `ignore_context=True` but `exchange` is not provided.
@@ -91,9 +95,15 @@ class Handle(Generic[AgentT_co]):
         *,
         exchange: ExchangeClient[Any] | None = None,
         ignore_context: bool = False,
+        serializer: SerializationStrategies | None = None,
+        result_serializer: SerializationStrategies | None = None,
+        exception_serializer: SerializationStrategies | None = None
     ) -> None:
         self._agent_id: AgentId[AgentT_co] | None = agent_id
         self._exchange = exchange
+        self.serialization = serializer
+        self.result_serializer = result_serializer
+        self.exception_serializer = exception_serializer
         self._registered_exchanges: WeakSet[ExchangeClient[Any]] = WeakSet()
         self.ignore_context = ignore_context
 
@@ -167,9 +177,23 @@ class Handle(Generic[AgentT_co]):
             raise PicklingError(
                 'Handle with ignore_context=True is not pickle-able',
             )
-        if self._agent_id is None:
-            raise PicklingError('Cannot pickle an unbound handle.')
-        return (Handle, (self._agent_id,))
+        return (
+            Handle, 
+            (self._agent_id,),
+            {
+                "serialization": self.serialization,
+                "result_serializer": self.result_serializer,
+                "exception_serializer": self.exception_serializer,
+            }
+        )
+    
+    def __setstate__(self, state):
+        """Set state.
+
+        This is necessary for unpickling to not treat set state as a
+        remote action.
+        """
+        self.__dict__.update(state)
 
     def __repr__(self) -> str:
         return (
@@ -190,17 +214,9 @@ class Handle(Generic[AgentT_co]):
 
     async def _process_response(self, response: Message[ResponseT]) -> None:
         future = self._pending_response_futures.pop(response.tag)
-
         if not future.cancelled():
             body = response.get_body()
-            if isinstance(body, ActionResponse):
-                future.set_result(body.get_result())
-            elif isinstance(body, ErrorResponse):
-                future.set_exception(body.get_exception())
-            elif isinstance(body, SuccessResponse):
-                future.set_result(None)
-            else:
-                raise AssertionError('Unreachable.')
+            future.set_result(body)
 
     def _register_with_exchange(self, exchange: ExchangeClient[Any]) -> None:
         """Register to receive messages from exchange.
@@ -251,16 +267,24 @@ class Handle(Generic[AgentT_co]):
         )
         exchange = self.exchange
         self._register_with_exchange(exchange)
+        serialization = self.serialization or default_serializer.get()
 
         request = Message.create(
             src=exchange.client_id,
             dest=self.agent_id,
             label=self.handle_id,
             tag=tag_id,
-            body=ActionRequest(action=action, pargs=args, kargs=kwargs),
+            body=ActionRequest(
+                action=action, 
+                pargs=args, 
+                kargs=kwargs,
+                serialization=serialization,
+                result_serialization=self.result_serializer,
+                exception_serialization=self.exception_serializer,
+            ),
         )
         loop = asyncio.get_running_loop()
-        future: asyncio.Future[R] = loop.create_future()
+        future: asyncio.Future[ResponseT] = loop.create_future()
         self._pending_response_futures[request.tag] = future
 
         try:
@@ -305,7 +329,27 @@ class Handle(Generic[AgentT_co]):
             self._pending_response_futures[cancel_request.tag] = cancel_future
             await self.exchange.send(cancel_request)
             raise
-        except Exception as e:
+
+        assert future.done()
+        assert future.exception() is None
+        body = future.result()
+
+        if isinstance(body, ActionResponse):
+            result = body.get_result()
+            logger.debug(
+                'Successfully completed action %s with tag id %s',
+                action,
+                tag_id,
+                extra=invocation_extra
+                | {
+                    'academy.action_state': 'success',
+                    'academy.result': result,
+                    'academy.agent_id': self.agent_id,
+                },
+            )
+            return result
+        elif isinstance(body, ErrorResponse):
+            exception = body.get_exception()
             logger.debug(
                 'Completed action %s with tag id %s with exception',
                 action,
@@ -314,28 +358,10 @@ class Handle(Generic[AgentT_co]):
                 | {
                     'academy.action_state': 'exception',
                 },
-                exc_info=e,
             )
-
-            raise
-
-        assert future.done()
-        assert future.exception() is None
-        result = future.result()
-
-        logger.debug(
-            'Successfully completed action %s with tag id %s',
-            action,
-            tag_id,
-            extra=invocation_extra
-            | {
-                'academy.action_state': 'success',
-                'academy.result': result,
-                'academy.agent_id': self.agent_id,
-            },
-        )
-
-        return result
+            raise exception
+        
+        raise RuntimeError("Invalid response received from action request.")
 
     async def ping(self, *, timeout: float | None = None) -> float:
         """Ping the agent.
@@ -364,7 +390,7 @@ class Handle(Generic[AgentT_co]):
             body=PingRequest(),
         )
         loop = asyncio.get_running_loop()
-        future: asyncio.Future[None] = loop.create_future()
+        future: asyncio.Future[ResponseT] = loop.create_future()
         self._pending_response_futures[request.tag] = future
         start = time.perf_counter()
         await self.exchange.send(request)
@@ -376,6 +402,12 @@ class Handle(Generic[AgentT_co]):
         )
 
         await asyncio.wait_for(future, timeout)
+
+        assert future.done()
+        body = future.result()
+
+        if isinstance(body, ErrorResponse):
+            raise body.get_exception()
 
         elapsed = time.perf_counter() - start
         logger.debug(
@@ -390,11 +422,16 @@ class Handle(Generic[AgentT_co]):
         )
         return elapsed
 
-    def _shutdown_callback(self, future: asyncio.Future[Any]) -> None:
-        if future.exception() is None:
-            return
+    def _shutdown_callback(self, future: asyncio.Future[ResponseT]) -> None:
+        exception: BaseException
+        if future.exception() is not None:
+            exception = future.exception()
+        else:
+            body = future.result()
+            if not isinstance(body, ErrorResponse):
+                return
+            exception = body.get_exception()
 
-        exception = future.exception()
         # The only ok error to be ignored is if the agent we intended to
         # shutdown was already shutdown.
         if (
@@ -439,7 +476,7 @@ class Handle(Generic[AgentT_co]):
         )
 
         loop = asyncio.get_running_loop()
-        future: asyncio.Future[None] = loop.create_future()
+        future: asyncio.Future[ResponseT] = loop.create_future()
         self._pending_response_futures[request.tag] = future
         await self.exchange.send(request)
 

--- a/academy/handle.py
+++ b/academy/handle.py
@@ -179,7 +179,7 @@ class Handle(Generic[AgentT_co]):
                 'Handle with ignore_context=True is not pickle-able',
             )
         return (
-            Handle, 
+            Handle,
             (self._agent_id,),
             {
                 'serialization': self.serialization,

--- a/academy/handle.py
+++ b/academy/handle.py
@@ -23,11 +23,11 @@ from academy.message import CancelRequest
 from academy.message import ErrorResponse
 from academy.message import Message
 from academy.message import PingRequest
+from academy.message import Response
 from academy.message import ResponseT
 from academy.message import ShutdownRequest
-from academy.message import SuccessResponse
-from academy.serialize import SerializationStrategies
 from academy.serialize import default_serializer
+from academy.serialize import SerializationStrategies
 
 if TYPE_CHECKING:
     from academy.agent import Agent
@@ -89,7 +89,7 @@ class Handle(Generic[AgentT_co]):
         ValueError: If `ignore_context=True` but `exchange` is not provided.
     """
 
-    def __init__(
+    def __init__(  # noqa: PLR0913
         self,
         agent_id: AgentId[AgentT_co] | None = None,
         *,
@@ -97,7 +97,7 @@ class Handle(Generic[AgentT_co]):
         ignore_context: bool = False,
         serializer: SerializationStrategies | None = None,
         result_serializer: SerializationStrategies | None = None,
-        exception_serializer: SerializationStrategies | None = None
+        exception_serializer: SerializationStrategies | None = None,
     ) -> None:
         self._agent_id: AgentId[AgentT_co] | None = agent_id
         self._exchange = exchange
@@ -172,6 +172,7 @@ class Handle(Generic[AgentT_co]):
     ) -> tuple[
         type[Handle[Any]],
         tuple[Any, ...],
+        dict[str, Any],
     ]:
         if self.ignore_context:
             raise PicklingError(
@@ -181,13 +182,13 @@ class Handle(Generic[AgentT_co]):
             Handle, 
             (self._agent_id,),
             {
-                "serialization": self.serialization,
-                "result_serializer": self.result_serializer,
-                "exception_serializer": self.exception_serializer,
-            }
+                'serialization': self.serialization,
+                'result_serializer': self.result_serializer,
+                'exception_serializer': self.exception_serializer,
+            },
         )
-    
-    def __setstate__(self, state):
+
+    def __setstate__(self, state: dict[str, Any]) -> None:
         """Set state.
 
         This is necessary for unpickling to not treat set state as a
@@ -275,8 +276,8 @@ class Handle(Generic[AgentT_co]):
             label=self.handle_id,
             tag=tag_id,
             body=ActionRequest(
-                action=action, 
-                pargs=args, 
+                action=action,
+                pargs=args,
                 kargs=kwargs,
                 serialization=serialization,
                 result_serialization=self.result_serializer,
@@ -284,7 +285,7 @@ class Handle(Generic[AgentT_co]):
             ),
         )
         loop = asyncio.get_running_loop()
-        future: asyncio.Future[ResponseT] = loop.create_future()
+        future: asyncio.Future[Response] = loop.create_future()
         self._pending_response_futures[request.tag] = future
 
         try:
@@ -360,8 +361,10 @@ class Handle(Generic[AgentT_co]):
                 },
             )
             raise exception
-        
-        raise RuntimeError("Invalid response received from action request.")
+
+        raise RuntimeError(
+            'Invalid response received from action request.',
+        )  # pragma: no cover
 
     async def ping(self, *, timeout: float | None = None) -> float:
         """Ping the agent.
@@ -390,7 +393,7 @@ class Handle(Generic[AgentT_co]):
             body=PingRequest(),
         )
         loop = asyncio.get_running_loop()
-        future: asyncio.Future[ResponseT] = loop.create_future()
+        future: asyncio.Future[Response] = loop.create_future()
         self._pending_response_futures[request.tag] = future
         start = time.perf_counter()
         await self.exchange.send(request)
@@ -425,7 +428,7 @@ class Handle(Generic[AgentT_co]):
     def _shutdown_callback(self, future: asyncio.Future[ResponseT]) -> None:
         exception: BaseException
         if future.exception() is not None:
-            exception = future.exception()
+            exception = future.exception()  # type: ignore[assignment]
         else:
             body = future.result()
             if not isinstance(body, ErrorResponse):
@@ -476,7 +479,7 @@ class Handle(Generic[AgentT_co]):
         )
 
         loop = asyncio.get_running_loop()
-        future: asyncio.Future[ResponseT] = loop.create_future()
+        future: asyncio.Future[Response] = loop.create_future()
         self._pending_response_futures[request.tag] = future
         await self.exchange.send(request)
 
@@ -528,8 +531,9 @@ class ProxyHandle(Handle[AgentT]):
     ) -> tuple[
         type[Handle[Any]],
         tuple[Any, ...],
+        dict[str, Any],
     ]:
-        return (ProxyHandle, (self.agent,))
+        return (ProxyHandle, (self.agent,), {})
 
     async def action(self, action: str, /, *args: Any, **kwargs: Any) -> R:
         """Invoke an action on the agent.

--- a/academy/handle.py
+++ b/academy/handle.py
@@ -178,6 +178,10 @@ class Handle(Generic[AgentT_co]):
             raise PicklingError(
                 'Handle with ignore_context=True is not pickle-able',
             )
+
+        if self._agent_id is None:
+            raise PicklingError('Cannot pickle an unbound handle.')
+
         return (
             Handle,
             (self._agent_id,),

--- a/academy/message.py
+++ b/academy/message.py
@@ -1,14 +1,18 @@
 from __future__ import annotations
 
 import base64
+from contextvars import ContextVar
+from enum import IntEnum
 import pickle
 import sys
 import uuid
-from typing import Any
+from typing import Any, Protocol, runtime_checkable
 from typing import Generic
 from typing import get_args
 from typing import Literal
 from typing import TypeVar
+
+from academy.exception import ActionCancelledError, ActionInvalidStateError, ExceptionSerializationError, MailboxTerminatedError, PingCancelledError
 
 if sys.version_info >= (3, 11):  # pragma: >=3.11 cover
     from typing import Self
@@ -23,6 +27,7 @@ from pydantic import SkipValidation
 from pydantic import TypeAdapter
 
 from academy.identifier import EntityId
+from academy.serialize import SerializationStrategies, deserialize, serialize
 
 DEFAULT_FROZEN_CONFIG = ConfigDict(
     arbitrary_types_allowed=True,
@@ -39,7 +44,6 @@ DEFAULT_MUTABLE_CONFIG = ConfigDict(
     validate_default=True,
 )
 
-
 class ActionRequest(BaseModel):
     """Agent action request message.
 
@@ -50,6 +54,23 @@ class ActionRequest(BaseModel):
     """
 
     action: str = Field(description='Name of the requested action.')
+    serialization: SerializationStrategies = Field(
+        description='Serialization strategy used send args'
+    )
+    result_serialization: SerializationStrategies | None = Field(
+        default=None,
+        description=(
+            "Requested serialization of results. If none, use the same "
+            "method the args were serialized with."
+        )
+    )
+    exception_serialization: SerializationStrategies | None = Field(
+        default=None,
+        description=(
+            "Requested serialization of exceptions. If none, use the same "
+            "method the args were serialized with."
+        )
+    )
     pargs: SkipValidation[tuple[Any, ...]] = Field(
         default_factory=tuple,
         description='Positional arguments to the action method.',
@@ -66,8 +87,7 @@ class ActionRequest(BaseModel):
     def _pickle_and_encode_obj(self, obj: Any) -> str:
         if isinstance(obj, str):  # pragma: no cover
             return obj
-        raw = pickle.dumps(obj)
-        return base64.b64encode(raw).decode('utf-8')
+        return serialize(obj, self.serialization)
 
     def get_args(self) -> tuple[Any, ...]:
         """Get the positional arguments.
@@ -79,7 +99,7 @@ class ActionRequest(BaseModel):
             The deserialized tuple of positional arguments.
         """
         if isinstance(self.pargs, str):
-            self.pargs = pickle.loads(base64.b64decode(self.pargs))
+            self.pargs = deserialize(self.pargs, self.serialization)
         return self.pargs
 
     def get_kwargs(self) -> dict[str, Any]:
@@ -92,7 +112,7 @@ class ActionRequest(BaseModel):
             The deserialized dictionary of keyword arguments.
         """
         if isinstance(self.kargs, str):
-            self.kargs = pickle.loads(base64.b64decode(self.kargs))
+            self.kargs = deserialize(self.kargs, self.serialization)
         return self.kargs
 
 
@@ -136,6 +156,9 @@ class ActionResponse(BaseModel):
     result: SkipValidation[Any] = Field(
         description='Result of the action, if successful.',
     )
+    serialization: SerializationStrategies = Field(
+        description='Serialization strategy used send result.'
+    )
     kind: Literal['action-response'] = Field('action-response', repr=False)
 
     model_config = DEFAULT_MUTABLE_CONFIG
@@ -145,16 +168,16 @@ class ActionResponse(BaseModel):
         if (
             isinstance(obj, list)
             and len(obj) == 2  # noqa PLR2004
-            and obj[0] == '__pickled__'
+            and obj[0] == '__serialized__'
         ):  # pragma: no cover
             # Prevent double serialization
             return obj
 
-        raw = pickle.dumps(obj)
+        data =  serialize(obj, self.serialization)
         # This sential value at the start of the tuple is so we can
         # disambiguate a result that is a str versus the string of a
         # serialized result.
-        return ['__pickled__', base64.b64encode(raw).decode('utf-8')]
+        return ['__serialized__', data]
 
     def get_result(self) -> Any:
         """Get the result.
@@ -168,29 +191,98 @@ class ActionResponse(BaseModel):
         if (
             isinstance(self.result, list)
             and len(self.result) == 2  # noqa PLR2004
-            and self.result[0] == '__pickled__'
+            and self.result[0] == '__serialized__'
         ):
-            self.result = pickle.loads(base64.b64decode(self.result[1]))
+            self.result = deserialize(self.result[1], self.serialization)
         return self.result
 
+@runtime_checkable
+class ErrorResponse(Protocol):
+    def get_exception(self) -> Exception:
+        """Get the exception.
 
-class ErrorResponse(BaseModel):
+        Returns:
+            The exception.
+        """
+        ...
+
+class ACADEMY_ERROR_CODE(IntEnum):
+    """Error codes returned by requests.
+    
+    These error codes allow us to return errrors without serialization.
+    """
+    MAILBOX_TERMINATED = 0
+    PING_CANCELLED = 1
+    ACTION_INVALID_STATE = 2
+    ACTION_CANCELLED = 3
+    INVALID_CLIENT = 4
+
+
+class AcademyErrorResponse(BaseModel):
+    """Error response created by Academy."""
+    error_code: ACADEMY_ERROR_CODE = Field(
+        description='Error code '
+    )
+    mailbox_id: EntityId | None = Field(
+        description='Mailbox id if necessary for the error.',
+        default=None,
+    )
+    kind: Literal['academy-error-response'] = Field('academy-error-response', repr=False)
+
+    def get_exception(self) -> Exception:
+        """Get the exception.
+
+        Returns:
+            The exception.
+        """
+        match self.error_code:
+            case ACADEMY_ERROR_CODE.MAILBOX_TERMINATED:
+                assert self.mailbox_id is not None, "Improper error response created."
+                return MailboxTerminatedError(self.mailbox_id)
+            case ACADEMY_ERROR_CODE.PING_CANCELLED:
+                return PingCancelledError()
+            case ACADEMY_ERROR_CODE.ACTION_INVALID_STATE:
+                return ActionInvalidStateError()
+            case ACADEMY_ERROR_CODE.ACTION_CANCELLED:
+                return ActionCancelledError()
+            case ACADEMY_ERROR_CODE.INVALID_CLIENT:
+                return TypeError(f'{self.mailbox_id} cannot fulfill requests.')
+        assert False, 'Unreachable'
+
+        
+class UserErrorResponse(BaseModel):
     """Error response message.
 
     Contains the exception raised by a failed request.
     """
-
+    serialization: SerializationStrategies = Field(
+        description='Serialization strategy used send exception.'
+    )
     exception: SkipValidation[Exception] = Field(
         description='Exception of the failed request.',
     )
-    kind: Literal['error-response'] = Field('error-response', repr=False)
+    kind: Literal['user-error-response'] = Field('user-error-response', repr=False)
 
     model_config = DEFAULT_MUTABLE_CONFIG
 
     @field_serializer('exception', when_used='json')
     def _pickle_and_encode_obj(self, obj: Any) -> str | None:
-        raw = pickle.dumps(obj)
-        return base64.b64encode(raw).decode('utf-8')
+        try:
+            return serialize(obj, self.serialization)
+        except Exception:
+            # If we get an exception while serializing an exception,
+            # we do not want to raise an exception and prevent any response
+            # from being returned. Instead we replace the exception with
+            # a exception we know can be serialized, letting the client know
+            # that a exception was hidden.
+            print("Serialization raised eception")
+            return serialize(
+                ExceptionSerializationError(
+                    obj.__class__.__name__,
+                    self.serialization
+                ),
+                self.serialization,
+            )
 
     def get_exception(self) -> Exception:
         """Get the exception.
@@ -202,7 +294,7 @@ class ErrorResponse(BaseModel):
             The deserialized exception.
         """
         if isinstance(self.exception, str):
-            self.exception = pickle.loads(base64.b64decode(self.exception))
+            self.exception =  deserialize(self.exception, self.serialization)
         return self.exception
 
 
@@ -215,7 +307,7 @@ class SuccessResponse(BaseModel):
 
 
 Request = ActionRequest | CancelRequest | PingRequest | ShutdownRequest
-Response = ActionResponse | ErrorResponse | SuccessResponse
+Response = ActionResponse | AcademyErrorResponse | UserErrorResponse | SuccessResponse
 Body = Request | Response
 
 BodyT = TypeVar('BodyT', bound=Body)

--- a/academy/message.py
+++ b/academy/message.py
@@ -1,18 +1,22 @@
 from __future__ import annotations
 
-import base64
-from contextvars import ContextVar
-from enum import IntEnum
 import pickle
 import sys
 import uuid
-from typing import Any, Protocol, runtime_checkable
+from enum import IntEnum
+from typing import Any
 from typing import Generic
 from typing import get_args
 from typing import Literal
+from typing import Protocol
+from typing import runtime_checkable
 from typing import TypeVar
 
-from academy.exception import ActionCancelledError, ActionInvalidStateError, ExceptionSerializationError, MailboxTerminatedError, PingCancelledError
+from academy.exception import ActionCancelledError
+from academy.exception import ActionInvalidStateError
+from academy.exception import ExceptionSerializationError
+from academy.exception import MailboxTerminatedError
+from academy.exception import PingCancelledError
 
 if sys.version_info >= (3, 11):  # pragma: >=3.11 cover
     from typing import Self
@@ -27,7 +31,9 @@ from pydantic import SkipValidation
 from pydantic import TypeAdapter
 
 from academy.identifier import EntityId
-from academy.serialize import SerializationStrategies, deserialize, serialize
+from academy.serialize import deserialize
+from academy.serialize import SerializationStrategies
+from academy.serialize import serialize
 
 DEFAULT_FROZEN_CONFIG = ConfigDict(
     arbitrary_types_allowed=True,
@@ -44,6 +50,7 @@ DEFAULT_MUTABLE_CONFIG = ConfigDict(
     validate_default=True,
 )
 
+
 class ActionRequest(BaseModel):
     """Agent action request message.
 
@@ -55,21 +62,21 @@ class ActionRequest(BaseModel):
 
     action: str = Field(description='Name of the requested action.')
     serialization: SerializationStrategies = Field(
-        description='Serialization strategy used send args'
+        description='Serialization strategy used send args',
     )
     result_serialization: SerializationStrategies | None = Field(
         default=None,
         description=(
-            "Requested serialization of results. If none, use the same "
-            "method the args were serialized with."
-        )
+            'Requested serialization of results. If none, use the same '
+            'method the args were serialized with.'
+        ),
     )
     exception_serialization: SerializationStrategies | None = Field(
         default=None,
         description=(
-            "Requested serialization of exceptions. If none, use the same "
-            "method the args were serialized with."
-        )
+            'Requested serialization of exceptions. If none, use the same '
+            'method the args were serialized with.'
+        ),
     )
     pargs: SkipValidation[tuple[Any, ...]] = Field(
         default_factory=tuple,
@@ -157,7 +164,7 @@ class ActionResponse(BaseModel):
         description='Result of the action, if successful.',
     )
     serialization: SerializationStrategies = Field(
-        description='Serialization strategy used send result.'
+        description='Serialization strategy used send result.',
     )
     kind: Literal['action-response'] = Field('action-response', repr=False)
 
@@ -173,7 +180,7 @@ class ActionResponse(BaseModel):
             # Prevent double serialization
             return obj
 
-        data =  serialize(obj, self.serialization)
+        data = serialize(obj, self.serialization)
         # This sential value at the start of the tuple is so we can
         # disambiguate a result that is a str versus the string of a
         # serialized result.
@@ -196,8 +203,11 @@ class ActionResponse(BaseModel):
             self.result = deserialize(self.result[1], self.serialization)
         return self.result
 
+
 @runtime_checkable
 class ErrorResponse(Protocol):
+    """Protocol for all error messages."""
+
     def get_exception(self) -> Exception:
         """Get the exception.
 
@@ -206,11 +216,13 @@ class ErrorResponse(Protocol):
         """
         ...
 
-class ACADEMY_ERROR_CODE(IntEnum):
+
+class AcademyErrorCode(IntEnum):
     """Error codes returned by requests.
-    
-    These error codes allow us to return errrors without serialization.
+
+    These error codes allow us to return errors without serialization.
     """
+
     MAILBOX_TERMINATED = 0
     PING_CANCELLED = 1
     ACTION_INVALID_STATE = 2
@@ -220,14 +232,18 @@ class ACADEMY_ERROR_CODE(IntEnum):
 
 class AcademyErrorResponse(BaseModel):
     """Error response created by Academy."""
-    error_code: ACADEMY_ERROR_CODE = Field(
-        description='Error code '
+
+    error_code: AcademyErrorCode = Field(
+        description='Error code ',
     )
     mailbox_id: EntityId | None = Field(
         description='Mailbox id if necessary for the error.',
         default=None,
     )
-    kind: Literal['academy-error-response'] = Field('academy-error-response', repr=False)
+    kind: Literal['academy-error-response'] = Field(
+        'academy-error-response',
+        repr=False,
+    )
 
     def get_exception(self) -> Exception:
         """Get the exception.
@@ -236,32 +252,38 @@ class AcademyErrorResponse(BaseModel):
             The exception.
         """
         match self.error_code:
-            case ACADEMY_ERROR_CODE.MAILBOX_TERMINATED:
-                assert self.mailbox_id is not None, "Improper error response created."
+            case AcademyErrorCode.MAILBOX_TERMINATED:
+                assert self.mailbox_id is not None, (
+                    'Improper error response created.'
+                )
                 return MailboxTerminatedError(self.mailbox_id)
-            case ACADEMY_ERROR_CODE.PING_CANCELLED:
+            case AcademyErrorCode.PING_CANCELLED:
                 return PingCancelledError()
-            case ACADEMY_ERROR_CODE.ACTION_INVALID_STATE:
+            case AcademyErrorCode.ACTION_INVALID_STATE:
                 return ActionInvalidStateError()
-            case ACADEMY_ERROR_CODE.ACTION_CANCELLED:
+            case AcademyErrorCode.ACTION_CANCELLED:
                 return ActionCancelledError()
-            case ACADEMY_ERROR_CODE.INVALID_CLIENT:
+            case AcademyErrorCode.INVALID_CLIENT:
                 return TypeError(f'{self.mailbox_id} cannot fulfill requests.')
-        assert False, 'Unreachable'
+        raise AssertionError('Unreachable.')
 
-        
+
 class UserErrorResponse(BaseModel):
     """Error response message.
 
     Contains the exception raised by a failed request.
     """
+
     serialization: SerializationStrategies = Field(
-        description='Serialization strategy used send exception.'
+        description='Serialization strategy used send exception.',
     )
     exception: SkipValidation[Exception] = Field(
         description='Exception of the failed request.',
     )
-    kind: Literal['user-error-response'] = Field('user-error-response', repr=False)
+    kind: Literal['user-error-response'] = Field(
+        'user-error-response',
+        repr=False,
+    )
 
     model_config = DEFAULT_MUTABLE_CONFIG
 
@@ -275,11 +297,11 @@ class UserErrorResponse(BaseModel):
             # from being returned. Instead we replace the exception with
             # a exception we know can be serialized, letting the client know
             # that a exception was hidden.
-            print("Serialization raised eception")
+            print('Serialization raised eception')
             return serialize(
                 ExceptionSerializationError(
                     obj.__class__.__name__,
-                    self.serialization
+                    self.serialization,
                 ),
                 self.serialization,
             )
@@ -294,7 +316,7 @@ class UserErrorResponse(BaseModel):
             The deserialized exception.
         """
         if isinstance(self.exception, str):
-            self.exception =  deserialize(self.exception, self.serialization)
+            self.exception = deserialize(self.exception, self.serialization)
         return self.exception
 
 
@@ -307,7 +329,9 @@ class SuccessResponse(BaseModel):
 
 
 Request = ActionRequest | CancelRequest | PingRequest | ShutdownRequest
-Response = ActionResponse | AcademyErrorResponse | UserErrorResponse | SuccessResponse
+Response = (
+    ActionResponse | AcademyErrorResponse | UserErrorResponse | SuccessResponse
+)
 Body = Request | Response
 
 BodyT = TypeVar('BodyT', bound=Body)

--- a/academy/message.py
+++ b/academy/message.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import pickle
 import sys
 import uuid
 from enum import IntEnum
@@ -32,7 +31,7 @@ from pydantic import TypeAdapter
 
 from academy.identifier import EntityId
 from academy.serialize import deserialize
-from academy.serialize import SerializationStrategies
+from academy.serialize import SerializationStrategy
 from academy.serialize import serialize
 
 DEFAULT_FROZEN_CONFIG = ConfigDict(
@@ -56,26 +55,27 @@ class ActionRequest(BaseModel):
 
     Warning:
         The positional and keywords arguments for the invoked action are
-        pickled and base64-encoded when serialized to JSON. This can have
-        non-trivial time and space overheads for large arguments.
+        serialized using `serialization` strategy when the message is
+        serialized to JSON. This can have non-trivial time and space
+        overheads for large arguments.
     """
 
     action: str = Field(description='Name of the requested action.')
-    serialization: SerializationStrategies = Field(
-        description='Serialization strategy used send args',
+    serialization: SerializationStrategy = Field(
+        description='Serialization strategy used to send args',
     )
-    result_serialization: SerializationStrategies | None = Field(
+    result_serialization: SerializationStrategy | None = Field(
         default=None,
         description=(
-            'Requested serialization of results. If none, use the same '
-            'method the args were serialized with.'
+            'Requested serialization of results. If none or empty, use the '
+            'same method the args were serialized with.'
         ),
     )
-    exception_serialization: SerializationStrategies | None = Field(
+    exception_serialization: SerializationStrategy | None = Field(
         default=None,
         description=(
-            'Requested serialization of exceptions. If none, use the same '
-            'method the args were serialized with.'
+            'Requested serialization of exceptions. If none or empty, use '
+            'the same method for exceptions as for results.'
         ),
     )
     pargs: SkipValidation[tuple[Any, ...]] = Field(
@@ -91,7 +91,7 @@ class ActionRequest(BaseModel):
     model_config = DEFAULT_MUTABLE_CONFIG
 
     @field_serializer('pargs', 'kargs', when_used='json')
-    def _pickle_and_encode_obj(self, obj: Any) -> str:
+    def _serialize_obj(self, obj: Any) -> str:
         if isinstance(obj, str):  # pragma: no cover
             return obj
         return serialize(obj, self.serialization)
@@ -156,22 +156,23 @@ class ActionResponse(BaseModel):
     """Agent action response message.
 
     Warning:
-        The result is pickled and base64-encoded when serialized to JSON.
-        This can have non-trivial time and space overheads for large results.
+        The result is serialized using `serialization` when the response is
+        serialized to JSON. This can have non-trivial time and space
+        overheads for large results.
     """
 
     result: SkipValidation[Any] = Field(
         description='Result of the action, if successful.',
     )
-    serialization: SerializationStrategies = Field(
-        description='Serialization strategy used send result.',
+    serialization: SerializationStrategy = Field(
+        description='Serialization strategy used to send result.',
     )
     kind: Literal['action-response'] = Field('action-response', repr=False)
 
     model_config = DEFAULT_MUTABLE_CONFIG
 
     @field_serializer('result', when_used='json')
-    def _pickle_and_encode_result(self, obj: Any) -> list[Any] | None:
+    def _serialize_result(self, obj: Any) -> list[Any] | None:
         if (
             isinstance(obj, list)
             and len(obj) == 2  # noqa PLR2004
@@ -217,7 +218,7 @@ class ErrorResponse(Protocol):
         ...
 
 
-class AcademyErrorCode(IntEnum):
+class ErrorCode(IntEnum):
     """Error codes returned by requests.
 
     These error codes allow us to return errors without serialization.
@@ -233,7 +234,7 @@ class AcademyErrorCode(IntEnum):
 class AcademyErrorResponse(BaseModel):
     """Error response created by Academy."""
 
-    error_code: AcademyErrorCode = Field(
+    error_code: ErrorCode = Field(
         description='Error code ',
     )
     mailbox_id: EntityId | None = Field(
@@ -252,18 +253,19 @@ class AcademyErrorResponse(BaseModel):
             The exception.
         """
         match self.error_code:
-            case AcademyErrorCode.MAILBOX_TERMINATED:
+            case ErrorCode.MAILBOX_TERMINATED:
                 assert self.mailbox_id is not None, (
-                    'Improper error response created.'
+                    'Improper error response while decoding exception. '
+                    'Missing mailbox_id field in MailboxTerminatedError.'
                 )
                 return MailboxTerminatedError(self.mailbox_id)
-            case AcademyErrorCode.PING_CANCELLED:
+            case ErrorCode.PING_CANCELLED:
                 return PingCancelledError()
-            case AcademyErrorCode.ACTION_INVALID_STATE:
+            case ErrorCode.ACTION_INVALID_STATE:
                 return ActionInvalidStateError()
-            case AcademyErrorCode.ACTION_CANCELLED:
+            case ErrorCode.ACTION_CANCELLED:
                 return ActionCancelledError()
-            case AcademyErrorCode.INVALID_CLIENT:
+            case ErrorCode.INVALID_CLIENT:
                 return TypeError(f'{self.mailbox_id} cannot fulfill requests.')
         raise AssertionError('Unreachable.')
 
@@ -274,8 +276,8 @@ class UserErrorResponse(BaseModel):
     Contains the exception raised by a failed request.
     """
 
-    serialization: SerializationStrategies = Field(
-        description='Serialization strategy used send exception.',
+    serialization: SerializationStrategy = Field(
+        description='Serialization strategy used to send exception.',
     )
     exception: SkipValidation[Exception] = Field(
         description='Exception of the failed request.',
@@ -288,7 +290,7 @@ class UserErrorResponse(BaseModel):
     model_config = DEFAULT_MUTABLE_CONFIG
 
     @field_serializer('exception', when_used='json')
-    def _pickle_and_encode_obj(self, obj: Any) -> str | None:
+    def _serialize_obj(self, obj: Any) -> str | None:
         try:
             return serialize(obj, self.serialization)
         except Exception:
@@ -297,7 +299,6 @@ class UserErrorResponse(BaseModel):
             # from being returned. Instead we replace the exception with
             # a exception we know can be serialized, letting the client know
             # that a exception was hidden.
-            print('Serialization raised eception')
             return serialize(
                 ExceptionSerializationError(
                     obj.__class__.__name__,
@@ -521,39 +522,24 @@ class Message(BaseModel, Generic[BodyT]):
 
     @classmethod
     def model_deserialize(cls, data: bytes) -> Message[BodyT]:
-        """Deserialize a message from bytes using pickle.
-
-        Warning:
-            This uses pickle and is therefore susceptible to all the
-            typical pickle warnings about code injection.
+        """Deserialize a message from bytes.
 
         Args:
             data: The serialized message as bytes.
 
         Returns:
             The deserialized message instance.
-
-        Raises:
-            TypeError: If the deserialized object is not a Message.
         """
-        message = pickle.loads(data)
-        if not isinstance(message, cls):
-            raise TypeError(
-                'Deserialized message is not of type Message.',
-            )
+        message = cls.model_validate_json(data.decode('utf-8'))
         return message
 
     def model_serialize(self) -> bytes:
-        """Serialize the message to bytes using pickle.
-
-        Warning:
-            This uses pickle and is therefore susceptible to all the
-            typical pickle warnings about code injection.
+        """Serialize the message to bytes.
 
         Returns:
             The serialized message as bytes.
         """
-        return pickle.dumps(self)
+        return self.model_dump_json().encode('utf-8')
 
     def log_extra(self) -> dict[str, object]:
         """Returns extra info useful in logs about this Message."""

--- a/academy/runtime.py
+++ b/academy/runtime.py
@@ -11,7 +11,7 @@ from collections.abc import Awaitable
 from collections.abc import Callable
 from concurrent.futures import ThreadPoolExecutor
 from types import TracebackType
-from typing import Any, List, Set
+from typing import Any
 from typing import Generic
 from typing import TYPE_CHECKING
 from typing import TypeVar
@@ -21,8 +21,9 @@ if sys.version_info >= (3, 11):  # pragma: >=3.11 cover
 else:  # pragma: <3.11 cover
     from typing_extensions import Self
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel
 from pydantic import ConfigDict
+from pydantic import Field
 
 import academy.exchange as ae
 from academy.context import ActionContext
@@ -34,7 +35,9 @@ from academy.exchange.transport import AgentRegistrationT
 from academy.exchange.transport import ExchangeTransportT
 from academy.handle import exchange_context
 from academy.identifier import EntityId
-from academy.message import ACADEMY_ERROR_CODE, AcademyErrorResponse, ActionRequest, UserErrorResponse
+from academy.message import AcademyErrorCode
+from academy.message import AcademyErrorResponse
+from academy.message import ActionRequest
 from academy.message import ActionResponse
 from academy.message import CancelRequest
 from academy.message import Message
@@ -44,10 +47,11 @@ from academy.message import Response
 from academy.message import ResponseT_co
 from academy.message import ShutdownRequest
 from academy.message import SuccessResponse
-from academy.serialize import ALL_SERIALIZERS, NoPickleMixin
-from academy.serialize import SerializationStrategies
+from academy.message import UserErrorResponse
 from academy.serialize import allowed_deserializers
 from academy.serialize import default_serializer
+from academy.serialize import NoPickleMixin
+from academy.serialize import SerializationStrategies
 from academy.task import spawn_guarded_background_task
 
 if TYPE_CHECKING:
@@ -85,10 +89,10 @@ class RuntimeConfig(BaseModel):
             permanently if the agent shuts down due to an error.
         terminate_on_success: Terminate the agent by closing its mailbox
             permanently if the agent shuts down without an error.
-        default_serializer: Serialization strategy to user when sending 
+        default_serializer: Serialization strategy to user when sending
             requests to other agents. This can be overridden by the `Handle`.
-        allowed_deserializers: Accept only requests whose arguments are 
-            serialized using one of the serializers in this list. If None, 
+        allowed_deserializers: Accept only requests whose arguments are
+            serialized using one of the serializers in this list. If None,
             this will be inherited from the parent context.
     """
 
@@ -101,7 +105,10 @@ class RuntimeConfig(BaseModel):
     terminate_on_error: bool = True
     terminate_on_success: bool = True
     default_serializer: SerializationStrategies | None = None
-    allowed_deserializers: Set[SerializationStrategies] | None = Field(default=None)
+    allowed_deserializers: set[SerializationStrategies] | None = Field(
+        default=None,
+    )
+
 
 class Runtime(Generic[AgentT], NoPickleMixin):
     """Agent runtime manager.
@@ -177,8 +184,12 @@ class Runtime(Generic[AgentT], NoPickleMixin):
             contextvars.Token[ae.ExchangeClient[Any]] | None
         ) = None
 
-        self.allowed_deserializers_token: contextvars.Token[Set[SerializationStrategies]] | None = None
-        self.default_serializer_token: contextvars.Token[SerializationStrategies] | None = None
+        self.allowed_deserializers_token: (
+            contextvars.Token[set[SerializationStrategies]] | None
+        ) = None
+        self.default_serializer_token: (
+            contextvars.Token[SerializationStrategies] | None
+        ) = None
 
     async def __aenter__(self) -> Self:
         try:
@@ -245,12 +256,14 @@ class Runtime(Generic[AgentT], NoPickleMixin):
                 'academy.action_state': 'execute_start',
             },
         )
-        exception_serialization = body.exception_serialization or body.serialization
 
+        result_serialization = body.result_serialization or body.serialization
+        exception_serialization = (
+            body.exception_serialization or result_serialization
+        )
         try:
             # Do not run the method until the startup sequence has finished
             await self._started_event.wait()
-            result_serialization = body.result_serialization or body.serialization
             result = await self.action(
                 body.action,
                 request.src,
@@ -268,7 +281,7 @@ class Runtime(Generic[AgentT], NoPickleMixin):
         except asyncio.CancelledError:
             response = request.create_response(
                 AcademyErrorResponse(
-                    error_code=ACADEMY_ERROR_CODE.ACTION_CANCELLED
+                    error_code=AcademyErrorCode.ACTION_CANCELLED,
                 ),
             )
             logger.debug(
@@ -285,10 +298,13 @@ class Runtime(Generic[AgentT], NoPickleMixin):
                 UserErrorResponse(
                     serialization=exception_serialization,
                     exception=e,
-                )
+                ),
             )
             logger.debug(
-                'Action %s ended with exception, with invocation id %s, serializer: %s',
+                (
+                    'Action %s ended with exception, with invocation '
+                    'id %s, serializer: %s'
+                ),
                 body.action,
                 invocation_id,
                 exception_serialization,
@@ -300,7 +316,10 @@ class Runtime(Generic[AgentT], NoPickleMixin):
             )
         else:
             logger.debug(
-                'Completed action %s with invocation id %s, result serializer: %s',
+                (
+                    'Completed action %s with invocation id %s, result '
+                    'serializer: %s'
+                ),
                 body.action,
                 invocation_id,
                 result_serialization,
@@ -322,7 +341,7 @@ class Runtime(Generic[AgentT], NoPickleMixin):
         except asyncio.CancelledError:
             response = request.create_response(
                 AcademyErrorResponse(
-                    error_code=ACADEMY_ERROR_CODE.PING_CANCELLED
+                    error_code=AcademyErrorCode.PING_CANCELLED,
                 ),
             )
         else:
@@ -379,7 +398,7 @@ class Runtime(Generic[AgentT], NoPickleMixin):
             else:
                 response = request.create_response(
                     AcademyErrorResponse(
-                        error_code=ACADEMY_ERROR_CODE.ACTION_INVALID_STATE
+                        error_code=AcademyErrorCode.ACTION_INVALID_STATE,
                     ),
                 )
             task = asyncio.create_task(self._send_response(response))
@@ -495,6 +514,39 @@ class Runtime(Generic[AgentT], NoPickleMixin):
         async with self:
             await self.wait_shutdown()
 
+    def _set_context_vars(self) -> None:
+        """Set up the context variables for the runtime context."""
+        if self.config.allowed_deserializers is not None:
+            self.allowed_deserializers_token = allowed_deserializers.set(
+                self.config.allowed_deserializers,
+            )
+
+        if self.config.default_serializer:
+            self.default_serializer_token = default_serializer.set(
+                self.config.default_serializer,
+            )
+
+        assert self._exchange_client is not None, (
+            'Context vars cannot be set before creating the exchange client.'
+        )
+        self.exchange_context_token = exchange_context.set(
+            self._exchange_client,
+        )
+
+    def _reset_context_vars(self) -> None:
+        """Reset the context variables for the runtime context."""
+        if self.exchange_context_token is not None:
+            exchange_context.reset(self.exchange_context_token)
+            self.exchange_context_token = None
+
+        if self.default_serializer_token is not None:
+            default_serializer.reset(self.default_serializer_token)
+            self.default_serializer_token = None
+
+        if self.allowed_deserializers_token is not None:
+            allowed_deserializers.reset(self.allowed_deserializers_token)
+            self.allowed_deserializers_token = None
+
     async def _start(self) -> None:
         if self._shutdown_event.is_set():
             raise RuntimeError('Agent has already been shutdown.')
@@ -508,23 +560,13 @@ class Runtime(Generic[AgentT], NoPickleMixin):
                 'academy.agent': self.agent,
             },
         )
-        if self.config.allowed_deserializers is not None:
-            self.allowed_deserializers_token = allowed_deserializers.set(
-                self.config.allowed_deserializers
-            )
-
-        if self.config.default_serializer:
-            self.default_serializer_token = default_serializer.set(
-                self.config.default_serializer
-            )
 
         self._exchange_client = await self.factory.create_agent_client(
             self.registration,
             request_handler=self._request_handler,
         )
-        self.exchange_context_token = exchange_context.set(
-            self._exchange_client,
-        )
+
+        self._set_context_vars()
 
         context = AgentContext(
             agent_id=self.agent_id,
@@ -622,23 +664,13 @@ class Runtime(Generic[AgentT], NoPickleMixin):
                 await task
 
         self._sync_executor.shutdown()
-        # Reset exchange client (for the case of nested execution)
-        if self.exchange_context_token is not None:
-            exchange_context.reset(self.exchange_context_token)
-            self.exchange_context_token = None
+
+        self._reset_context_vars()
 
         if self._exchange_client is not None:
             if self._should_terminate_mailbox():
                 await self._exchange_client.terminate(self.agent_id)
             await self._exchange_client.close()
-
-        if self.default_serializer_token is not None:
-            default_serializer.reset(self.default_serializer_token)
-            self.default_serializer_token = None
-
-        if self.allowed_deserializers_token is not None:
-            allowed_deserializers.reset(self.allowed_deserializers_token)
-            self.allowed_deserializers_token = None
 
         if self.config.raise_loop_errors_on_shutdown:
             # Raise loop exceptions so the caller sees them, even if the loop

--- a/academy/runtime.py
+++ b/academy/runtime.py
@@ -35,11 +35,11 @@ from academy.exchange.transport import AgentRegistrationT
 from academy.exchange.transport import ExchangeTransportT
 from academy.handle import exchange_context
 from academy.identifier import EntityId
-from academy.message import AcademyErrorCode
 from academy.message import AcademyErrorResponse
 from academy.message import ActionRequest
 from academy.message import ActionResponse
 from academy.message import CancelRequest
+from academy.message import ErrorCode
 from academy.message import Message
 from academy.message import PingRequest
 from academy.message import Request
@@ -51,7 +51,7 @@ from academy.message import UserErrorResponse
 from academy.serialize import allowed_deserializers
 from academy.serialize import default_serializer
 from academy.serialize import NoPickleMixin
-from academy.serialize import SerializationStrategies
+from academy.serialize import SerializationStrategy
 from academy.task import spawn_guarded_background_task
 
 if TYPE_CHECKING:
@@ -89,7 +89,7 @@ class RuntimeConfig(BaseModel):
             permanently if the agent shuts down due to an error.
         terminate_on_success: Terminate the agent by closing its mailbox
             permanently if the agent shuts down without an error.
-        default_serializer: Serialization strategy to user when sending
+        default_serializer: Serialization strategy to use when sending
             requests to other agents. This can be overridden by the `Handle`.
         allowed_deserializers: Accept only requests whose arguments are
             serialized using one of the serializers in this list. If None,
@@ -104,8 +104,8 @@ class RuntimeConfig(BaseModel):
     shutdown_on_loop_error: bool = True
     terminate_on_error: bool = True
     terminate_on_success: bool = True
-    default_serializer: SerializationStrategies | None = None
-    allowed_deserializers: set[SerializationStrategies] | None = Field(
+    default_serializer: SerializationStrategy | None = None
+    allowed_deserializers: set[SerializationStrategy] | None = Field(
         default=None,
     )
 
@@ -185,10 +185,10 @@ class Runtime(Generic[AgentT], NoPickleMixin):
         ) = None
 
         self.allowed_deserializers_token: (
-            contextvars.Token[set[SerializationStrategies]] | None
+            contextvars.Token[set[SerializationStrategy]] | None
         ) = None
         self.default_serializer_token: (
-            contextvars.Token[SerializationStrategies] | None
+            contextvars.Token[SerializationStrategy] | None
         ) = None
 
     async def __aenter__(self) -> Self:
@@ -281,7 +281,7 @@ class Runtime(Generic[AgentT], NoPickleMixin):
         except asyncio.CancelledError:
             response = request.create_response(
                 AcademyErrorResponse(
-                    error_code=AcademyErrorCode.ACTION_CANCELLED,
+                    error_code=ErrorCode.ACTION_CANCELLED,
                 ),
             )
             logger.debug(
@@ -311,6 +311,7 @@ class Runtime(Generic[AgentT], NoPickleMixin):
                 extra=invocation_extra
                 | {
                     'academy.action_state': 'execute_exception',
+                    'academy.exception_serialization': exception_serialization,
                 },
                 exc_info=e,
             )
@@ -326,6 +327,7 @@ class Runtime(Generic[AgentT], NoPickleMixin):
                 extra=invocation_extra
                 | {
                     'academy.action_state': 'execute_success',
+                    'academy.result_serialization': result_serialization,
                 },
             )
         finally:
@@ -341,7 +343,7 @@ class Runtime(Generic[AgentT], NoPickleMixin):
         except asyncio.CancelledError:
             response = request.create_response(
                 AcademyErrorResponse(
-                    error_code=AcademyErrorCode.PING_CANCELLED,
+                    error_code=ErrorCode.PING_CANCELLED,
                 ),
             )
         else:
@@ -398,7 +400,7 @@ class Runtime(Generic[AgentT], NoPickleMixin):
             else:
                 response = request.create_response(
                     AcademyErrorResponse(
-                        error_code=AcademyErrorCode.ACTION_INVALID_STATE,
+                        error_code=ErrorCode.ACTION_INVALID_STATE,
                     ),
                 )
             task = asyncio.create_task(self._send_response(response))

--- a/academy/runtime.py
+++ b/academy/runtime.py
@@ -11,7 +11,7 @@ from collections.abc import Awaitable
 from collections.abc import Callable
 from concurrent.futures import ThreadPoolExecutor
 from types import TracebackType
-from typing import Any
+from typing import Any, List, Set
 from typing import Generic
 from typing import TYPE_CHECKING
 from typing import TypeVar
@@ -21,26 +21,22 @@ if sys.version_info >= (3, 11):  # pragma: >=3.11 cover
 else:  # pragma: <3.11 cover
     from typing_extensions import Self
 
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 from pydantic import ConfigDict
 
 import academy.exchange as ae
 from academy.context import ActionContext
 from academy.context import AgentContext
-from academy.exception import ActionCancelledError
-from academy.exception import ActionInvalidStateError
 from academy.exception import ExchangeError
 from academy.exception import MailboxTerminatedError
-from academy.exception import PingCancelledError
 from academy.exception import raise_exceptions
 from academy.exchange.transport import AgentRegistrationT
 from academy.exchange.transport import ExchangeTransportT
 from academy.handle import exchange_context
 from academy.identifier import EntityId
-from academy.message import ActionRequest
+from academy.message import ACADEMY_ERROR_CODE, AcademyErrorResponse, ActionRequest, UserErrorResponse
 from academy.message import ActionResponse
 from academy.message import CancelRequest
-from academy.message import ErrorResponse
 from academy.message import Message
 from academy.message import PingRequest
 from academy.message import Request
@@ -48,7 +44,10 @@ from academy.message import Response
 from academy.message import ResponseT_co
 from academy.message import ShutdownRequest
 from academy.message import SuccessResponse
-from academy.serialize import NoPickleMixin
+from academy.serialize import ALL_SERIALIZERS, NoPickleMixin
+from academy.serialize import SerializationStrategies
+from academy.serialize import allowed_deserializers
+from academy.serialize import default_serializer
 from academy.task import spawn_guarded_background_task
 
 if TYPE_CHECKING:
@@ -86,6 +85,11 @@ class RuntimeConfig(BaseModel):
             permanently if the agent shuts down due to an error.
         terminate_on_success: Terminate the agent by closing its mailbox
             permanently if the agent shuts down without an error.
+        default_serializer: Serialization strategy to user when sending 
+            requests to other agents. This can be overridden by the `Handle`.
+        allowed_deserializers: Accept only requests whose arguments are 
+            serialized using one of the serializers in this list. If None, 
+            this will be inherited from the parent context.
     """
 
     model_config = ConfigDict(extra='forbid')
@@ -96,7 +100,8 @@ class RuntimeConfig(BaseModel):
     shutdown_on_loop_error: bool = True
     terminate_on_error: bool = True
     terminate_on_success: bool = True
-
+    default_serializer: SerializationStrategies | None = None
+    allowed_deserializers: Set[SerializationStrategies] | None = Field(default=None)
 
 class Runtime(Generic[AgentT], NoPickleMixin):
     """Agent runtime manager.
@@ -172,6 +177,9 @@ class Runtime(Generic[AgentT], NoPickleMixin):
             contextvars.Token[ae.ExchangeClient[Any]] | None
         ) = None
 
+        self.allowed_deserializers_token: contextvars.Token[Set[SerializationStrategies]] | None = None
+        self.default_serializer_token: contextvars.Token[SerializationStrategies] | None = None
+
     async def __aenter__(self) -> Self:
         try:
             await self._start()
@@ -237,10 +245,12 @@ class Runtime(Generic[AgentT], NoPickleMixin):
                 'academy.action_state': 'execute_start',
             },
         )
+        exception_serialization = body.exception_serialization or body.serialization
 
         try:
             # Do not run the method until the startup sequence has finished
             await self._started_event.wait()
+            result_serialization = body.result_serialization or body.serialization
             result = await self.action(
                 body.action,
                 request.src,
@@ -248,9 +258,18 @@ class Runtime(Generic[AgentT], NoPickleMixin):
                 kwargs=body.get_kwargs(),
             )
 
+            # Keep response in try/except so serialization errors are caught
+            response = request.create_response(
+                ActionResponse(
+                    serialization=result_serialization,
+                    result=result,
+                ),
+            )
         except asyncio.CancelledError:
             response = request.create_response(
-                ErrorResponse(exception=ActionCancelledError(body.action)),
+                AcademyErrorResponse(
+                    error_code=ACADEMY_ERROR_CODE.ACTION_CANCELLED
+                ),
             )
             logger.debug(
                 'Cancelled action %s with invocation id %s',
@@ -262,11 +281,17 @@ class Runtime(Generic[AgentT], NoPickleMixin):
                 },
             )
         except Exception as e:
-            response = request.create_response(ErrorResponse(exception=e))
+            response = request.create_response(
+                UserErrorResponse(
+                    serialization=exception_serialization,
+                    exception=e,
+                )
+            )
             logger.debug(
-                'Action %s ended with exception, with invocation id %s',
+                'Action %s ended with exception, with invocation id %s, serializer: %s',
                 body.action,
                 invocation_id,
+                exception_serialization,
                 extra=invocation_extra
                 | {
                     'academy.action_state': 'execute_exception',
@@ -274,13 +299,11 @@ class Runtime(Generic[AgentT], NoPickleMixin):
                 exc_info=e,
             )
         else:
-            response = request.create_response(
-                ActionResponse(result=result),
-            )
             logger.debug(
-                'Completed action %s with invocation id %s',
+                'Completed action %s with invocation id %s, result serializer: %s',
                 body.action,
                 invocation_id,
+                result_serialization,
                 extra=invocation_extra
                 | {
                     'academy.action_state': 'execute_success',
@@ -298,7 +321,9 @@ class Runtime(Generic[AgentT], NoPickleMixin):
             await self._started_event.wait()
         except asyncio.CancelledError:
             response = request.create_response(
-                ErrorResponse(exception=PingCancelledError()),
+                AcademyErrorResponse(
+                    error_code=ACADEMY_ERROR_CODE.PING_CANCELLED
+                ),
             )
         else:
             response = request.create_response(SuccessResponse())
@@ -353,7 +378,9 @@ class Runtime(Generic[AgentT], NoPickleMixin):
                 response = request.create_response(SuccessResponse())
             else:
                 response = request.create_response(
-                    ErrorResponse(exception=ActionInvalidStateError()),
+                    AcademyErrorResponse(
+                        error_code=ACADEMY_ERROR_CODE.ACTION_INVALID_STATE
+                    ),
                 )
             task = asyncio.create_task(self._send_response(response))
             self._action_tasks[request.tag] = task
@@ -481,6 +508,15 @@ class Runtime(Generic[AgentT], NoPickleMixin):
                 'academy.agent': self.agent,
             },
         )
+        if self.config.allowed_deserializers is not None:
+            self.allowed_deserializers_token = allowed_deserializers.set(
+                self.config.allowed_deserializers
+            )
+
+        if self.config.default_serializer:
+            self.default_serializer_token = default_serializer.set(
+                self.config.default_serializer
+            )
 
         self._exchange_client = await self.factory.create_agent_client(
             self.registration,
@@ -595,6 +631,14 @@ class Runtime(Generic[AgentT], NoPickleMixin):
             if self._should_terminate_mailbox():
                 await self._exchange_client.terminate(self.agent_id)
             await self._exchange_client.close()
+
+        if self.default_serializer_token is not None:
+            default_serializer.reset(self.default_serializer_token)
+            self.default_serializer_token = None
+
+        if self.allowed_deserializers_token is not None:
+            allowed_deserializers.reset(self.allowed_deserializers_token)
+            self.allowed_deserializers_token = None
 
         if self.config.raise_loop_errors_on_shutdown:
             # Raise loop exceptions so the caller sees them, even if the loop

--- a/academy/serialize.py
+++ b/academy/serialize.py
@@ -1,11 +1,139 @@
 from __future__ import annotations
 
+import base64
+from contextvars import ContextVar
+from enum import StrEnum
 import pickle
-from typing import Any
+from typing import Any, Literal, Protocol, TypeAlias
+import traceback
+import json
+import logging
 
+from academy.exception import DeserializationMethodProhibited, RemoteException
+
+logger = logging.getLogger(__name__)
 
 class NoPickleMixin:
     """Mixin that raises an error if a type is pickled."""
 
     def __getstate__(self) -> Any:
         raise pickle.PicklingError(f'{type(self).__name__} is not pickleable.')
+
+class Serializer(Protocol):
+    """Protocol for different types of serialization methods.
+    """
+    @classmethod
+    def serialize(cls, obj: Any) -> str:
+        """Serailize object."""
+        ...
+
+    @classmethod
+    def deserialize(cls, data: str) -> Any:
+        """Deserialize data."""
+        ...
+
+def json_exception_serializer(obj: Any) -> dict:
+    """Serialize exceptions as json.
+    
+    Extension to json serialization to deal with arbitrary exceptions.
+    """
+    if isinstance(obj, BaseException):
+        exception_str = "".join(traceback.format_exception(
+            type(obj),
+            obj,
+            obj.__traceback__,
+        ))
+        return {
+            '__exception__': True,
+            'exception_str': exception_str
+        }
+    
+    raise TypeError(f'Cannot serialize object of {type(obj)}')
+
+def json_exception_deserializer(dct: dict[str, Any]) -> Exception | dict[str, Any]:
+    """Deserialize exceptions from json.
+
+    Extension to json serializer that parses serialized exceptions into
+    a RemoteException.
+    """
+    if '__exception__' in dct:
+        return RemoteException(dct['exception_str'])
+    
+    return dct
+
+class JsonSerializer:
+    @classmethod
+    def serialize(self, obj: Any) -> str:
+        """Serailize object."""
+        return json.dumps(obj, default=json_exception_serializer)
+    
+    @classmethod
+    def deserialize(self, data: str) -> Any:
+        """Deserialize data."""
+        return json.loads(data, object_hook=json_exception_deserializer)
+    
+class PickleSerializer:
+    @classmethod
+    def serialize(self, obj: Any) -> str:
+        """Serailize object."""
+        raw = pickle.dumps(obj)
+        return base64.b64encode(raw).decode('utf-8')
+
+    @classmethod    
+    def deserialize(self, data: str) -> Any:
+        """Deserialize data."""
+        return pickle.loads(base64.b64decode(data))
+    
+class SerializationStrategies(StrEnum):
+    PICKLE = "pickle"
+    JSON = "json"
+
+ALL_SERIALIZERS = {
+    SerializationStrategies.PICKLE, 
+    SerializationStrategies.JSON
+}
+
+default_serializer: ContextVar[SerializationStrategies] = ContextVar(
+    'default_serializer',
+    default=SerializationStrategies.PICKLE,
+)
+
+allowed_deserializers: ContextVar[set[SerializationStrategies]] = ContextVar(
+    'deserialization_allow_list',
+    default=ALL_SERIALIZERS,
+)
+    
+def _get_serializer(strategy: SerializationStrategies):
+    if strategy == SerializationStrategies.PICKLE:
+        return PickleSerializer
+    elif strategy == SerializationStrategies.JSON:
+        return JsonSerializer
+    
+    assert False, "Unreachable"
+
+def serialize(obj: Any, strategy: SerializationStrategies) -> str:
+    '''Serialize object using strategy.
+
+    Args:
+        obj: Object to be serialized.
+        strategy: Strategy used for serialization.
+    Returns:
+        Serialized data.
+    '''
+    serializer = _get_serializer(strategy)
+    return serializer.serialize(obj)
+
+def deserialize(obj: str, strategy: SerializationStrategies) -> Any:
+    '''Deserialize object using strategy.
+
+    Args:
+        obj: Json data.
+        strategy: Strategy used for serialization.
+    Returns:
+        Deserialized object.
+    '''
+    logger.debug(f"Allowed Deserializers: {allowed_deserializers.get()}")
+    if strategy not in allowed_deserializers.get():
+        raise DeserializationMethodProhibited()
+    serializer = _get_serializer(strategy)
+    return serializer.deserialize(obj)

--- a/academy/serialize.py
+++ b/academy/serialize.py
@@ -78,7 +78,7 @@ class JsonSerializer:
     """Serializes objects into json.
 
     Works only on basic python types, but allows deserialization without
-    arbitrary code execution, and has increased compatibility between
+    arbitrary code execution, and is compatible between
     python versions.
     """
 
@@ -99,7 +99,8 @@ class PickleSerializer:
     Seriliazes objects using pickle. Generally allows for a wider range of
     types to be serialized, but cannot deserialize without allowing arbitrary
     code execution. Sending pickled python objects between processes with
-    different python versions can lead to unexpected results.
+    different python versions or different environments can lead to unexpected
+    results.
     """
 
     @classmethod
@@ -114,7 +115,7 @@ class PickleSerializer:
         return pickle.loads(base64.b64decode(data))
 
 
-class SerializationStrategies(str, Enum):
+class SerializationStrategy(str, Enum):
     """Enum for different serialization strategies."""
 
     PICKLE = 'pickle'
@@ -122,34 +123,34 @@ class SerializationStrategies(str, Enum):
 
 
 ALL_SERIALIZERS = {
-    SerializationStrategies.PICKLE,
-    SerializationStrategies.JSON,
+    SerializationStrategy.PICKLE,
+    SerializationStrategy.JSON,
 }
 
 
-default_serializer: ContextVar[SerializationStrategies] = ContextVar(
+default_serializer: ContextVar[SerializationStrategy] = ContextVar(
     'default_serializer',
-    default=SerializationStrategies.PICKLE,
+    default=SerializationStrategy.PICKLE,
 )
 """Default serialization method used to send requests."""
 
-allowed_deserializers: ContextVar[set[SerializationStrategies]] = ContextVar(
-    'deserialization_allow_list',
+allowed_deserializers: ContextVar[set[SerializationStrategy]] = ContextVar(
+    'allowed_deserializers',
     default=ALL_SERIALIZERS,
 )
 """Deserializers allowed in this context."""
 
 
-def _get_serializer(strategy: SerializationStrategies) -> type[Serializer]:
-    if strategy == SerializationStrategies.PICKLE:
+def _get_serializer(strategy: SerializationStrategy) -> type[Serializer]:
+    if strategy == SerializationStrategy.PICKLE:
         return PickleSerializer
-    elif strategy == SerializationStrategies.JSON:
+    elif strategy == SerializationStrategy.JSON:
         return JsonSerializer
 
     raise AssertionError('Unreachable')
 
 
-def serialize(obj: Any, strategy: SerializationStrategies) -> str:
+def serialize(obj: Any, strategy: SerializationStrategy) -> str:
     """Serialize object using strategy.
 
     Args:
@@ -163,7 +164,7 @@ def serialize(obj: Any, strategy: SerializationStrategies) -> str:
     return serializer.serialize(obj)
 
 
-def deserialize(obj: str, strategy: SerializationStrategies) -> Any:
+def deserialize(obj: str, strategy: SerializationStrategy) -> Any:
     """Deserialize object using strategy.
 
     Args:

--- a/academy/serialize.py
+++ b/academy/serialize.py
@@ -6,7 +6,7 @@ import logging
 import pickle
 import traceback
 from contextvars import ContextVar
-from enum import StrEnum
+from enum import Enum
 from typing import Any
 from typing import Protocol
 
@@ -114,7 +114,7 @@ class PickleSerializer:
         return pickle.loads(base64.b64decode(data))
 
 
-class SerializationStrategies(StrEnum):
+class SerializationStrategies(str, Enum):
     """Enum for different serialization strategies."""
 
     PICKLE = 'pickle'

--- a/academy/serialize.py
+++ b/academy/serialize.py
@@ -1,17 +1,20 @@
 from __future__ import annotations
 
 import base64
-from contextvars import ContextVar
-from enum import StrEnum
-import pickle
-from typing import Any, Literal, Protocol, TypeAlias
-import traceback
 import json
 import logging
+import pickle
+import traceback
+from contextvars import ContextVar
+from enum import StrEnum
+from typing import Any
+from typing import Protocol
 
-from academy.exception import DeserializationMethodProhibited, RemoteException
+from academy.exception import AcademyRemoteError
+from academy.exception import DeserializationMethodProhibitedError
 
 logger = logging.getLogger(__name__)
+
 
 class NoPickleMixin:
     """Mixin that raises an error if a type is pickled."""
@@ -19,12 +22,13 @@ class NoPickleMixin:
     def __getstate__(self) -> Any:
         raise pickle.PicklingError(f'{type(self).__name__} is not pickleable.')
 
+
 class Serializer(Protocol):
-    """Protocol for different types of serialization methods.
-    """
+    """Protocol for different types of serialization methods."""
+
     @classmethod
     def serialize(cls, obj: Any) -> str:
-        """Serailize object."""
+        """Serialize object."""
         ...
 
     @classmethod
@@ -32,108 +36,144 @@ class Serializer(Protocol):
         """Deserialize data."""
         ...
 
-def json_exception_serializer(obj: Any) -> dict:
+
+def json_exception_serializer(obj: Any) -> dict[str, bool | str]:
     """Serialize exceptions as json.
-    
+
     Extension to json serialization to deal with arbitrary exceptions.
     """
     if isinstance(obj, BaseException):
-        exception_str = "".join(traceback.format_exception(
-            type(obj),
-            obj,
-            obj.__traceback__,
-        ))
+        exception_str = ''.join(
+            traceback.format_exception(
+                type(obj),
+                obj,
+                obj.__traceback__,
+            ),
+        )
         return {
             '__exception__': True,
-            'exception_str': exception_str
+            'exception_str': exception_str,
         }
-    
-    raise TypeError(f'Cannot serialize object of {type(obj)}')
 
-def json_exception_deserializer(dct: dict[str, Any]) -> Exception | dict[str, Any]:
+    raise TypeError(
+        f'Cannot serialize object of {type(obj)}',
+    )  # pragma: no cover
+
+
+def json_exception_deserializer(
+    dct: dict[str, Any],
+) -> Exception | dict[str, Any]:
     """Deserialize exceptions from json.
 
     Extension to json serializer that parses serialized exceptions into
     a RemoteException.
     """
     if '__exception__' in dct:
-        return RemoteException(dct['exception_str'])
-    
+        return AcademyRemoteError(dct['exception_str'])
+
     return dct
 
+
 class JsonSerializer:
+    """Serializes objects into json.
+
+    Works only on basic python types, but allows deserialization without
+    arbitrary code execution, and has increased compatibility between
+    python versions.
+    """
+
     @classmethod
-    def serialize(self, obj: Any) -> str:
-        """Serailize object."""
+    def serialize(cls, obj: Any) -> str:
+        """Serialize object."""
         return json.dumps(obj, default=json_exception_serializer)
-    
+
     @classmethod
-    def deserialize(self, data: str) -> Any:
+    def deserialize(cls, data: str) -> Any:
         """Deserialize data."""
         return json.loads(data, object_hook=json_exception_deserializer)
-    
+
+
 class PickleSerializer:
+    """Serializes objects using pickle.
+
+    Seriliazes objects using pickle. Generally allows for a wider range of
+    types to be serialized, but cannot deserialize without allowing arbitrary
+    code execution. Sending pickled python objects between processes with
+    different python versions can lead to unexpected results.
+    """
+
     @classmethod
-    def serialize(self, obj: Any) -> str:
-        """Serailize object."""
+    def serialize(cls, obj: Any) -> str:
+        """Serialize object."""
         raw = pickle.dumps(obj)
         return base64.b64encode(raw).decode('utf-8')
 
-    @classmethod    
-    def deserialize(self, data: str) -> Any:
+    @classmethod
+    def deserialize(cls, data: str) -> Any:
         """Deserialize data."""
         return pickle.loads(base64.b64decode(data))
-    
+
+
 class SerializationStrategies(StrEnum):
-    PICKLE = "pickle"
-    JSON = "json"
+    """Enum for different serialization strategies."""
+
+    PICKLE = 'pickle'
+    JSON = 'json'
+
 
 ALL_SERIALIZERS = {
-    SerializationStrategies.PICKLE, 
-    SerializationStrategies.JSON
+    SerializationStrategies.PICKLE,
+    SerializationStrategies.JSON,
 }
+
 
 default_serializer: ContextVar[SerializationStrategies] = ContextVar(
     'default_serializer',
     default=SerializationStrategies.PICKLE,
 )
+"""Default serialization method used to send requests."""
 
 allowed_deserializers: ContextVar[set[SerializationStrategies]] = ContextVar(
     'deserialization_allow_list',
     default=ALL_SERIALIZERS,
 )
-    
-def _get_serializer(strategy: SerializationStrategies):
+"""Deserializers allowed in this context."""
+
+
+def _get_serializer(strategy: SerializationStrategies) -> type[Serializer]:
     if strategy == SerializationStrategies.PICKLE:
         return PickleSerializer
     elif strategy == SerializationStrategies.JSON:
         return JsonSerializer
-    
-    assert False, "Unreachable"
+
+    raise AssertionError('Unreachable')
+
 
 def serialize(obj: Any, strategy: SerializationStrategies) -> str:
-    '''Serialize object using strategy.
+    """Serialize object using strategy.
 
     Args:
         obj: Object to be serialized.
         strategy: Strategy used for serialization.
+
     Returns:
         Serialized data.
-    '''
+    """
     serializer = _get_serializer(strategy)
     return serializer.serialize(obj)
 
+
 def deserialize(obj: str, strategy: SerializationStrategies) -> Any:
-    '''Deserialize object using strategy.
+    """Deserialize object using strategy.
 
     Args:
         obj: Json data.
         strategy: Strategy used for serialization.
+
     Returns:
         Deserialized object.
-    '''
-    logger.debug(f"Allowed Deserializers: {allowed_deserializers.get()}")
+    """
     if strategy not in allowed_deserializers.get():
-        raise DeserializationMethodProhibited()
+        raise DeserializationMethodProhibitedError()
     serializer = _get_serializer(strategy)
     return serializer.deserialize(obj)

--- a/docs/guides/persistent.md
+++ b/docs/guides/persistent.md
@@ -112,7 +112,7 @@ User=centos
 ExecStart=~/.venv/bin/python -m academy.run --config <config.toml>
 ```
 
-Once you have created you unit file, you can start the service:
+Once you have created a unit file, you can start the service:
 ```
 systemctl --user start <service_name>
 ```

--- a/testing/utils.py
+++ b/testing/utils.py
@@ -27,7 +27,7 @@ def urlencoded_params_matcher_allow_missing(
         valid = True
         request_body = request.body
         qsl_body = (
-            dict(parse_qsl(request_body, keep_blank_values=allow_blank))  # type: ignore[type-var]
+            dict(parse_qsl(request_body, keep_blank_values=allow_blank))
             if request_body
             else {}
         )

--- a/testing/utils.py
+++ b/testing/utils.py
@@ -27,7 +27,7 @@ def urlencoded_params_matcher_allow_missing(
         valid = True
         request_body = request.body
         qsl_body = (
-            dict(parse_qsl(request_body, keep_blank_values=allow_blank))
+            dict(parse_qsl(request_body, keep_blank_values=allow_blank))  # type: ignore[type-var]
             if request_body
             else {}
         )

--- a/tests/unit/exception_test.py
+++ b/tests/unit/exception_test.py
@@ -4,11 +4,14 @@ import pickle
 
 import pytest
 
-from academy.exception import ActionCancelledError, DeserializationMethodProhibited, ExceptionSerializationError, RemoteException
+from academy.exception import AcademyRemoteError
+from academy.exception import ActionCancelledError
 from academy.exception import ActionInvalidStateError
 from academy.exception import AgentNotInitializedError
 from academy.exception import AgentTerminatedError
 from academy.exception import BadEntityIdError
+from academy.exception import DeserializationMethodProhibitedError
+from academy.exception import ExceptionSerializationError
 from academy.exception import ExchangeClientNotFoundError
 from academy.exception import ExchangeError
 from academy.exception import ForbiddenError
@@ -37,9 +40,9 @@ from academy.identifier import UserId
         UnauthorizedError(),
         ExchangeClientNotFoundError(AgentId.new()),
         PingCancelledError(),
-        DeserializationMethodProhibited(),
-        ExceptionSerializationError(TypeError, 'pickle'),
-        RemoteException(),
+        DeserializationMethodProhibitedError(),
+        ExceptionSerializationError('TestError traceback', 'pickle'),
+        AcademyRemoteError(),
     ),
 )
 def test_pickle_exception(exc: Exception) -> None:

--- a/tests/unit/exception_test.py
+++ b/tests/unit/exception_test.py
@@ -4,7 +4,7 @@ import pickle
 
 import pytest
 
-from academy.exception import ActionCancelledError
+from academy.exception import ActionCancelledError, DeserializationMethodProhibited, ExceptionSerializationError, RemoteException
 from academy.exception import ActionInvalidStateError
 from academy.exception import AgentNotInitializedError
 from academy.exception import AgentTerminatedError
@@ -24,7 +24,7 @@ from academy.identifier import UserId
 @pytest.mark.parametrize(
     'exc',
     (
-        ActionCancelledError('test'),
+        ActionCancelledError(),
         ActionInvalidStateError(),
         AgentNotInitializedError(),
         ExchangeError(),
@@ -37,6 +37,9 @@ from academy.identifier import UserId
         UnauthorizedError(),
         ExchangeClientNotFoundError(AgentId.new()),
         PingCancelledError(),
+        DeserializationMethodProhibited(),
+        ExceptionSerializationError(TypeError, 'pickle'),
+        RemoteException(),
     ),
 )
 def test_pickle_exception(exc: Exception) -> None:

--- a/tests/unit/exchange/cloud/backend_test.py
+++ b/tests/unit/exchange/cloud/backend_test.py
@@ -130,7 +130,7 @@ async def test_mailbox_backend_mailbox_delete_agent(
 
     message = await backend.get(client, uid, timeout=0.01)
     assert isinstance(message.get_body(), ErrorResponse)
-    assert isinstance(message.body.exception, MailboxTerminatedError)
+    assert isinstance(message.body.get_exception(), MailboxTerminatedError)
 
     with pytest.raises(TimeoutError):
         await backend.get(client, uid, timeout=0.01)

--- a/tests/unit/exchange/proxystore_test.py
+++ b/tests/unit/exchange/proxystore_test.py
@@ -14,7 +14,7 @@ from academy.message import ActionRequest
 from academy.message import ActionResponse
 from academy.message import Message
 from academy.message import PingRequest
-from academy.serialize import SerializationStrategies
+from academy.serialize import SerializationStrategy
 from testing.agents import EmptyAgent
 from testing.constant import TEST_SLEEP_INTERVAL
 
@@ -89,7 +89,7 @@ async def test_wrap_basic_transport_functionality(
             action='test',
             pargs=('value', 123),
             kargs={'foo': 'value', 'bar': 123},
-            serialization=SerializationStrategies.PICKLE,
+            serialization=SerializationStrategy.PICKLE,
         )
         sent_request_message = Message.create(
             src=src,
@@ -119,7 +119,7 @@ async def test_wrap_basic_transport_functionality(
             assert old == new
 
         sent_response = ActionResponse(
-            serialization=SerializationStrategies.PICKLE,
+            serialization=SerializationStrategy.PICKLE,
             result='result',
         )
         sent_response_message = sent_request_message.create_response(

--- a/tests/unit/exchange/proxystore_test.py
+++ b/tests/unit/exchange/proxystore_test.py
@@ -14,6 +14,7 @@ from academy.message import ActionRequest
 from academy.message import ActionResponse
 from academy.message import Message
 from academy.message import PingRequest
+from academy.serialize import SerializationStrategies
 from testing.agents import EmptyAgent
 from testing.constant import TEST_SLEEP_INTERVAL
 
@@ -88,6 +89,7 @@ async def test_wrap_basic_transport_functionality(
             action='test',
             pargs=('value', 123),
             kargs={'foo': 'value', 'bar': 123},
+            serialization=SerializationStrategies.PICKLE,
         )
         sent_request_message = Message.create(
             src=src,
@@ -116,7 +118,10 @@ async def test_wrap_basic_transport_functionality(
             assert (type(new) is Proxy) == should_proxy(old)
             assert old == new
 
-        sent_response = ActionResponse(result='result')
+        sent_response = ActionResponse(
+            serialization=SerializationStrategies.PICKLE,
+            result='result',
+        )
         sent_response_message = sent_request_message.create_response(
             sent_response,
         )

--- a/tests/unit/handle_test.py
+++ b/tests/unit/handle_test.py
@@ -11,7 +11,8 @@ from unittest import mock
 import pytest
 import pytest_asyncio
 
-from academy.exception import AgentTerminatedError, DeserializationMethodProhibited
+from academy.exception import AgentTerminatedError
+from academy.exception import DeserializationMethodProhibitedError
 from academy.exception import ExchangeClientNotFoundError
 from academy.exchange import LocalExchangeFactory
 from academy.exchange import LocalExchangeTransport
@@ -24,12 +25,16 @@ from academy.handle import Handle
 from academy.handle import ProxyHandle
 from academy.identifier import AgentId
 from academy.manager import Manager
+from academy.message import AcademyErrorCode
+from academy.message import AcademyErrorResponse
 from academy.message import ActionRequest
 from academy.message import CancelRequest
 from academy.message import Message
 from academy.message import Request
-from academy.serialize import SerializationStrategies, default_serializer
+from academy.message import Response
 from academy.serialize import allowed_deserializers
+from academy.serialize import default_serializer
+from academy.serialize import SerializationStrategies
 from testing.agents import CounterAgent
 from testing.agents import EmptyAgent
 from testing.agents import ErrorAgent
@@ -115,7 +120,10 @@ async def test_agent_handle_serialize(
     exchange_client: UserExchangeClient[LocalExchangeTransport],
 ) -> None:
     registration = await exchange_client.register_agent(EmptyAgent)
-    handle = Handle(registration.agent_id, serializer=SerializationStrategies.PICKLE)
+    handle = Handle(
+        registration.agent_id,
+        serializer=SerializationStrategies.PICKLE,
+    )
     reconstructed = pickle.loads(pickle.dumps(handle))
     assert isinstance(reconstructed, Handle)
     assert reconstructed.agent_id == handle.agent_id
@@ -208,22 +216,27 @@ async def test_client_handle_ping_timeout(
         await handle.ping(timeout=TEST_SLEEP_INTERVAL)
 
 
-async def test_client_handle_shutdown_ignore_already_terminated() -> None:
-    handle: Handle[EmptyAgent] = Handle(AgentId.new())
-    future: asyncio.Future[None] = asyncio.Future()
-    future.set_exception(AgentTerminatedError(handle.agent_id))
-    handle._shutdown_callback(future)
-
-
 @pytest.mark.asyncio
-async def test_client_handle_shutdown_log_error_response(caplog) -> None:
+async def test_client_handle_shutdown_future_error_logged(caplog) -> None:
     handle: Handle[EmptyAgent] = Handle(AgentId.new())
-    future: asyncio.Future[None] = asyncio.Future()
-    future.set_exception(AgentTerminatedError(AgentId.new()))
-
+    future: asyncio.Future[Response] = asyncio.Future()
+    future.set_exception(Exception('Test'))
+    handle._shutdown_callback(future)
     with caplog.at_level(logging.ERROR):
         handle._shutdown_callback(future)
     assert f'Failure requesting shutdown for {handle.agent_id}' in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_client_handle_shutdown_ignore_already_terminated() -> None:
+    handle: Handle[EmptyAgent] = Handle(AgentId.new())
+    future: asyncio.Future[Response] = asyncio.Future()
+    response = AcademyErrorResponse(
+        error_code=AcademyErrorCode.MAILBOX_TERMINATED,
+        mailbox_id=handle.agent_id,
+    )
+    future.set_result(response)
+    handle._shutdown_callback(future)
 
 
 EXCHANGE_FACTORY_TYPES = (
@@ -558,70 +571,79 @@ async def test_handle_covariance(
 
 @pytest.mark.asyncio
 async def test_handle_respects_deserialize_allow_list(
-    http_exchange_factory: HttpExchangeFactory
+    http_exchange_factory: HttpExchangeFactory,
 ):
     async with await Manager.from_exchange_factory(
         factory=http_exchange_factory,
     ) as manager:
         handle = await manager.launch(CounterAgent())
         assert await handle.ping() > 0
-        with allowed_deserializers.set({SerializationStrategies.JSON}):
-            with pytest.raises(DeserializationMethodProhibited):
-                await handle.action('add', 1)
+        token = allowed_deserializers.set({SerializationStrategies.JSON})
+        with pytest.raises(DeserializationMethodProhibitedError):
+            await handle.action('add', 1)
+        allowed_deserializers.reset(token)
 
 
 @pytest.mark.asyncio
 async def test_handle_uses_default_serializer(
-    http_exchange_factory: HttpExchangeFactory
+    http_exchange_factory: HttpExchangeFactory,
 ):
     async with await Manager.from_exchange_factory(
         factory=http_exchange_factory,
     ) as manager:
         handle = await manager.launch(CounterAgent())
         assert await handle.ping() > 0
-        with allowed_deserializers.set({SerializationStrategies.JSON}):
-            with default_serializer.set(SerializationStrategies.JSON):
-                    await handle.action('add', 1)
+        token = allowed_deserializers.set({SerializationStrategies.JSON})
+        default_token = default_serializer.set(SerializationStrategies.JSON)
+        await handle.action('add', 1)
+        default_serializer.reset(default_token)
+        allowed_deserializers.reset(token)
+
 
 @pytest.mark.asyncio
 async def test_handle_args_serializer(
-    http_exchange_factory: HttpExchangeFactory
+    http_exchange_factory: HttpExchangeFactory,
 ):
     async with await Manager.from_exchange_factory(
         factory=http_exchange_factory,
     ) as manager:
-        with allowed_deserializers.set({SerializationStrategies.JSON}):
-            handle = await manager.launch(CounterAgent())
-            handle.serialization = SerializationStrategies.JSON
-            assert await handle.ping() > 0
-            await handle.action('add', 1)
+        token = allowed_deserializers.set({SerializationStrategies.JSON})
+        handle = await manager.launch(CounterAgent())
+        handle.serialization = SerializationStrategies.JSON
+        assert await handle.ping() > 0
+        await handle.action('add', 1)
+        allowed_deserializers.reset(token)
+
 
 @pytest.mark.asyncio
 async def test_handle_results_serializer(
-    http_exchange_factory: HttpExchangeFactory
+    http_exchange_factory: HttpExchangeFactory,
 ):
     async with await Manager.from_exchange_factory(
         factory=http_exchange_factory,
     ) as manager:
-        with allowed_deserializers.set({SerializationStrategies.JSON}):
-            handle = await manager.launch(CounterAgent())
-            handle.serialization = SerializationStrategies.JSON
-            handle.result_serializer = SerializationStrategies.PICKLE
-            assert await handle.ping() > 0
-            with pytest.raises(DeserializationMethodProhibited):
-                await handle.action('add', 1)
+        token = allowed_deserializers.set({SerializationStrategies.JSON})
+        handle = await manager.launch(CounterAgent())
+        handle.serialization = SerializationStrategies.JSON
+        handle.result_serializer = SerializationStrategies.PICKLE
+        assert await handle.ping() > 0
+        with pytest.raises(DeserializationMethodProhibitedError):
+            await handle.action('add', 1)
+        allowed_deserializers.reset(token)
+
 
 @pytest.mark.asyncio
 async def test_handle_exception_serializer(
-    http_exchange_factory: HttpExchangeFactory
+    http_exchange_factory: HttpExchangeFactory,
 ):
     async with await Manager.from_exchange_factory(
         factory=http_exchange_factory,
     ) as manager:
-        with allowed_deserializers.set({SerializationStrategies.JSON}):
-            error_handle = await manager.launch(ErrorAgent)
-            error_handle.serialization = SerializationStrategies.JSON
-            error_handle.exception_serializer = SerializationStrategies.PICKLE
-            assert await error_handle.ping() > 0
-            with pytest.raises(DeserializationMethodProhibited):
-                await error_handle.fails()
+        token = allowed_deserializers.set({SerializationStrategies.JSON})
+        error_handle = await manager.launch(ErrorAgent)
+        error_handle.serialization = SerializationStrategies.JSON
+        error_handle.exception_serializer = SerializationStrategies.PICKLE
+        assert await error_handle.ping() > 0
+        with pytest.raises(DeserializationMethodProhibitedError):
+            await error_handle.fails()
+        allowed_deserializers.reset(token)

--- a/tests/unit/handle_test.py
+++ b/tests/unit/handle_test.py
@@ -25,16 +25,16 @@ from academy.handle import Handle
 from academy.handle import ProxyHandle
 from academy.identifier import AgentId
 from academy.manager import Manager
-from academy.message import AcademyErrorCode
 from academy.message import AcademyErrorResponse
 from academy.message import ActionRequest
 from academy.message import CancelRequest
+from academy.message import ErrorCode
 from academy.message import Message
 from academy.message import Request
 from academy.message import Response
 from academy.serialize import allowed_deserializers
 from academy.serialize import default_serializer
-from academy.serialize import SerializationStrategies
+from academy.serialize import SerializationStrategy
 from testing.agents import CounterAgent
 from testing.agents import EmptyAgent
 from testing.agents import ErrorAgent
@@ -122,14 +122,14 @@ async def test_agent_handle_serialize(
     registration = await exchange_client.register_agent(EmptyAgent)
     handle = Handle(
         registration.agent_id,
-        serializer=SerializationStrategies.PICKLE,
+        request_serializer=SerializationStrategy.PICKLE,
     )
     reconstructed = pickle.loads(pickle.dumps(handle))
     assert isinstance(reconstructed, Handle)
     assert reconstructed.agent_id == handle.agent_id
     assert str(reconstructed) == str(handle)
     assert repr(reconstructed) == repr(handle)
-    assert reconstructed.serialization == handle.serialization
+    assert reconstructed.request_serializer == handle.request_serializer
 
 
 def test_handle_pickle_unbound_raises() -> None:
@@ -232,7 +232,7 @@ async def test_client_handle_shutdown_ignore_already_terminated() -> None:
     handle: Handle[EmptyAgent] = Handle(AgentId.new())
     future: asyncio.Future[Response] = asyncio.Future()
     response = AcademyErrorResponse(
-        error_code=AcademyErrorCode.MAILBOX_TERMINATED,
+        error_code=ErrorCode.MAILBOX_TERMINATED,
         mailbox_id=handle.agent_id,
     )
     future.set_result(response)
@@ -578,7 +578,7 @@ async def test_handle_respects_deserialize_allow_list(
     ) as manager:
         handle = await manager.launch(CounterAgent())
         assert await handle.ping() > 0
-        token = allowed_deserializers.set({SerializationStrategies.JSON})
+        token = allowed_deserializers.set({SerializationStrategy.JSON})
         with pytest.raises(DeserializationMethodProhibitedError):
             await handle.action('add', 1)
         allowed_deserializers.reset(token)
@@ -593,8 +593,8 @@ async def test_handle_uses_default_serializer(
     ) as manager:
         handle = await manager.launch(CounterAgent())
         assert await handle.ping() > 0
-        token = allowed_deserializers.set({SerializationStrategies.JSON})
-        default_token = default_serializer.set(SerializationStrategies.JSON)
+        token = allowed_deserializers.set({SerializationStrategy.JSON})
+        default_token = default_serializer.set(SerializationStrategy.JSON)
         await handle.action('add', 1)
         default_serializer.reset(default_token)
         allowed_deserializers.reset(token)
@@ -607,9 +607,9 @@ async def test_handle_args_serializer(
     async with await Manager.from_exchange_factory(
         factory=http_exchange_factory,
     ) as manager:
-        token = allowed_deserializers.set({SerializationStrategies.JSON})
+        token = allowed_deserializers.set({SerializationStrategy.JSON})
         handle = await manager.launch(CounterAgent())
-        handle.serialization = SerializationStrategies.JSON
+        handle.request_serializer = SerializationStrategy.JSON
         assert await handle.ping() > 0
         await handle.action('add', 1)
         allowed_deserializers.reset(token)
@@ -622,10 +622,10 @@ async def test_handle_results_serializer(
     async with await Manager.from_exchange_factory(
         factory=http_exchange_factory,
     ) as manager:
-        token = allowed_deserializers.set({SerializationStrategies.JSON})
+        token = allowed_deserializers.set({SerializationStrategy.JSON})
         handle = await manager.launch(CounterAgent())
-        handle.serialization = SerializationStrategies.JSON
-        handle.result_serializer = SerializationStrategies.PICKLE
+        handle.request_serializer = SerializationStrategy.JSON
+        handle.result_serializer = SerializationStrategy.PICKLE
         assert await handle.ping() > 0
         with pytest.raises(DeserializationMethodProhibitedError):
             await handle.action('add', 1)
@@ -639,10 +639,10 @@ async def test_handle_exception_serializer(
     async with await Manager.from_exchange_factory(
         factory=http_exchange_factory,
     ) as manager:
-        token = allowed_deserializers.set({SerializationStrategies.JSON})
+        token = allowed_deserializers.set({SerializationStrategy.JSON})
         error_handle = await manager.launch(ErrorAgent)
-        error_handle.serialization = SerializationStrategies.JSON
-        error_handle.exception_serializer = SerializationStrategies.PICKLE
+        error_handle.request_serializer = SerializationStrategy.JSON
+        error_handle.exception_serializer = SerializationStrategy.PICKLE
         assert await error_handle.ping() > 0
         with pytest.raises(DeserializationMethodProhibitedError):
             await error_handle.fails()

--- a/tests/unit/handle_test.py
+++ b/tests/unit/handle_test.py
@@ -11,7 +11,7 @@ from unittest import mock
 import pytest
 import pytest_asyncio
 
-from academy.exception import AgentTerminatedError
+from academy.exception import AgentTerminatedError, DeserializationMethodProhibited
 from academy.exception import ExchangeClientNotFoundError
 from academy.exchange import LocalExchangeFactory
 from academy.exchange import LocalExchangeTransport
@@ -28,6 +28,8 @@ from academy.message import ActionRequest
 from academy.message import CancelRequest
 from academy.message import Message
 from academy.message import Request
+from academy.serialize import SerializationStrategies, default_serializer
+from academy.serialize import allowed_deserializers
 from testing.agents import CounterAgent
 from testing.agents import EmptyAgent
 from testing.agents import ErrorAgent
@@ -113,12 +115,13 @@ async def test_agent_handle_serialize(
     exchange_client: UserExchangeClient[LocalExchangeTransport],
 ) -> None:
     registration = await exchange_client.register_agent(EmptyAgent)
-    handle = Handle(registration.agent_id)
+    handle = Handle(registration.agent_id, serializer=SerializationStrategies.PICKLE)
     reconstructed = pickle.loads(pickle.dumps(handle))
     assert isinstance(reconstructed, Handle)
     assert reconstructed.agent_id == handle.agent_id
     assert str(reconstructed) == str(handle)
     assert repr(reconstructed) == repr(handle)
+    assert reconstructed.serialization == handle.serialization
 
 
 def test_handle_pickle_unbound_raises() -> None:
@@ -551,3 +554,74 @@ async def test_handle_covariance(
     # Only useful for my type checking
     assert test_func(handle)
     assert test_func(sub_handle)
+
+
+@pytest.mark.asyncio
+async def test_handle_respects_deserialize_allow_list(
+    http_exchange_factory: HttpExchangeFactory
+):
+    async with await Manager.from_exchange_factory(
+        factory=http_exchange_factory,
+    ) as manager:
+        handle = await manager.launch(CounterAgent())
+        assert await handle.ping() > 0
+        with allowed_deserializers.set({SerializationStrategies.JSON}):
+            with pytest.raises(DeserializationMethodProhibited):
+                await handle.action('add', 1)
+
+
+@pytest.mark.asyncio
+async def test_handle_uses_default_serializer(
+    http_exchange_factory: HttpExchangeFactory
+):
+    async with await Manager.from_exchange_factory(
+        factory=http_exchange_factory,
+    ) as manager:
+        handle = await manager.launch(CounterAgent())
+        assert await handle.ping() > 0
+        with allowed_deserializers.set({SerializationStrategies.JSON}):
+            with default_serializer.set(SerializationStrategies.JSON):
+                    await handle.action('add', 1)
+
+@pytest.mark.asyncio
+async def test_handle_args_serializer(
+    http_exchange_factory: HttpExchangeFactory
+):
+    async with await Manager.from_exchange_factory(
+        factory=http_exchange_factory,
+    ) as manager:
+        with allowed_deserializers.set({SerializationStrategies.JSON}):
+            handle = await manager.launch(CounterAgent())
+            handle.serialization = SerializationStrategies.JSON
+            assert await handle.ping() > 0
+            await handle.action('add', 1)
+
+@pytest.mark.asyncio
+async def test_handle_results_serializer(
+    http_exchange_factory: HttpExchangeFactory
+):
+    async with await Manager.from_exchange_factory(
+        factory=http_exchange_factory,
+    ) as manager:
+        with allowed_deserializers.set({SerializationStrategies.JSON}):
+            handle = await manager.launch(CounterAgent())
+            handle.serialization = SerializationStrategies.JSON
+            handle.result_serializer = SerializationStrategies.PICKLE
+            assert await handle.ping() > 0
+            with pytest.raises(DeserializationMethodProhibited):
+                await handle.action('add', 1)
+
+@pytest.mark.asyncio
+async def test_handle_exception_serializer(
+    http_exchange_factory: HttpExchangeFactory
+):
+    async with await Manager.from_exchange_factory(
+        factory=http_exchange_factory,
+    ) as manager:
+        with allowed_deserializers.set({SerializationStrategies.JSON}):
+            error_handle = await manager.launch(ErrorAgent)
+            error_handle.serialization = SerializationStrategies.JSON
+            error_handle.exception_serializer = SerializationStrategies.PICKLE
+            assert await error_handle.ping() > 0
+            with pytest.raises(DeserializationMethodProhibited):
+                await error_handle.fails()

--- a/tests/unit/message_test.py
+++ b/tests/unit/message_test.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
 
+import base64
 import pickle
 import uuid
 from typing import Any
 
+import pydantic
 import pytest
 
 from academy.exception import ActionCancelledError
@@ -12,11 +14,11 @@ from academy.exception import ExceptionSerializationError
 from academy.exception import MailboxTerminatedError
 from academy.exception import PingCancelledError
 from academy.identifier import AgentId
-from academy.message import AcademyErrorCode
 from academy.message import AcademyErrorResponse
 from academy.message import ActionRequest
 from academy.message import ActionResponse
 from academy.message import CancelRequest
+from academy.message import ErrorCode
 from academy.message import ErrorResponse
 from academy.message import Header
 from academy.message import Message
@@ -24,14 +26,14 @@ from academy.message import PingRequest
 from academy.message import ShutdownRequest
 from academy.message import SuccessResponse
 from academy.message import UserErrorResponse
-from academy.serialize import SerializationStrategies
+from academy.serialize import SerializationStrategy
 
 
 @pytest.mark.parametrize(
     'message_body',
     (
         ActionRequest(
-            serialization=SerializationStrategies.PICKLE,
+            serialization=SerializationStrategy.PICKLE,
             action='foo',
             pargs=(b'bar',),
         ),
@@ -63,14 +65,14 @@ def test_request_message(message_body: Any) -> None:
     'message_body',
     (
         ActionResponse(
-            serialization=SerializationStrategies.PICKLE,
+            serialization=SerializationStrategy.PICKLE,
             result=b'bar',
         ),
         AcademyErrorResponse(
-            error_code=AcademyErrorCode.PING_CANCELLED,
+            error_code=ErrorCode.PING_CANCELLED,
         ),
         UserErrorResponse(
-            serialization=SerializationStrategies.PICKLE,
+            serialization=SerializationStrategy.PICKLE,
             exception=Exception(),
         ),
         SuccessResponse(),
@@ -95,11 +97,8 @@ def test_response_message(message_body: Any) -> None:
 
 
 def test_deserialize_bad_type() -> None:
-    pickled = pickle.dumps('string')
-    with pytest.raises(
-        TypeError,
-        match=r'Deserialized message is not of type Message\.',
-    ):
+    pickled = base64.b64encode(pickle.dumps('string'))
+    with pytest.raises(pydantic.ValidationError):
         Message.model_deserialize(pickled)
 
 
@@ -119,8 +118,8 @@ def tests_create_response_from_response_error() -> None:
 @pytest.mark.parametrize(
     'serialization_stratgey',
     (
-        SerializationStrategies.PICKLE,
-        SerializationStrategies.JSON,
+        SerializationStrategy.PICKLE,
+        SerializationStrategy.JSON,
     ),
 )
 def test_action_request_lazy_deserialize(serialization_stratgey) -> None:
@@ -148,8 +147,8 @@ def test_action_request_lazy_deserialize(serialization_stratgey) -> None:
 @pytest.mark.parametrize(
     'serialization_stratgey',
     (
-        SerializationStrategies.PICKLE,
-        SerializationStrategies.JSON,
+        SerializationStrategy.PICKLE,
+        SerializationStrategy.JSON,
     ),
 )
 def test_action_response_lazy_deserialize(serialization_stratgey) -> None:
@@ -172,15 +171,15 @@ def test_action_response_lazy_deserialize(serialization_stratgey) -> None:
 @pytest.mark.parametrize(
     ('error_code', 'exception_type'),
     (
-        (AcademyErrorCode.MAILBOX_TERMINATED, MailboxTerminatedError),
-        (AcademyErrorCode.PING_CANCELLED, PingCancelledError),
-        (AcademyErrorCode.ACTION_INVALID_STATE, ActionInvalidStateError),
-        (AcademyErrorCode.ACTION_CANCELLED, ActionCancelledError),
-        (AcademyErrorCode.INVALID_CLIENT, TypeError),
+        (ErrorCode.MAILBOX_TERMINATED, MailboxTerminatedError),
+        (ErrorCode.PING_CANCELLED, PingCancelledError),
+        (ErrorCode.ACTION_INVALID_STATE, ActionInvalidStateError),
+        (ErrorCode.ACTION_CANCELLED, ActionCancelledError),
+        (ErrorCode.INVALID_CLIENT, TypeError),
     ),
 )
 def test_academy_error_response_to_exception(
-    error_code: AcademyErrorCode,
+    error_code: ErrorCode,
     exception_type: type[Exception],
 ):
     response = AcademyErrorResponse(
@@ -202,8 +201,8 @@ def test_academy_error_response_to_exception(
 @pytest.mark.parametrize(
     'serialization_stratgey',
     (
-        SerializationStrategies.PICKLE,
-        SerializationStrategies.JSON,
+        SerializationStrategy.PICKLE,
+        SerializationStrategy.JSON,
     ),
 )
 def test_user_error_response_lazy_deserialize(serialization_stratgey) -> None:
@@ -230,12 +229,11 @@ class UnserializableError(Exception):
 
 def test_user_error_response_serialization_error() -> None:
     response = UserErrorResponse(
-        serialization=SerializationStrategies.PICKLE,
+        serialization=SerializationStrategy.PICKLE,
         exception=UnserializableError(),
     )
 
     json = response.model_dump_json()
-    print(json)
     reconstructed = UserErrorResponse.model_validate_json(json)
 
     assert isinstance(reconstructed, ErrorResponse)

--- a/tests/unit/message_test.py
+++ b/tests/unit/message_test.py
@@ -6,9 +6,15 @@ from typing import Any
 
 import pytest
 
-from academy.exception import ActionCancelledError, ActionInvalidStateError, ExceptionSerializationError, MailboxTerminatedError, PingCancelledError
+from academy.exception import ActionCancelledError
+from academy.exception import ActionInvalidStateError
+from academy.exception import ExceptionSerializationError
+from academy.exception import MailboxTerminatedError
+from academy.exception import PingCancelledError
 from academy.identifier import AgentId
-from academy.message import ACADEMY_ERROR_CODE, AcademyErrorResponse, ActionRequest, UserErrorResponse
+from academy.message import AcademyErrorCode
+from academy.message import AcademyErrorResponse
+from academy.message import ActionRequest
 from academy.message import ActionResponse
 from academy.message import CancelRequest
 from academy.message import ErrorResponse
@@ -17,6 +23,7 @@ from academy.message import Message
 from academy.message import PingRequest
 from academy.message import ShutdownRequest
 from academy.message import SuccessResponse
+from academy.message import UserErrorResponse
 from academy.serialize import SerializationStrategies
 
 
@@ -26,7 +33,7 @@ from academy.serialize import SerializationStrategies
         ActionRequest(
             serialization=SerializationStrategies.PICKLE,
             action='foo',
-            pargs=(b'bar',)
+            pargs=(b'bar',),
         ),
         CancelRequest(target_tag=uuid.uuid4()),
         PingRequest(),
@@ -60,7 +67,7 @@ def test_request_message(message_body: Any) -> None:
             result=b'bar',
         ),
         AcademyErrorResponse(
-            error_code=ACADEMY_ERROR_CODE.PING_CANCELLED,
+            error_code=AcademyErrorCode.PING_CANCELLED,
         ),
         UserErrorResponse(
             serialization=SerializationStrategies.PICKLE,
@@ -118,10 +125,10 @@ def tests_create_response_from_response_error() -> None:
 )
 def test_action_request_lazy_deserialize(serialization_stratgey) -> None:
     request = ActionRequest(
-        serialization=serialization_stratgey, 
-        action='foo', 
-        pargs=('bar',), 
-        kargs={'foo': 'bar'}
+        serialization=serialization_stratgey,
+        action='foo',
+        pargs=('bar',),
+        kargs={'foo': 'bar'},
     )
 
     json = request.model_dump_json()
@@ -137,6 +144,7 @@ def test_action_request_lazy_deserialize(serialization_stratgey) -> None:
     assert isinstance(reconstructed.pargs, tuple | list)
     assert isinstance(reconstructed.kargs, dict)
 
+
 @pytest.mark.parametrize(
     'serialization_stratgey',
     (
@@ -147,7 +155,7 @@ def test_action_request_lazy_deserialize(serialization_stratgey) -> None:
 def test_action_response_lazy_deserialize(serialization_stratgey) -> None:
     response = ActionResponse(
         serialization=serialization_stratgey,
-        result={'foo': 'bar'}
+        result={'foo': 'bar'},
     )
 
     json = response.model_dump_json()
@@ -164,15 +172,15 @@ def test_action_response_lazy_deserialize(serialization_stratgey) -> None:
 @pytest.mark.parametrize(
     ('error_code', 'exception_type'),
     (
-        (ACADEMY_ERROR_CODE.MAILBOX_TERMINATED, MailboxTerminatedError),
-        (ACADEMY_ERROR_CODE.PING_CANCELLED, PingCancelledError),
-        (ACADEMY_ERROR_CODE.ACTION_INVALID_STATE, ActionInvalidStateError),
-        (ACADEMY_ERROR_CODE.ACTION_CANCELLED, ActionCancelledError),
-        (ACADEMY_ERROR_CODE.INVALID_CLIENT, TypeError),
+        (AcademyErrorCode.MAILBOX_TERMINATED, MailboxTerminatedError),
+        (AcademyErrorCode.PING_CANCELLED, PingCancelledError),
+        (AcademyErrorCode.ACTION_INVALID_STATE, ActionInvalidStateError),
+        (AcademyErrorCode.ACTION_CANCELLED, ActionCancelledError),
+        (AcademyErrorCode.INVALID_CLIENT, TypeError),
     ),
 )
 def test_academy_error_response_to_exception(
-    error_code: ACADEMY_ERROR_CODE, 
+    error_code: AcademyErrorCode,
     exception_type: type[Exception],
 ):
     response = AcademyErrorResponse(
@@ -190,6 +198,7 @@ def test_academy_error_response_to_exception(
 
     assert isinstance(exception, exception_type)
 
+
 @pytest.mark.parametrize(
     'serialization_stratgey',
     (
@@ -200,7 +209,7 @@ def test_academy_error_response_to_exception(
 def test_user_error_response_lazy_deserialize(serialization_stratgey) -> None:
     response = UserErrorResponse(
         serialization=serialization_stratgey,
-        exception=Exception('Oops!')
+        exception=Exception('Oops!'),
     )
 
     json = response.model_dump_json()
@@ -214,14 +223,15 @@ def test_user_error_response_lazy_deserialize(serialization_stratgey) -> None:
     assert isinstance(reconstructed.exception, Exception)
 
 
-class UnserializableException(Exception):
+class UnserializableError(Exception):
     def __reduce__(self):
-        raise Exception("This exception cannot be serialized.")
-    
+        raise Exception('This exception cannot be serialized.')
+
+
 def test_user_error_response_serialization_error() -> None:
     response = UserErrorResponse(
         serialization=SerializationStrategies.PICKLE,
-        exception=UnserializableException(),
+        exception=UnserializableError(),
     )
 
     json = response.model_dump_json()

--- a/tests/unit/message_test.py
+++ b/tests/unit/message_test.py
@@ -6,8 +6,9 @@ from typing import Any
 
 import pytest
 
+from academy.exception import ActionCancelledError, ActionInvalidStateError, ExceptionSerializationError, MailboxTerminatedError, PingCancelledError
 from academy.identifier import AgentId
-from academy.message import ActionRequest
+from academy.message import ACADEMY_ERROR_CODE, AcademyErrorResponse, ActionRequest, UserErrorResponse
 from academy.message import ActionResponse
 from academy.message import CancelRequest
 from academy.message import ErrorResponse
@@ -16,12 +17,17 @@ from academy.message import Message
 from academy.message import PingRequest
 from academy.message import ShutdownRequest
 from academy.message import SuccessResponse
+from academy.serialize import SerializationStrategies
 
 
 @pytest.mark.parametrize(
     'message_body',
     (
-        ActionRequest(action='foo', pargs=(b'bar',)),
+        ActionRequest(
+            serialization=SerializationStrategies.PICKLE,
+            action='foo',
+            pargs=(b'bar',)
+        ),
         CancelRequest(target_tag=uuid.uuid4()),
         PingRequest(),
         ShutdownRequest(),
@@ -49,8 +55,17 @@ def test_request_message(message_body: Any) -> None:
 @pytest.mark.parametrize(
     'message_body',
     (
-        ActionResponse(result=b'bar'),
-        ErrorResponse(exception=Exception()),
+        ActionResponse(
+            serialization=SerializationStrategies.PICKLE,
+            result=b'bar',
+        ),
+        AcademyErrorResponse(
+            error_code=ACADEMY_ERROR_CODE.PING_CANCELLED,
+        ),
+        UserErrorResponse(
+            serialization=SerializationStrategies.PICKLE,
+            exception=Exception(),
+        ),
         SuccessResponse(),
     ),
 )
@@ -94,8 +109,20 @@ def tests_create_response_from_response_error() -> None:
         message.create_response(SuccessResponse())
 
 
-def test_action_request_lazy_deserialize() -> None:
-    request = ActionRequest(action='foo', pargs=('bar',), kargs={'foo': 'bar'})
+@pytest.mark.parametrize(
+    'serialization_stratgey',
+    (
+        SerializationStrategies.PICKLE,
+        SerializationStrategies.JSON,
+    ),
+)
+def test_action_request_lazy_deserialize(serialization_stratgey) -> None:
+    request = ActionRequest(
+        serialization=serialization_stratgey, 
+        action='foo', 
+        pargs=('bar',), 
+        kargs={'foo': 'bar'}
+    )
 
     json = request.model_dump_json()
     reconstructed = ActionRequest.model_validate_json(json)
@@ -107,12 +134,21 @@ def test_action_request_lazy_deserialize() -> None:
     reconstructed.get_args()
     reconstructed.get_kwargs()
 
-    assert isinstance(reconstructed.pargs, tuple)
+    assert isinstance(reconstructed.pargs, tuple | list)
     assert isinstance(reconstructed.kargs, dict)
 
-
-def test_action_response_lazy_deserialize() -> None:
-    response = ActionResponse(result={'foo': 'bar'})
+@pytest.mark.parametrize(
+    'serialization_stratgey',
+    (
+        SerializationStrategies.PICKLE,
+        SerializationStrategies.JSON,
+    ),
+)
+def test_action_response_lazy_deserialize(serialization_stratgey) -> None:
+    response = ActionResponse(
+        serialization=serialization_stratgey,
+        result={'foo': 'bar'}
+    )
 
     json = response.model_dump_json()
     reconstructed = ActionResponse.model_validate_json(json)
@@ -125,11 +161,50 @@ def test_action_response_lazy_deserialize() -> None:
     assert isinstance(reconstructed.result, dict)
 
 
-def test_error_response_lazy_deserialize() -> None:
-    response = ErrorResponse(exception=Exception('Oops!'))
+@pytest.mark.parametrize(
+    ('error_code', 'exception_type'),
+    (
+        (ACADEMY_ERROR_CODE.MAILBOX_TERMINATED, MailboxTerminatedError),
+        (ACADEMY_ERROR_CODE.PING_CANCELLED, PingCancelledError),
+        (ACADEMY_ERROR_CODE.ACTION_INVALID_STATE, ActionInvalidStateError),
+        (ACADEMY_ERROR_CODE.ACTION_CANCELLED, ActionCancelledError),
+        (ACADEMY_ERROR_CODE.INVALID_CLIENT, TypeError),
+    ),
+)
+def test_academy_error_response_to_exception(
+    error_code: ACADEMY_ERROR_CODE, 
+    exception_type: type[Exception],
+):
+    response = AcademyErrorResponse(
+        error_code=error_code,
+        mailbox_id=AgentId.new(),
+    )
 
     json = response.model_dump_json()
-    reconstructed = ErrorResponse.model_validate_json(json)
+    reconstructed = AcademyErrorResponse.model_validate_json(json)
+
+    assert isinstance(reconstructed, AcademyErrorResponse)
+    assert isinstance(reconstructed, ErrorResponse)
+
+    exception = reconstructed.get_exception()
+
+    assert isinstance(exception, exception_type)
+
+@pytest.mark.parametrize(
+    'serialization_stratgey',
+    (
+        SerializationStrategies.PICKLE,
+        SerializationStrategies.JSON,
+    ),
+)
+def test_user_error_response_lazy_deserialize(serialization_stratgey) -> None:
+    response = UserErrorResponse(
+        serialization=serialization_stratgey,
+        exception=Exception('Oops!')
+    )
+
+    json = response.model_dump_json()
+    reconstructed = UserErrorResponse.model_validate_json(json)
 
     assert isinstance(reconstructed, ErrorResponse)
     assert isinstance(reconstructed.exception, str)
@@ -137,3 +212,25 @@ def test_error_response_lazy_deserialize() -> None:
     reconstructed.get_exception()
 
     assert isinstance(reconstructed.exception, Exception)
+
+
+class UnserializableException(Exception):
+    def __reduce__(self):
+        raise Exception("This exception cannot be serialized.")
+    
+def test_user_error_response_serialization_error() -> None:
+    response = UserErrorResponse(
+        serialization=SerializationStrategies.PICKLE,
+        exception=UnserializableException(),
+    )
+
+    json = response.model_dump_json()
+    print(json)
+    reconstructed = UserErrorResponse.model_validate_json(json)
+
+    assert isinstance(reconstructed, ErrorResponse)
+    assert isinstance(reconstructed.exception, str)
+
+    reconstructed.get_exception()
+
+    assert isinstance(reconstructed.exception, ExceptionSerializationError)

--- a/tests/unit/runtime_test.py
+++ b/tests/unit/runtime_test.py
@@ -40,7 +40,7 @@ from academy.runtime import Runtime
 from academy.runtime import RuntimeConfig
 from academy.serialize import allowed_deserializers
 from academy.serialize import default_serializer
-from academy.serialize import SerializationStrategies
+from academy.serialize import SerializationStrategy
 from testing.agents import CounterAgent
 from testing.agents import EmptyAgent
 from testing.agents import ErrorAgent
@@ -374,7 +374,7 @@ async def test_runtime_action_message(
             body=ActionRequest(
                 action='add',
                 pargs=(value,),
-                serialization=SerializationStrategies.PICKLE,
+                serialization=SerializationStrategy.PICKLE,
             ),
         )
         await exchange_client.send(request)
@@ -389,7 +389,7 @@ async def test_runtime_action_message(
             dest=runtime.agent_id,
             body=ActionRequest(
                 action='count',
-                serialization=SerializationStrategies.PICKLE,
+                serialization=SerializationStrategy.PICKLE,
             ),
         )
         await exchange_client.send(request)
@@ -420,7 +420,7 @@ async def test_runtime_cancel_action_message(
             body=ActionRequest(
                 action='sleep',
                 pargs=(value,),
-                serialization=SerializationStrategies.PICKLE,
+                serialization=SerializationStrategy.PICKLE,
             ),
         )
         await exchange_client.send(request)
@@ -502,7 +502,7 @@ async def test_runtime_cancel_action_requests_on_shutdown(
         dest=runtime.agent_id,
         body=ActionRequest(
             action='sleep',
-            serialization=SerializationStrategies.PICKLE,
+            serialization=SerializationStrategy.PICKLE,
         ),
     )
     await exchange_client.send(request)
@@ -548,7 +548,7 @@ async def test_runtime_action_message_error(
             dest=runtime.agent_id,
             body=ActionRequest(
                 action='fails',
-                serialization=SerializationStrategies.PICKLE,
+                serialization=SerializationStrategy.PICKLE,
             ),
         )
         await exchange_client.send(request)
@@ -578,7 +578,7 @@ async def test_runtime_action_message_unknown(
             dest=runtime.agent_id,
             body=ActionRequest(
                 action='null',
-                serialization=SerializationStrategies.PICKLE,
+                serialization=SerializationStrategy.PICKLE,
             ),
         )
         await exchange_client.send(request)
@@ -628,7 +628,7 @@ async def test_runtime_delay_actions_and_loops_to_after_startup(
         dest=registration.agent_id,
         body=ActionRequest(
             action='check_action',
-            serialization=SerializationStrategies.PICKLE,
+            serialization=SerializationStrategy.PICKLE,
         ),
     )
     await exchange_client.send(request)
@@ -766,13 +766,13 @@ async def test_runtime_uses_default_serializer(
 ):
     class _CheckSerializationAgent(Agent):
         async def agent_on_startup(self):
-            assert default_serializer.get() == SerializationStrategies.JSON
+            assert default_serializer.get() == SerializationStrategy.JSON
 
     registration = await exchange_client.register_agent(
         _CheckSerializationAgent,
     )
 
-    token = default_serializer.set(SerializationStrategies.JSON)
+    token = default_serializer.set(SerializationStrategy.JSON)
     async with Runtime(
         _CheckSerializationAgent(),
         exchange_factory=exchange_client.factory(),
@@ -788,7 +788,7 @@ async def test_runtime_sets_default_serializer(
 ):
     class _CheckSerializationAgent(Agent):
         async def agent_on_startup(self):
-            assert default_serializer.get() == SerializationStrategies.JSON
+            assert default_serializer.get() == SerializationStrategy.JSON
 
     registration = await exchange_client.register_agent(
         _CheckSerializationAgent,
@@ -797,7 +797,7 @@ async def test_runtime_sets_default_serializer(
         _CheckSerializationAgent(),
         exchange_factory=exchange_client.factory(),
         registration=registration,
-        config=RuntimeConfig(default_serializer=SerializationStrategies.JSON),
+        config=RuntimeConfig(default_serializer=SerializationStrategy.JSON),
     ) as runtime:
         runtime.signal_shutdown()
 
@@ -824,7 +824,7 @@ async def test_runtime_respects_allowed_deserializers(
         exchange_factory=http_exchange_client.factory(),
         registration=registration,
         config=RuntimeConfig(
-            allowed_deserializers={SerializationStrategies.JSON},
+            allowed_deserializers={SerializationStrategy.JSON},
         ),
     ) as runtime:
         value = 1
@@ -834,7 +834,7 @@ async def test_runtime_respects_allowed_deserializers(
             body=ActionRequest(
                 action='sleep',
                 pargs=(value,),
-                serialization=SerializationStrategies.PICKLE,
+                serialization=SerializationStrategy.PICKLE,
             ),
         )
         await http_exchange_client.send(request)
@@ -842,7 +842,7 @@ async def test_runtime_respects_allowed_deserializers(
 
         body = response.get_body()
         assert isinstance(body, ErrorResponse)
-        token = allowed_deserializers.set({SerializationStrategies.PICKLE})
+        token = allowed_deserializers.set({SerializationStrategy.PICKLE})
         assert isinstance(
             body.get_exception(),
             DeserializationMethodProhibitedError,
@@ -869,8 +869,8 @@ async def test_runtime_uses_result_serialization(
             body=ActionRequest(
                 action='sleep',
                 pargs=(value,),
-                serialization=SerializationStrategies.PICKLE,
-                result_serialization=SerializationStrategies.JSON,
+                serialization=SerializationStrategy.PICKLE,
+                result_serialization=SerializationStrategy.JSON,
             ),
         )
         await http_exchange_client.send(request)
@@ -878,7 +878,7 @@ async def test_runtime_uses_result_serialization(
         body = response.get_body()
 
         assert isinstance(body, ActionResponse)
-        assert body.serialization == SerializationStrategies.JSON
+        assert body.serialization == SerializationStrategy.JSON
 
 
 @pytest.mark.asyncio
@@ -900,8 +900,8 @@ async def test_runtime_uses_exception_serialization(
             dest=runtime.agent_id,
             body=ActionRequest(
                 action='fails',
-                serialization=SerializationStrategies.PICKLE,
-                exception_serialization=SerializationStrategies.JSON,
+                serialization=SerializationStrategy.PICKLE,
+                exception_serialization=SerializationStrategy.JSON,
             ),
         )
         await http_exchange_client.send(request)
@@ -909,4 +909,4 @@ async def test_runtime_uses_exception_serialization(
         body = response.get_body()
 
         assert isinstance(body, UserErrorResponse)
-        assert body.serialization == SerializationStrategies.JSON
+        assert body.serialization == SerializationStrategy.JSON

--- a/tests/unit/runtime_test.py
+++ b/tests/unit/runtime_test.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import asyncio
 import sys
 import uuid
-from typing import Any
+from typing import Any, AsyncGenerator
 from unittest import mock
 
 import pytest
@@ -13,17 +13,18 @@ from academy.agent import Agent
 from academy.agent import loop
 from academy.context import ActionContext
 from academy.debug import set_academy_debug
-from academy.exception import ActionCancelledError
+from academy.exception import ActionCancelledError, DeserializationMethodProhibited
 from academy.exception import ActionInvalidStateError
 from academy.exchange import ExchangeClient
 from academy.exchange import LocalExchangeTransport
 from academy.exchange import UserExchangeClient
+from academy.exchange.cloud.client import HttpExchangeFactory, HttpExchangeTransport
 from academy.exchange.transport import MailboxStatus
 from academy.handle import Handle
 from academy.handle import ProxyHandle
 from academy.identifier import AgentId
 from academy.identifier import EntityId
-from academy.message import ActionRequest
+from academy.message import ActionRequest, UserErrorResponse
 from academy.message import ActionResponse
 from academy.message import CancelRequest
 from academy.message import ErrorResponse
@@ -33,6 +34,9 @@ from academy.message import ShutdownRequest
 from academy.message import SuccessResponse
 from academy.runtime import Runtime
 from academy.runtime import RuntimeConfig
+from academy.serialize import default_serializer
+from academy.serialize import allowed_deserializers
+from academy.serialize import SerializationStrategies
 from testing.agents import CounterAgent
 from testing.agents import EmptyAgent
 from testing.agents import ErrorAgent
@@ -727,3 +731,143 @@ def test_runtime_background_error(
     set_academy_debug()
     with pytest.raises(SystemExit):
         asyncio.run(run())
+
+
+@pytest.mark.asyncio
+async def test_runtime_uses_default_serializer(
+    exchange_client: UserExchangeClient[LocalExchangeTransport],
+):
+    class _CheckSerializationAgent(Agent):
+        async def agent_on_startup(self):
+            assert default_serializer.get() == SerializationStrategies.JSON
+    
+    registration = await exchange_client.register_agent(_CheckSerializationAgent)
+
+    with default_serializer.set(SerializationStrategies.JSON):
+        async with Runtime(
+            _CheckSerializationAgent(),
+            exchange_factory=exchange_client.factory(),
+            registration=registration,
+        ) as runtime:
+            runtime.signal_shutdown()
+
+
+@pytest.mark.asyncio
+async def test_runtime_sets_default_serializer(
+    exchange_client: UserExchangeClient[LocalExchangeTransport],
+):
+    class _CheckSerializationAgent(Agent):
+        async def agent_on_startup(self):
+            assert default_serializer.get() == SerializationStrategies.JSON
+    
+    registration = await exchange_client.register_agent(_CheckSerializationAgent)
+    async with Runtime(
+        _CheckSerializationAgent(),
+        exchange_factory=exchange_client.factory(),
+        registration=registration,
+        config=RuntimeConfig(default_serializer=SerializationStrategies.JSON)
+    ) as runtime:
+        runtime.signal_shutdown()
+
+@pytest.fixture
+async def http_exchange_client(
+    http_exchange_factory: HttpExchangeFactory
+) -> AsyncGenerator[UserExchangeClient[HttpExchangeTransport]]:
+    async with await http_exchange_factory.create_user_client(start_listener=False) as client:
+        yield client
+
+
+@pytest.mark.asyncio
+async def test_runtime_respects_allowed_deserializers(
+    http_exchange_client: UserExchangeClient[HttpExchangeTransport],
+):
+    registration = await http_exchange_client.register_agent(SleepAgent)
+    listener = http_exchange_client._transport.listen(1)
+
+    async with Runtime(
+        SleepAgent(),
+        exchange_factory=http_exchange_client.factory(),
+        registration=registration,
+        config=RuntimeConfig(
+            allowed_deserializers={SerializationStrategies.JSON},
+        ),
+    ) as runtime:
+        value = 1
+        request = Message.create(
+            src=http_exchange_client.client_id,
+            dest=runtime.agent_id,
+            body=ActionRequest(
+                action='sleep',
+                pargs=(value,),
+                serialization=SerializationStrategies.PICKLE
+            ),
+        )
+        await http_exchange_client.send(request)
+        response = await anext(listener)
+
+        body = response.get_body()
+        assert isinstance(body, ErrorResponse)
+        with allowed_deserializers.set({SerializationStrategies.PICKLE}):
+            assert isinstance(body.get_exception(), DeserializationMethodProhibited)
+
+
+@pytest.mark.asyncio
+async def test_runtime_uses_result_serialization(
+    http_exchange_client: UserExchangeClient[HttpExchangeTransport],
+):
+    registration = await http_exchange_client.register_agent(SleepAgent)
+    listener = http_exchange_client._transport.listen(1)
+
+    async with Runtime(
+        SleepAgent(),
+        exchange_factory=http_exchange_client.factory(),
+        registration=registration,
+    ) as runtime:
+        value = TEST_SLEEP_INTERVAL
+        request = Message.create(
+            src=http_exchange_client.client_id,
+            dest=runtime.agent_id,
+            body=ActionRequest(
+                action='sleep',
+                pargs=(value,),
+                serialization=SerializationStrategies.PICKLE,
+                result_serialization=SerializationStrategies.JSON
+            ),
+        )
+        await http_exchange_client.send(request)
+        response = await anext(listener)
+        body = response.get_body()
+
+        assert isinstance(body, ActionResponse)
+        assert body.serialization == SerializationStrategies.JSON
+
+
+@pytest.mark.asyncio
+async def test_runtime_uses_exception_serialization(
+    http_exchange_client: UserExchangeClient[HttpExchangeTransport],
+):
+    registration = await http_exchange_client.register_agent(SleepAgent)
+    # Cancel listener so test can intercept agent responses
+    await http_exchange_client._stop_listener_task()
+    listener = http_exchange_client._transport.listen(0.1)
+
+    async with Runtime(
+        ErrorAgent(),
+        exchange_factory=http_exchange_client.factory(),
+        registration=registration,
+    ) as runtime:
+        request = Message.create(
+            src=http_exchange_client.client_id,
+            dest=runtime.agent_id,
+            body=ActionRequest(
+                action='fails',
+                serialization=SerializationStrategies.PICKLE,
+                result_serialization=SerializationStrategies.JSON
+            ),
+        )
+        await http_exchange_client.send(request)
+        response = await anext(listener)
+        body = response.get_body()
+
+        assert isinstance(body, UserErrorResponse)
+        assert body.serialization == SerializationStrategies.JSON

--- a/tests/unit/runtime_test.py
+++ b/tests/unit/runtime_test.py
@@ -3,7 +3,8 @@ from __future__ import annotations
 import asyncio
 import sys
 import uuid
-from typing import Any, AsyncGenerator
+from collections.abc import AsyncGenerator
+from typing import Any
 from unittest import mock
 
 import pytest
@@ -13,18 +14,20 @@ from academy.agent import Agent
 from academy.agent import loop
 from academy.context import ActionContext
 from academy.debug import set_academy_debug
-from academy.exception import ActionCancelledError, DeserializationMethodProhibited
+from academy.exception import ActionCancelledError
 from academy.exception import ActionInvalidStateError
+from academy.exception import DeserializationMethodProhibitedError
 from academy.exchange import ExchangeClient
 from academy.exchange import LocalExchangeTransport
 from academy.exchange import UserExchangeClient
-from academy.exchange.cloud.client import HttpExchangeFactory, HttpExchangeTransport
+from academy.exchange.cloud.client import HttpExchangeFactory
+from academy.exchange.cloud.client import HttpExchangeTransport
 from academy.exchange.transport import MailboxStatus
 from academy.handle import Handle
 from academy.handle import ProxyHandle
 from academy.identifier import AgentId
 from academy.identifier import EntityId
-from academy.message import ActionRequest, UserErrorResponse
+from academy.message import ActionRequest
 from academy.message import ActionResponse
 from academy.message import CancelRequest
 from academy.message import ErrorResponse
@@ -32,10 +35,11 @@ from academy.message import Message
 from academy.message import PingRequest
 from academy.message import ShutdownRequest
 from academy.message import SuccessResponse
+from academy.message import UserErrorResponse
 from academy.runtime import Runtime
 from academy.runtime import RuntimeConfig
-from academy.serialize import default_serializer
 from academy.serialize import allowed_deserializers
+from academy.serialize import default_serializer
 from academy.serialize import SerializationStrategies
 from testing.agents import CounterAgent
 from testing.agents import EmptyAgent
@@ -367,7 +371,11 @@ async def test_runtime_action_message(
         request = Message.create(
             src=exchange_client.client_id,
             dest=runtime.agent_id,
-            body=ActionRequest(action='add', pargs=(value,)),
+            body=ActionRequest(
+                action='add',
+                pargs=(value,),
+                serialization=SerializationStrategies.PICKLE,
+            ),
         )
         await exchange_client.send(request)
         message = await anext(listener)
@@ -379,7 +387,10 @@ async def test_runtime_action_message(
         request = Message.create(
             src=exchange_client.client_id,
             dest=runtime.agent_id,
-            body=ActionRequest(action='count'),
+            body=ActionRequest(
+                action='count',
+                serialization=SerializationStrategies.PICKLE,
+            ),
         )
         await exchange_client.send(request)
         message = await anext(listener)
@@ -406,7 +417,11 @@ async def test_runtime_cancel_action_message(
         request = Message.create(
             src=exchange_client.client_id,
             dest=runtime.agent_id,
-            body=ActionRequest(action='sleep', pargs=(value,)),
+            body=ActionRequest(
+                action='sleep',
+                pargs=(value,),
+                serialization=SerializationStrategies.PICKLE,
+            ),
         )
         await exchange_client.send(request)
         cancel_request = Message.create(
@@ -485,7 +500,10 @@ async def test_runtime_cancel_action_requests_on_shutdown(
     request = Message.create(
         src=exchange_client.client_id,
         dest=runtime.agent_id,
-        body=ActionRequest(action='sleep'),
+        body=ActionRequest(
+            action='sleep',
+            serialization=SerializationStrategies.PICKLE,
+        ),
     )
     await exchange_client.send(request)
 
@@ -528,7 +546,10 @@ async def test_runtime_action_message_error(
         request = Message.create(
             src=exchange_client.client_id,
             dest=runtime.agent_id,
-            body=ActionRequest(action='fails'),
+            body=ActionRequest(
+                action='fails',
+                serialization=SerializationStrategies.PICKLE,
+            ),
         )
         await exchange_client.send(request)
         message = await anext(listener)
@@ -555,7 +576,10 @@ async def test_runtime_action_message_unknown(
         request = Message.create(
             src=exchange_client.client_id,
             dest=runtime.agent_id,
-            body=ActionRequest(action='null'),
+            body=ActionRequest(
+                action='null',
+                serialization=SerializationStrategies.PICKLE,
+            ),
         )
         await exchange_client.send(request)
         message = await anext(listener)
@@ -602,7 +626,10 @@ async def test_runtime_delay_actions_and_loops_to_after_startup(
     request = Message.create(
         src=exchange_client.client_id,
         dest=registration.agent_id,
-        body=ActionRequest(action='check_action'),
+        body=ActionRequest(
+            action='check_action',
+            serialization=SerializationStrategies.PICKLE,
+        ),
     )
     await exchange_client.send(request)
 
@@ -740,16 +767,19 @@ async def test_runtime_uses_default_serializer(
     class _CheckSerializationAgent(Agent):
         async def agent_on_startup(self):
             assert default_serializer.get() == SerializationStrategies.JSON
-    
-    registration = await exchange_client.register_agent(_CheckSerializationAgent)
 
-    with default_serializer.set(SerializationStrategies.JSON):
-        async with Runtime(
-            _CheckSerializationAgent(),
-            exchange_factory=exchange_client.factory(),
-            registration=registration,
-        ) as runtime:
-            runtime.signal_shutdown()
+    registration = await exchange_client.register_agent(
+        _CheckSerializationAgent,
+    )
+
+    token = default_serializer.set(SerializationStrategies.JSON)
+    async with Runtime(
+        _CheckSerializationAgent(),
+        exchange_factory=exchange_client.factory(),
+        registration=registration,
+    ) as runtime:
+        runtime.signal_shutdown()
+    default_serializer.reset(token)
 
 
 @pytest.mark.asyncio
@@ -759,21 +789,26 @@ async def test_runtime_sets_default_serializer(
     class _CheckSerializationAgent(Agent):
         async def agent_on_startup(self):
             assert default_serializer.get() == SerializationStrategies.JSON
-    
-    registration = await exchange_client.register_agent(_CheckSerializationAgent)
+
+    registration = await exchange_client.register_agent(
+        _CheckSerializationAgent,
+    )
     async with Runtime(
         _CheckSerializationAgent(),
         exchange_factory=exchange_client.factory(),
         registration=registration,
-        config=RuntimeConfig(default_serializer=SerializationStrategies.JSON)
+        config=RuntimeConfig(default_serializer=SerializationStrategies.JSON),
     ) as runtime:
         runtime.signal_shutdown()
 
+
 @pytest.fixture
 async def http_exchange_client(
-    http_exchange_factory: HttpExchangeFactory
+    http_exchange_factory: HttpExchangeFactory,
 ) -> AsyncGenerator[UserExchangeClient[HttpExchangeTransport]]:
-    async with await http_exchange_factory.create_user_client(start_listener=False) as client:
+    async with await http_exchange_factory.create_user_client(
+        start_listener=False,
+    ) as client:
         yield client
 
 
@@ -799,7 +834,7 @@ async def test_runtime_respects_allowed_deserializers(
             body=ActionRequest(
                 action='sleep',
                 pargs=(value,),
-                serialization=SerializationStrategies.PICKLE
+                serialization=SerializationStrategies.PICKLE,
             ),
         )
         await http_exchange_client.send(request)
@@ -807,8 +842,12 @@ async def test_runtime_respects_allowed_deserializers(
 
         body = response.get_body()
         assert isinstance(body, ErrorResponse)
-        with allowed_deserializers.set({SerializationStrategies.PICKLE}):
-            assert isinstance(body.get_exception(), DeserializationMethodProhibited)
+        token = allowed_deserializers.set({SerializationStrategies.PICKLE})
+        assert isinstance(
+            body.get_exception(),
+            DeserializationMethodProhibitedError,
+        )
+        allowed_deserializers.reset(token)
 
 
 @pytest.mark.asyncio
@@ -831,7 +870,7 @@ async def test_runtime_uses_result_serialization(
                 action='sleep',
                 pargs=(value,),
                 serialization=SerializationStrategies.PICKLE,
-                result_serialization=SerializationStrategies.JSON
+                result_serialization=SerializationStrategies.JSON,
             ),
         )
         await http_exchange_client.send(request)
@@ -862,7 +901,7 @@ async def test_runtime_uses_exception_serialization(
             body=ActionRequest(
                 action='fails',
                 serialization=SerializationStrategies.PICKLE,
-                result_serialization=SerializationStrategies.JSON
+                exception_serialization=SerializationStrategies.JSON,
             ),
         )
         await http_exchange_client.send(request)

--- a/tests/unit/serialize_test.py
+++ b/tests/unit/serialize_test.py
@@ -4,15 +4,17 @@ import pickle
 
 import pytest
 
-from academy.exception import DeserializationMethodProhibited, RemoteException
-from academy.serialize import NoPickleMixin
-from academy.serialize import Serializer
+from academy.exception import AcademyRemoteError
+from academy.exception import DeserializationMethodProhibitedError
+from academy.serialize import allowed_deserializers
+from academy.serialize import deserialize
 from academy.serialize import JsonSerializer
+from academy.serialize import NoPickleMixin
 from academy.serialize import PickleSerializer
 from academy.serialize import SerializationStrategies
 from academy.serialize import serialize
-from academy.serialize import deserialize
-from academy.serialize import allowed_deserializers
+from academy.serialize import Serializer
+
 
 class CanItPickle(NoPickleMixin):
     pass
@@ -31,7 +33,7 @@ def test_no_pickle_mixin() -> None:
     ),
 )
 def test_serializer_serialize_deserialize(serializer: Serializer):
-    params = [5, "test", {'key': 'value'}]
+    params = [5, 'test', {'key': 'value'}]
     data = serializer.serialize(params)
     reconstructed = serializer.deserialize(data)
     assert reconstructed == params
@@ -41,8 +43,7 @@ def test_json_serialize_exception():
     test_exception = Exception()
     json = JsonSerializer.serialize(test_exception)
     reconstructed = JsonSerializer.deserialize(json)
-    assert isinstance(reconstructed, RemoteException)
-
+    assert isinstance(reconstructed, AcademyRemoteError)
 
 
 @pytest.mark.parametrize(
@@ -53,17 +54,18 @@ def test_json_serialize_exception():
     ),
 )
 def test_serialize_deserialize(strategy: SerializationStrategies):
-    params = [5, "test", {'key': 'value'}]
+    params = [5, 'test', {'key': 'value'}]
     data = serialize(params, strategy)
     reconstructed = deserialize(data, strategy)
     assert reconstructed == params
 
 
 def test_serialization_allow_list():
-    params = [5, "test", {'key': 'value'}]
+    params = [5, 'test', {'key': 'value'}]
     data = serialize(params, SerializationStrategies.PICKLE)
-    with allowed_deserializers.set({}):
-        with pytest.raises(DeserializationMethodProhibited):
-            deserialize(data, SerializationStrategies.PICKLE)
+    token = allowed_deserializers.set(set())
+    with pytest.raises(DeserializationMethodProhibitedError):
+        deserialize(data, SerializationStrategies.PICKLE)
+    allowed_deserializers.reset(token)
 
     deserialize(data, SerializationStrategies.PICKLE)

--- a/tests/unit/serialize_test.py
+++ b/tests/unit/serialize_test.py
@@ -4,8 +4,15 @@ import pickle
 
 import pytest
 
+from academy.exception import DeserializationMethodProhibited, RemoteException
 from academy.serialize import NoPickleMixin
-
+from academy.serialize import Serializer
+from academy.serialize import JsonSerializer
+from academy.serialize import PickleSerializer
+from academy.serialize import SerializationStrategies
+from academy.serialize import serialize
+from academy.serialize import deserialize
+from academy.serialize import allowed_deserializers
 
 class CanItPickle(NoPickleMixin):
     pass
@@ -14,3 +21,49 @@ class CanItPickle(NoPickleMixin):
 def test_no_pickle_mixin() -> None:
     with pytest.raises(pickle.PicklingError):
         pickle.dumps(CanItPickle())
+
+
+@pytest.mark.parametrize(
+    'serializer',
+    (
+        JsonSerializer,
+        PickleSerializer,
+    ),
+)
+def test_serializer_serialize_deserialize(serializer: Serializer):
+    params = [5, "test", {'key': 'value'}]
+    data = serializer.serialize(params)
+    reconstructed = serializer.deserialize(data)
+    assert reconstructed == params
+
+
+def test_json_serialize_exception():
+    test_exception = Exception()
+    json = JsonSerializer.serialize(test_exception)
+    reconstructed = JsonSerializer.deserialize(json)
+    assert isinstance(reconstructed, RemoteException)
+
+
+
+@pytest.mark.parametrize(
+    'strategy',
+    (
+        SerializationStrategies.PICKLE,
+        SerializationStrategies.JSON,
+    ),
+)
+def test_serialize_deserialize(strategy: SerializationStrategies):
+    params = [5, "test", {'key': 'value'}]
+    data = serialize(params, strategy)
+    reconstructed = deserialize(data, strategy)
+    assert reconstructed == params
+
+
+def test_serialization_allow_list():
+    params = [5, "test", {'key': 'value'}]
+    data = serialize(params, SerializationStrategies.PICKLE)
+    with allowed_deserializers.set({}):
+        with pytest.raises(DeserializationMethodProhibited):
+            deserialize(data, SerializationStrategies.PICKLE)
+
+    deserialize(data, SerializationStrategies.PICKLE)

--- a/tests/unit/serialize_test.py
+++ b/tests/unit/serialize_test.py
@@ -11,7 +11,7 @@ from academy.serialize import deserialize
 from academy.serialize import JsonSerializer
 from academy.serialize import NoPickleMixin
 from academy.serialize import PickleSerializer
-from academy.serialize import SerializationStrategies
+from academy.serialize import SerializationStrategy
 from academy.serialize import serialize
 from academy.serialize import Serializer
 
@@ -49,11 +49,11 @@ def test_json_serialize_exception():
 @pytest.mark.parametrize(
     'strategy',
     (
-        SerializationStrategies.PICKLE,
-        SerializationStrategies.JSON,
+        SerializationStrategy.PICKLE,
+        SerializationStrategy.JSON,
     ),
 )
-def test_serialize_deserialize(strategy: SerializationStrategies):
+def test_serialize_deserialize(strategy: SerializationStrategy):
     params = [5, 'test', {'key': 'value'}]
     data = serialize(params, strategy)
     reconstructed = deserialize(data, strategy)
@@ -62,10 +62,10 @@ def test_serialize_deserialize(strategy: SerializationStrategies):
 
 def test_serialization_allow_list():
     params = [5, 'test', {'key': 'value'}]
-    data = serialize(params, SerializationStrategies.PICKLE)
+    data = serialize(params, SerializationStrategy.PICKLE)
     token = allowed_deserializers.set(set())
     with pytest.raises(DeserializationMethodProhibitedError):
-        deserialize(data, SerializationStrategies.PICKLE)
+        deserialize(data, SerializationStrategy.PICKLE)
     allowed_deserializers.reset(token)
 
-    deserialize(data, SerializationStrategies.PICKLE)
+    deserialize(data, SerializationStrategy.PICKLE)


### PR DESCRIPTION
## Summary
<!--- Provide a summary of the changes --->
This PR enables a user to choose between using JSON or Pickle to serialize arguments and responses.
I chose to make the serialization method part of the messaging protocol rather than having a "try them until one works" approach that was in [proxystore](https://github.com/proxystore/proxystore/blob/main/proxystore/serialize.py) and [globus compute](https://github.com/globus/globus-compute/tree/96e79f843354dc3382675206523a8aa45b9d2df4/compute_sdk/globus_compute_sdk/serialize). My hope is that by making the serialization method more explicit, we can simplify both the process of serialization and the cognitive load of debugging when something fails. 
This also more easily enabled me to do things like specify specific serialization for responses and exceptions. 
Exceptions in particular led me to make a different change: exceptions raised by academy are not serialized and sent via pickle, but communicated via an exception code. This was so that those exceptions could remain independent of the serialization method desired and could be raised at different points in the process (i.e. the exchange could send a mailbox terminated error the same way regardless of how the client wants to deal with serialization).
Right now serialization is attached to "context", meaning an agent or a client can say I want to serialize things a certain way or only want to allow these deserializers. I think a natural extension would be to allow serialization customization at the level of actions as well.

!! Warning
This PR would cause incompatibilities between the hosted exchange and older clients.

Some other features that I want to implement but am leaving to a different PR:
 - Advertising of serialization method on the exchange (i.e. before you send a request you know how the request "should" be serialized).
 - Including pedantic as a serializer to allow action arguments to be validated (i.e. defining arguments and results as pedantic classes the using pedantic methods for serialization)
 - a "raw binary" mode that allows the agent or client to handle serialization internally.

## Related Issues
<!--- List any issue numbers above that this PR addresses --->

- Closes #406 

## Changes
<!--- Check which of the following changes were made --->

- [x] Breaking (backwards incompatible changes to public interfaces)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Enhancement (non-breaking change or feature addition)
- [ ] Refactor (internal code or design clean up)
- [ ] Documentation (no changes to the code)
- [ ] Test (changes or additions to testing)
- [ ] Build (change to CI workflows or build processes)
- [ ] Package (changes to package metadata or dependency versions)

## Testing
<!--- Please describe the test ran to verify changes --->

N/A

## Pull Request Checklist

Please confirm the PR meets the following requirements.
- [x] Relevant tags are added based on the types of changes.
- [x] Code changes pass `pre-commit` (e.g., ruff, mypy, etc.).
- [x] Tests have been added to show the fix is effective or that the new feature works.
- [x] New and existing unit tests pass locally with the changes.
- [x] Docs have been updated and reviewed if relevant.
