### PR TITLE
Increasing COUNT in scan_iter

### DIFF
--- a/academy/exchange/cloud/backend.py
+++ b/academy/exchange/cloud/backend.py
@@ -912,7 +912,11 @@ class RedisBackend:
             await self._client.delete(self._agent_key(uid))
 
         req_keys = [
-            key async for key in self._client.scan_iter(f'request:{uid.uid}:*')
+            key
+            async for key in self._client.scan_iter(
+                f'request:{uid.uid}:*',
+                count=1000,
+            )
         ]
         pending_requests: list[Header] = []
         for req_key in req_keys:
@@ -982,6 +986,7 @@ class RedisBackend:
         found: list[AgentId[Any]] = []
         async for key in self._client.scan_iter(
             'agent:*',
+            count=1000,
         ):  # pragma: no branch
             mro_str = (await self._client.get(key)).decode()
             assert isinstance(mro_str, str)

--- a/testing/redis.py
+++ b/testing/redis.py
@@ -138,7 +138,11 @@ class MockRedis:
             self.lists[key].append(value)
             self.events[key].set()
 
-    async def scan_iter(self, pattern: bytes | str) -> AsyncGenerator[bytes]:
+    async def scan_iter(
+        self,
+        pattern: bytes | str,
+        count: int = 10,
+    ) -> AsyncGenerator[bytes]:
         pattern = self._encode(pattern)
         for key in self.values:
             if fnmatch.fnmatch(key, pattern):


### PR DESCRIPTION
## Summary
<!--- Provide a summary of the changes --->
Since we introduced request tracking I had noticed a long wait in terminating the mailbox. I tracked it down to the time it takes to find the requests associated with a client in redis:
```
[2026-05-15 19:01:32.833] [tid=245501 pid=245501 task=Task-86]  INFO     (academy.exchange.cloud.backend) Starting to scan for requests.
[2026-05-15 19:01:52.909] [tid=245501 pid=245501 task=Task-86]  INFO     (academy.exchange.cloud.backend) Finished scanning for requests.
```

One of the easy fixes for this is to increase the `count` parameter of scan_iter, which attempts to match more keys against `match` per round trip request. With this PR, the round trip time decreases to <1 second:
```
[2026-05-15 19:25:13.632] [tid=245782 pid=245782 task=Task-86]  INFO     (academy.exchange.cloud.backend) Starting to scan for requests.
[2026-05-15 19:25:14.519] [tid=245782 pid=245782 task=Task-86]  INFO     (academy.exchange.cloud.backend) Finished scanning for requests.
```

Note, that this is just a temporary fix, scanning redis will never be an efficient and scalable solution. This should be seen as the first signs that the scalability of redis is limited and we should start looking at alternatives.

## Related Issues
<!--- List any issue numbers above that this PR addresses --->
 
I didn't open an issue for this.

## Changes
<!--- Check which of the following changes were made --->

- [ ] Breaking (backwards incompatible changes to public interfaces)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (non-breaking change or feature addition)
- [ ] Refactor (internal code or design clean up)
- [ ] Documentation (no changes to the code)
- [ ] Test (changes or additions to testing)
- [ ] Build (change to CI workflows or build processes)
- [ ] Package (changes to package metadata or dependency versions)

## Testing
<!--- Please describe the test ran to verify changes --->

N/A

## Pull Request Checklist

Please confirm the PR meets the following requirements.
- [x] Relevant tags are added based on the types of changes.
- [x] Code changes pass `pre-commit` (e.g., ruff, mypy, etc.).
- [ ] Tests have been added to show the fix is effective or that the new feature works.
- [x] New and existing unit tests pass locally with the changes.
- [ ] Docs have been updated and reviewed if relevant.
