### PR TITLE
Adding Protocol Version to Messages

### DIFF
--- a/academy/exception.py
+++ b/academy/exception.py
@@ -232,8 +232,9 @@ class IncompatibleNetworkProtocolError(Exception):
 
     def __init__(self) -> None:
         super().__init__(
-            'Incompatible academy network protocol. This likely means '
-            'you need to upgrade your academy version. ',
+            'Incompatible academy network protocol. The network protocol '
+            'version needs to match between communicating agents and the '
+            'exchange.',
         )
 
     def __reduce__(self) -> Any:

--- a/academy/exception.py
+++ b/academy/exception.py
@@ -230,15 +230,22 @@ class AcademyRemoteError(Exception):
 class IncompatibleNetworkProtocolError(Exception):
     """Received message incompatible with this version."""
 
-    def __init__(self) -> None:
+    def __init__(
+        self,
+        version: str | None = None,
+        cur_version: str | None = None,
+    ) -> None:
         super().__init__(
             'Incompatible academy network protocol. The network protocol '
             'version needs to match between communicating agents and the '
-            'exchange.',
+            f'exchange. Remote version {version}, current version '
+            f'{cur_version}',
         )
+        self.version = version
+        self.cur_version = cur_version
 
     def __reduce__(self) -> Any:
-        return type(self), ()
+        return type(self), (self.version, self.cur_version)
 
 
 def raise_exceptions(

--- a/academy/exception.py
+++ b/academy/exception.py
@@ -227,6 +227,19 @@ class AcademyRemoteError(Exception):
     """
 
 
+class IncompatibleNetworkProtocolError(Exception):
+    """Received message incompatible with this version."""
+
+    def __init__(self) -> None:
+        super().__init__(
+            'Incompatible academy network protocol. This likely means '
+            'you need to upgrade your academy version. ',
+        )
+
+    def __reduce__(self) -> Any:
+        return type(self), ()
+
+
 def raise_exceptions(
     exceptions: Iterable[BaseException],
     *,

--- a/academy/exchange/client.py
+++ b/academy/exchange/client.py
@@ -31,6 +31,7 @@ from academy.identifier import AgentId
 from academy.identifier import EntityId
 from academy.identifier import UserId
 from academy.message import AcademyErrorResponse
+from academy.message import check_version
 from academy.message import ErrorCode
 from academy.message import Message
 from academy.message import RequestT_co
@@ -378,9 +379,7 @@ class AgentExchangeClient(
             )
 
     async def _handle_message(self, message: Message[Any]) -> None:
-        if message.is_request():
-            await self._request_handler(message)
-        elif message.is_response():
+        if message.is_response():
             if message.label is None or message.label not in self._handles:
                 logger.warning(
                     'Exchange client for %s received an unexpected response '
@@ -392,6 +391,23 @@ class AgentExchangeClient(
                 return
             handle = self._handles[message.label]
             await handle._process_response(message)
+        elif not check_version(message.protocol_version):
+            response = message.create_response(
+                AcademyErrorResponse(
+                    error_code=ErrorCode.INCOMPATIBLE_PROTOCOL,
+                    mailbox_id=self.client_id,
+                ),
+            )
+            await self._transport.send(response)
+            logger.warning(
+                'Exchange client for %s received message with incompatible '
+                'version from %s',
+                self.client_id,
+                message.src,
+                extra=message.log_extra(),
+            )
+        elif message.is_request():
+            await self._request_handler(message)
         else:
             raise AssertionError('Unreachable.')
 
@@ -461,7 +477,34 @@ class UserExchangeClient(ExchangeClient[ExchangeTransportT]):
             )
 
     async def _handle_message(self, message: Message[Any]) -> None:
-        if message.is_request():
+        if message.is_response():
+            if message.label is None or message.label not in self._handles:
+                logger.warning(
+                    'Exchange client for %s received an unexpected response '
+                    'message from %s but no corresponding handle exists.',
+                    self.client_id,
+                    message.src,
+                    extra=message.log_extra(),
+                )
+                return
+            handle = self._handles[message.label]
+            await handle._process_response(message)
+        elif not check_version(message.protocol_version):
+            response = message.create_response(
+                AcademyErrorResponse(
+                    error_code=ErrorCode.INCOMPATIBLE_PROTOCOL,
+                    mailbox_id=self.client_id,
+                ),
+            )
+            await self._transport.send(response)
+            logger.warning(
+                'Exchange client for %s received message with incompatible '
+                'version from %s',
+                self.client_id,
+                message.src,
+                extra=message.log_extra(),
+            )
+        elif message.is_request():
             response = message.create_response(
                 AcademyErrorResponse(
                     error_code=ErrorCode.INVALID_CLIENT,
@@ -476,18 +519,6 @@ class UserExchangeClient(ExchangeClient[ExchangeTransportT]):
                 message.src,
                 extra=message.log_extra(),
             )
-        elif message.is_response():
-            if message.label is None or message.label not in self._handles:
-                logger.warning(
-                    'Exchange client for %s received an unexpected response '
-                    'message from %s but no corresponding handle exists.',
-                    self.client_id,
-                    message.src,
-                    extra=message.log_extra(),
-                )
-                return
-            handle = self._handles[message.label]
-            await handle._process_response(message)
         else:
             raise AssertionError('Unreachable.')
 

--- a/academy/exchange/cloud/client.py
+++ b/academy/exchange/cloud/client.py
@@ -54,7 +54,7 @@ else:
 
 logger = logging.getLogger(__name__)
 
-DEFAULT_EXCHANGE_URL = 'https://exchange.academy-agents.org'
+DEFAULT_EXCHANGE_URL = 'https://exchange.academy-agents.org/v1'
 
 
 class _HttpConnectionInfo(NamedTuple):

--- a/academy/exchange/cloud/globus.py
+++ b/academy/exchange/cloud/globus.py
@@ -20,6 +20,8 @@ from typing import Literal
 from typing import NamedTuple
 from typing import TYPE_CHECKING
 
+from academy.exchange.cloud.client import DEFAULT_EXCHANGE_URL
+
 if sys.version_info >= (3, 11):  # pragma: >=3.11 cover
     from typing import Self
 else:  # pragma: <3.11 cover
@@ -86,7 +88,7 @@ class AcademyGlobusClient(globus_sdk.BaseClient):
     asyncio.
     """
 
-    base_url = 'https://exchange.academy-agents.org'
+    base_url = DEFAULT_EXCHANGE_URL
     scopes = AcademyExchangeScopes
     default_scope_requirements: ClassVar[list[Scope]] = [
         AcademyExchangeScopes.academy_exchange,

--- a/academy/handle.py
+++ b/academy/handle.py
@@ -225,8 +225,7 @@ class Handle(Generic[AgentT_co]):
     async def _process_response(self, response: Message[ResponseT]) -> None:
         future = self._pending_response_futures.pop(response.tag)
         if not future.cancelled():
-            body = response.get_body()
-            future.set_result(body)
+            future.set_result(response)
 
     def _register_with_exchange(self, exchange: ExchangeClient[Any]) -> None:
         """Register to receive messages from exchange.
@@ -294,7 +293,7 @@ class Handle(Generic[AgentT_co]):
             ),
         )
         loop = asyncio.get_running_loop()
-        future: asyncio.Future[Response] = loop.create_future()
+        future: asyncio.Future[Message[Response]] = loop.create_future()
         self._pending_response_futures[request.tag] = future
 
         try:
@@ -342,7 +341,8 @@ class Handle(Generic[AgentT_co]):
 
         assert future.done()
         assert future.exception() is None
-        body = future.result()
+        message = future.result()
+        body = message.get_body()
 
         if isinstance(body, ActionResponse):
             result = body.get_result()
@@ -402,7 +402,7 @@ class Handle(Generic[AgentT_co]):
             body=PingRequest(),
         )
         loop = asyncio.get_running_loop()
-        future: asyncio.Future[Response] = loop.create_future()
+        future: asyncio.Future[Message[Response]] = loop.create_future()
         self._pending_response_futures[request.tag] = future
         start = time.perf_counter()
         await self.exchange.send(request)
@@ -416,7 +416,8 @@ class Handle(Generic[AgentT_co]):
         await asyncio.wait_for(future, timeout)
 
         assert future.done()
-        body = future.result()
+        message = future.result()
+        body = message.get_body()
 
         if isinstance(body, ErrorResponse):
             raise body.get_exception()
@@ -434,12 +435,16 @@ class Handle(Generic[AgentT_co]):
         )
         return elapsed
 
-    def _shutdown_callback(self, future: asyncio.Future[ResponseT]) -> None:
+    def _shutdown_callback(
+        self,
+        future: asyncio.Future[Message[ResponseT]],
+    ) -> None:
         exception: BaseException
         if future.exception() is not None:
             exception = future.exception()  # type: ignore[assignment]
         else:
-            body = future.result()
+            message = future.result()
+            body = message.get_body()
             if not isinstance(body, ErrorResponse):
                 return
             exception = body.get_exception()
@@ -488,7 +493,7 @@ class Handle(Generic[AgentT_co]):
         )
 
         loop = asyncio.get_running_loop()
-        future: asyncio.Future[Response] = loop.create_future()
+        future: asyncio.Future[Message[Response]] = loop.create_future()
         self._pending_response_futures[request.tag] = future
         await self.exchange.send(request)
 

--- a/academy/message.py
+++ b/academy/message.py
@@ -39,24 +39,30 @@ from academy.serialize import serialize
 
 DEFAULT_FROZEN_CONFIG = ConfigDict(
     arbitrary_types_allowed=True,
-    extra='forbid',
+    extra='ignore',
     frozen=True,
     use_enum_values=True,
     validate_default=True,
 )
 DEFAULT_MUTABLE_CONFIG = ConfigDict(
     arbitrary_types_allowed=True,
-    extra='forbid',
+    extra='ignore',
     frozen=False,
     use_enum_values=True,
     validate_default=True,
 )
 
-PROTOCOL_VERSION: Version = Version('0.0')
+PROTOCOL_VERSION: Version = Version('1')
 
 
 def check_version(version: str | None) -> bool:
-    """Checks is a `protocol_version` is compatible.
+    """Checks if a `protocol_version` is compatible.
+
+    Messages within a major version are intended to be mutually
+    compatible, while minor version changes might introduce
+    optional fields or remove existing fields without prohibiting
+    their existence. Local tags may be added for branches/forks
+    and must match exactly.
 
     Args:
         version: The version string to check
@@ -65,7 +71,9 @@ def check_version(version: str | None) -> bool:
         True if the version is compatible.
     """
     return (
-        version is not None and parse(version).major == PROTOCOL_VERSION.major
+        version is not None
+        and parse(version).major == PROTOCOL_VERSION.major
+        and parse(version).local == PROTOCOL_VERSION.local
     )
 
 
@@ -387,8 +395,10 @@ class Header(BaseModel):
     protocol_version: str | None = Field(
         str(PROTOCOL_VERSION),
         description=(
-            'Version of the academy protocol used. Until version 1.0, the '
-            'network protocol may change between minor versions.'
+            'Version of the academy protocol used. Messages within a major '
+            'version are intended to be mutually compatible, while minor '
+            'version changes might introduce optional fields or remove '
+            'existing fields without prohibiting their existence.'
         ),
     )
 
@@ -470,7 +480,7 @@ class Message(BaseModel, Generic[BodyT]):
 
     @property
     def protocol_version(self) -> str | None:
-        """Message label."""
+        """Message protocol version."""
         return self.header.protocol_version
 
     @classmethod

--- a/academy/message.py
+++ b/academy/message.py
@@ -11,11 +11,8 @@ from typing import Protocol
 from typing import runtime_checkable
 from typing import TypeVar
 
-from academy.exception import ActionCancelledError
-from academy.exception import ActionInvalidStateError
-from academy.exception import ExceptionSerializationError
-from academy.exception import MailboxTerminatedError
-from academy.exception import PingCancelledError
+from packaging.version import parse
+from packaging.version import Version
 
 if sys.version_info >= (3, 11):  # pragma: >=3.11 cover
     from typing import Self
@@ -29,6 +26,12 @@ from pydantic import field_serializer
 from pydantic import SkipValidation
 from pydantic import TypeAdapter
 
+from academy.exception import ActionCancelledError
+from academy.exception import ActionInvalidStateError
+from academy.exception import ExceptionSerializationError
+from academy.exception import IncompatibleNetworkProtocolError
+from academy.exception import MailboxTerminatedError
+from academy.exception import PingCancelledError
 from academy.identifier import EntityId
 from academy.serialize import deserialize
 from academy.serialize import SerializationStrategy
@@ -48,6 +51,22 @@ DEFAULT_MUTABLE_CONFIG = ConfigDict(
     use_enum_values=True,
     validate_default=True,
 )
+
+PROTOCOL_VERSION: Version = Version('0.0')
+
+
+def check_version(version: str | None) -> bool:
+    """Checks is a `protocol_version` is compatible.
+
+    Args:
+        version: The version string to check
+
+    Returns:
+        True if the version is compatible.
+    """
+    return (
+        version is not None and parse(version).major == PROTOCOL_VERSION.major
+    )
 
 
 class ActionRequest(BaseModel):
@@ -229,6 +248,7 @@ class ErrorCode(IntEnum):
     ACTION_INVALID_STATE = 2
     ACTION_CANCELLED = 3
     INVALID_CLIENT = 4
+    INCOMPATIBLE_PROTOCOL = 5
 
 
 class AcademyErrorResponse(BaseModel):
@@ -267,6 +287,8 @@ class AcademyErrorResponse(BaseModel):
                 return ActionCancelledError()
             case ErrorCode.INVALID_CLIENT:
                 return TypeError(f'{self.mailbox_id} cannot fulfill requests.')
+            case ErrorCode.INCOMPATIBLE_PROTOCOL:
+                return IncompatibleNetworkProtocolError()
         raise AssertionError('Unreachable.')
 
 
@@ -362,6 +384,13 @@ class Header(BaseModel):
         ),
     )
     kind: Literal['request', 'response']
