### PR TITLE
Heartbeat and Request Key Expiration in Redis Backend

### DIFF
--- a/academy/exchange/cloud/backend.py
+++ b/academy/exchange/cloud/backend.py
@@ -792,6 +792,10 @@ class RedisBackend:
             self._owner_key(entity),
             self.gravestone_expiration_s,
         )
+        await self._client.expire(
+            self._heartbeat_key(entity),
+            self.gravestone_expiration_s,
+        )
         if isinstance(entity, AgentId):
             await self._client.expire(
                 self._agent_key(entity),
@@ -950,6 +954,7 @@ class RedisBackend:
         now = await self._redis_current_time()
 
         await self._client.set(self._heartbeat_key(uid), str(now))
+        await self._update_expirations(uid)
 
     async def heartbeat_status(self, uid: EntityId) -> float | None:
         """Get the time since last heartbeat timestamp for a mailbox."""
@@ -1098,6 +1103,11 @@ class RedisBackend:
                 self._request_key(message.dest, message.tag),
                 message.header.model_dump_json(),
             )
+            if self.mailbox_expiration_s:
+                await self._client.expire(
+                    self._request_key(message.dest, message.tag),
+                    self.mailbox_expiration_s,
+                )
             logger.debug(
                 'Tracking in-flight request: tag=%s src=%s dest=%s',
                 message.tag,

--- a/testing/redis.py
+++ b/testing/redis.py
@@ -88,10 +88,13 @@ class MockRedis:
         xx: bool = False,
         gt: bool = False,
         lt: bool = False,
-    ) -> None:
+    ) -> bool:
+        if not await self.exists(key):
+            return False
+
         key = self._encode(key)
         if nx and key in self.timeouts:
-            return
+            return False
 
         if xx or gt or lt:
             raise NotImplementedError()
@@ -103,6 +106,7 @@ class MockRedis:
         self.timeouts[key] = asyncio.ensure_future(
             self._expire_key(key, time),
         )
+        return True
 
     async def get(
         self,


### PR DESCRIPTION
## Summary
<!--- Provide a summary of the changes --->
Right now all the keys we insert into redis except for heartbeat and requests have expiration times, this adds expiration times to those two key types as well. The goal of these expirations is to keep redis relatively clean --- as long as we are just using Redis, we don't want to infinitely store messages and other keys in memory, especially for "abandoned" mailboxes. The goal for expiration is if there is no activity for an extended amount of time (as configured by mailbox and gravestone expiration), Redis will expire keys until nothing is stored.

## Related Issues
<!--- List any issue numbers above that this PR addresses --->

N/A

## Changes
<!--- Check which of the following changes were made --->

- [ ] Breaking (backwards incompatible changes to public interfaces)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (non-breaking change or feature addition)
- [ ] Refactor (internal code or design clean up)
- [ ] Documentation (no changes to the code)
- [ ] Test (changes or additions to testing)
- [ ] Build (change to CI workflows or build processes)
- [ ] Package (changes to package metadata or dependency versions)

## Testing
<!--- Please describe the test ran to verify changes --->

N/A

## Pull Request Checklist

Please confirm the PR meets the following requirements.
- [x] Relevant tags are added based on the types of changes.
- [x] Code changes pass `pre-commit` (e.g., ruff, mypy, etc.).
- [ ] Tests have been added to show the fix is effective or that the new feature works.
- [x] New and existing unit tests pass locally with the changes.
- [ ] Docs have been updated and reviewed if relevant.