+    protocol_version: str | None = Field(
+        str(PROTOCOL_VERSION),
+        description=(
+            'Version of the academy protocol used. Until version 1.0, the '
+            'network protocol may change between minor versions.'
+        ),
+    )
 
     model_config = DEFAULT_FROZEN_CONFIG
 
@@ -439,6 +468,11 @@ class Message(BaseModel, Generic[BodyT]):
         """Message label."""
         return self.header.label
 
+    @property
+    def protocol_version(self) -> str | None:
+        """Message label."""
+        return self.header.protocol_version
+
     @classmethod
     def create(
         cls,
@@ -502,6 +536,12 @@ class Message(BaseModel, Generic[BodyT]):
         """
         if isinstance(self.body, get_args(Body)):
             return self.body
+
+        if not check_version(self.protocol_version):
+            # If we are deserializing from another protocol version,
+            # we expect the validation to fail, but we would like to
+            # raise a more informative error.
+            raise IncompatibleNetworkProtocolError()
 
         adapter: TypeAdapter[BodyT] = TypeAdapter(Body)
         body = (

--- a/academy/message.py
+++ b/academy/message.py
@@ -296,7 +296,7 @@ class AcademyErrorResponse(BaseModel):
             case ErrorCode.INVALID_CLIENT:
                 return TypeError(f'{self.mailbox_id} cannot fulfill requests.')
             case ErrorCode.INCOMPATIBLE_PROTOCOL:
-                return IncompatibleNetworkProtocolError()
+                return IncompatibleNetworkProtocolError(None, PROTOCOL_VERSION)
         raise AssertionError('Unreachable.')
 
 
@@ -551,7 +551,10 @@ class Message(BaseModel, Generic[BodyT]):
             # If we are deserializing from another protocol version,
             # we expect the validation to fail, but we would like to
             # raise a more informative error.
-            raise IncompatibleNetworkProtocolError()
+            raise IncompatibleNetworkProtocolError(
+                self.protocol_version,
+                PROTOCOL_VERSION,
+            )
 
         adapter: TypeAdapter[BodyT] = TypeAdapter(Body)
         body = (

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -12,6 +12,11 @@ Please refer to our [Version Policy](version-policy.md) for more details on when
 
 ## Academy v0.5
 
+## Message Protocol Change
+
+Between version v0.4 and v0.5 we made breaking changes to the format of the communication between agents.
+If you are using standard interfaces (i.e. Runtime, Handle, ExchangeClient, etc.) these create and send messages behind the scenes, so this change will not be visible to you, but this is a *breaking* change to the protocol. Agents using v0.4 will not be able to deserialize messages from agents using v0.5 and visa-versa. Furthermore the hosted exchange will communicate using v0.5, which will create confusing/un-interpretable errors for users/agents using v0.4.
+
 ## Logging Configuration
 
 This version of Academy introduces new logging configuration which is intended to help users configure logging across multiple processes, and to provide a base for development of other log-oriented features (such as provenance tracking, and distributed/cloud based logging)

--- a/examples/04-execution/run-04.py
+++ b/examples/04-execution/run-04.py
@@ -54,7 +54,10 @@ async def main() -> int:
     )
 
     async with await Manager.from_exchange_factory(
-        factory=HttpExchangeFactory(),
+        factory=HttpExchangeFactory(
+            'https://exchange.academy-agents.org/main',
+            auth_method='globus',
+        ),
         # Agents are run by the manager in the processes of this
         # process pool executor.
         executors=executor,

--- a/examples/04-execution/run-04.py
+++ b/examples/04-execution/run-04.py
@@ -54,10 +54,7 @@ async def main() -> int:
     )
 
     async with await Manager.from_exchange_factory(
-        factory=HttpExchangeFactory(
-            'https://exchange.academy-agents.org/main',
-            auth_method='globus',
-        ),
+        factory=HttpExchangeFactory(),
         # Agents are run by the manager in the processes of this
         # process pool executor.
         executors=executor,

--- a/tests/unit/exception_test.py
+++ b/tests/unit/exception_test.py
@@ -15,6 +15,7 @@ from academy.exception import ExceptionSerializationError
 from academy.exception import ExchangeClientNotFoundError
 from academy.exception import ExchangeError
 from academy.exception import ForbiddenError
+from academy.exception import IncompatibleNetworkProtocolError
 from academy.exception import MailboxTerminatedError
 from academy.exception import MessageTooLargeError
 from academy.exception import PingCancelledError
@@ -43,6 +44,7 @@ from academy.identifier import UserId
         DeserializationMethodProhibitedError(),
         ExceptionSerializationError('TestError traceback', 'pickle'),
         AcademyRemoteError(),
+        IncompatibleNetworkProtocolError(),
     ),
 )
 def test_pickle_exception(exc: Exception) -> None:

--- a/tests/unit/exception_test.py
+++ b/tests/unit/exception_test.py
@@ -44,7 +44,7 @@ from academy.identifier import UserId
         DeserializationMethodProhibitedError(),
         ExceptionSerializationError('TestError traceback', 'pickle'),
         AcademyRemoteError(),
-        IncompatibleNetworkProtocolError(),
+        IncompatibleNetworkProtocolError('2', '1'),
     ),
 )
 def test_pickle_exception(exc: Exception) -> None:

--- a/tests/unit/exchange/client_test.py
+++ b/tests/unit/exchange/client_test.py
@@ -13,6 +13,7 @@ import pytest_asyncio
 
 from academy.debug import set_academy_debug
 from academy.exception import BadEntityIdError
+from academy.exception import IncompatibleNetworkProtocolError
 from academy.exchange import ExchangeFactory
 from academy.exchange import MailboxStatus
 from academy.exchange import UserExchangeClient
@@ -295,6 +296,71 @@ async def test_client_reply_error_on_request(
             body = response.get_body()
             assert isinstance(body, ErrorResponse)
             assert isinstance(body.get_exception(), TypeError)
+
+
+@pytest.mark.asyncio
+async def test_user_client_reply_on_incompatible_protocol(
+    factory: ExchangeFactory[Any],
+) -> None:
+    async with await factory.create_user_client() as client:
+        registration = await client.register_agent(EmptyAgent)
+        async with await factory.create_agent_client(
+            registration,
+            _request_handler,
+        ) as agent_client:
+            message = Message.create(
+                src=agent_client.client_id,
+                dest=client.client_id,
+                body=PingRequest(),
+            )
+            message.header = message.header.model_copy(
+                update={'protocol_version': '1000.0.0'},
+            )
+
+            await agent_client.send(message)
+            response = await anext(
+                agent_client._transport.listen(timeout=TEST_WAIT_TIMEOUT),
+            )
+            body = response.get_body()
+            assert isinstance(body, ErrorResponse)
+            assert isinstance(
+                body.get_exception(),
+                IncompatibleNetworkProtocolError,
+            )
+
+
+@pytest.mark.asyncio
+async def test_agent_client_reply_on_incompatible_protocol(
+    factory: ExchangeFactory[Any],
+) -> None:
+    async with await factory.create_user_client(
+        start_listener=False,
+    ) as client:
+        registration = await client.register_agent(EmptyAgent)
+        async with await factory.create_agent_client(
+            registration,
+            _request_handler,
+        ) as agent_client:
+            message = Message.create(
+                src=agent_client.client_id,
+                dest=client.client_id,
+                body=PingRequest(),
+            )
+            message.header = message.header.model_copy(
+                update={'protocol_version': '1000.0.0'},
+            )
+            await agent_client._handle_message(message)
+
+            await client.send(message)
+            response = await anext(
+                agent_client._transport.listen(timeout=TEST_WAIT_TIMEOUT),
+            )
+            body = response.get_body()
+            assert isinstance(body, ErrorResponse)
+            assert isinstance(
+                body.get_exception(),
+                IncompatibleNetworkProtocolError,
+            )
 
 
 def test_client_background_error(

--- a/tests/unit/exchange/client_test.py
+++ b/tests/unit/exchange/client_test.py
@@ -308,13 +308,21 @@ async def test_user_client_reply_on_incompatible_protocol(
             registration,
             _request_handler,
         ) as agent_client:
-            message = Message.create(
-                src=agent_client.client_id,
-                dest=client.client_id,
-                body=PingRequest(),
-            )
-            message.header = message.header.model_copy(
-                update={'protocol_version': '1000.0.0'},
+            message: Message[Any] = Message.model_validate(
+                {
+                    'header': {
+                        'src': agent_client.client_id,
+                        'dest': client.client_id,
+                        'kind': 'request',
+                        'tag': uuid.uuid4(),
+                        'protocol_version': '1000.0.0',
+                        'additional_header_info': 'test',
+                    },
+                    'body': {
+                        'type': 'brand-new-type-of-request',
+                        'with_arbitrary_info': '...',
+                    },
+                },
             )
 
             await agent_client.send(message)

--- a/tests/unit/handle_test.py
+++ b/tests/unit/handle_test.py
@@ -219,7 +219,7 @@ async def test_client_handle_ping_timeout(
 @pytest.mark.asyncio
 async def test_client_handle_shutdown_future_error_logged(caplog) -> None:
     handle: Handle[EmptyAgent] = Handle(AgentId.new())
-    future: asyncio.Future[Response] = asyncio.Future()
+    future: asyncio.Future[Message[Response]] = asyncio.Future()
     future.set_exception(Exception('Test'))
     handle._shutdown_callback(future)
     with caplog.at_level(logging.ERROR):
@@ -230,10 +230,14 @@ async def test_client_handle_shutdown_future_error_logged(caplog) -> None:
 @pytest.mark.asyncio
 async def test_client_handle_shutdown_ignore_already_terminated() -> None:
     handle: Handle[EmptyAgent] = Handle(AgentId.new())
-    future: asyncio.Future[Response] = asyncio.Future()
-    response = AcademyErrorResponse(
-        error_code=ErrorCode.MAILBOX_TERMINATED,
-        mailbox_id=handle.agent_id,
+    future: asyncio.Future[Message[AcademyErrorResponse]] = asyncio.Future()
+    response = Message.create(
+        src=handle.agent_id,
+        dest=AgentId.new(),
+        body=AcademyErrorResponse(
+            error_code=ErrorCode.MAILBOX_TERMINATED,
+            mailbox_id=handle.agent_id,
+        ),
     )
     future.set_result(response)
     handle._shutdown_callback(future)

--- a/tests/unit/message_test.py
+++ b/tests/unit/message_test.py
@@ -7,6 +7,7 @@ from typing import Any
 
 import pydantic
 import pytest
+from pydantic import Field
 
 from academy.exception import ActionCancelledError
 from academy.exception import ActionInvalidStateError
@@ -274,3 +275,33 @@ def test_incompatible_protocol_error() -> None:
     )
     with pytest.raises(IncompatibleNetworkProtocolError):
         bad_message.get_body()
+
+
+def test_compatible_major_version() -> None:
+    class NewActionRequest(ActionRequest):
+        ttl: int | None = Field(
+            None,
+            description='Time to live of request',
+        )
+
+    message: Message[NewActionRequest] = Message.model_validate(
+        {
+            'header': {
+                'src': AgentId.new(),
+                'dest': AgentId.new(),
+                'tag': uuid.uuid4(),
+                'protocol_version': '1.1',
+                'kind': 'request',
+            },
+            'body': NewActionRequest(
+                action='test',
+                serialization=SerializationStrategy.JSON,
+                ttl=8,
+            ).model_dump(),
+        },
+    )
+
+    # Body is retrieved as old action request (without ttl)
+    body = message.get_body()
+    assert isinstance(body, ActionRequest)
+    assert not isinstance(body, NewActionRequest)

--- a/tests/unit/message_test.py
+++ b/tests/unit/message_test.py
@@ -11,6 +11,7 @@ import pytest
 from academy.exception import ActionCancelledError
 from academy.exception import ActionInvalidStateError
 from academy.exception import ExceptionSerializationError
+from academy.exception import IncompatibleNetworkProtocolError
 from academy.exception import MailboxTerminatedError
 from academy.exception import PingCancelledError
 from academy.identifier import AgentId
@@ -18,15 +19,29 @@ from academy.message import AcademyErrorResponse
 from academy.message import ActionRequest
 from academy.message import ActionResponse
 from academy.message import CancelRequest
+from academy.message import check_version
 from academy.message import ErrorCode
 from academy.message import ErrorResponse
 from academy.message import Header
 from academy.message import Message
 from academy.message import PingRequest
+from academy.message import PROTOCOL_VERSION
 from academy.message import ShutdownRequest
 from academy.message import SuccessResponse
 from academy.message import UserErrorResponse
 from academy.serialize import SerializationStrategy
+
+
+def test_check_version_good():
+    assert check_version(str(PROTOCOL_VERSION))
+
+
+def test_check_version_bad():
+    assert not check_version('1000.0.0')
+
+
+def test_check_version_none():
+    assert not check_version(None)
 
 
 @pytest.mark.parametrize(
@@ -176,6 +191,7 @@ def test_action_response_lazy_deserialize(serialization_stratgey) -> None:
         (ErrorCode.ACTION_INVALID_STATE, ActionInvalidStateError),
         (ErrorCode.ACTION_CANCELLED, ActionCancelledError),
         (ErrorCode.INVALID_CLIENT, TypeError),
+        (ErrorCode.INCOMPATIBLE_PROTOCOL, IncompatibleNetworkProtocolError),
     ),
 )
 def test_academy_error_response_to_exception(
@@ -242,3 +258,19 @@ def test_user_error_response_serialization_error() -> None:
     reconstructed.get_exception()
 
     assert isinstance(reconstructed.exception, ExceptionSerializationError)
+
+
+def test_incompatible_protocol_error() -> None:
+    bad_header = Header(
+        src=AgentId.new(),
+        dest=AgentId.new(),
+        tag=uuid.uuid4(),
+        protocol_version=None,
+        kind='response',
+    )
+    bad_message: Message[SuccessResponse] = Message(
+        header=bad_header,
+        body=b'',
+    )
+    with pytest.raises(IncompatibleNetworkProtocolError):
+        bad_message.get_body()


### PR DESCRIPTION
## Summary
<!--- Provide a summary of the changes --->
Since #406 changed the protocol of the messages sent over the exchange, it has raised the issue that some changes to the network protocol will make it incompatible for agents to talk to each other or for agents to use the hosted exchange. I introduce a protocol_version for messages on the network that we can use to define compatibility beyond just the releases. The idea being a "release" might have some breaking change for code using in the same environment, while a "protocol_version" upgrade may cause agents to be unable to talk to one another. (For instance, agents in v0.3.x and v0.4.0 were able to talk using the same protocol even though other interfaces changed, but this will not be true between agents in v0.4.0 and v0.5.0 because we now require the serialization method as part of the message.)

In the future I expect this versioning to let us think more about what compatibility we support, but at the moment, this is very simple based on major version of the `protocol_version`.


## Related Issues
<!--- List any issue numbers above that this PR addresses --->

N/A

## Changes
<!--- Check which of the following changes were made --->

- [x] Breaking (backwards incompatible changes to public interfaces)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (non-breaking change or feature addition)
- [ ] Refactor (internal code or design clean up)
- [ ] Documentation (no changes to the code)
- [ ] Test (changes or additions to testing)
- [ ] Build (change to CI workflows or build processes)
- [ ] Package (changes to package metadata or dependency versions)

## Testing
<!--- Please describe the test ran to verify changes --->

N/A

## Pull Request Checklist

Please confirm the PR meets the following requirements.
- [x] Relevant tags are added based on the types of changes.
- [x] Code changes pass `pre-commit` (e.g., ruff, mypy, etc.).
- [x] Tests have been added to show the fix is effective or that the new feature works.
- [x] New and existing unit tests pass locally with the changes.
- [ ] Docs have been updated and reviewed if relevant.
