### PR TITLE
Auth friction and sub-agents convo

### DIFF
--- a/academy/exchange/cloud/credentials.py
+++ b/academy/exchange/cloud/credentials.py
@@ -40,13 +40,7 @@ class PersistentAgentCredentials(BaseModel, Generic[AgentT]):
     """Client ID of the agent's Globus Auth resource server."""
 
     client_secret: SecretStr
-    """Secret used to authenticate the agent's Globus Auth client.
-
-    Stored as ``SecretStr`` so ``repr`` and accidental ``model_dump_json``
-    calls do not leak the secret. The credential file store opts into
-    unmasking via ``model_dump_json(context={'unmask': True})``; all other
-    callers see ``'**********'``.
-    """
+    """Secret used to authenticate the agent's Globus Auth client."""
 
     scope_string: str
     """Per-agent scope requested via ``client_credentials``."""
@@ -64,8 +58,7 @@ class PersistentAgentCredentials(BaseModel, Generic[AgentT]):
     """Whether this agent may spawn child agents.
 
     Default ``False``. ``True`` grants project-admin authority and is
-    not safe for production until sub-project isolation lands in v1.1
-    (see threat model T1).
+    not safe for production until isolation is implemented. 
     """
 
     model_config = ConfigDict(frozen=True)
@@ -153,8 +146,7 @@ class AgentCredentialFileStore:
         """List identifiers for all agents with credentials on disk.
 
         Returns ``AgentId`` instances with ``name=None``. Call
-        ``load(agent_id)`` if the display name is needed; this method
-        deliberately avoids reading every file just to enumerate IDs.
+        ``load(agent_id)`` if the display name is needed.
         """
         return [
             AgentId(uid=uuid.UUID(p.stem))

--- a/academy/exchange/cloud/credentials.py
+++ b/academy/exchange/cloud/credentials.py
@@ -1,0 +1,170 @@
+"""Persistent agent credentials and on-disk store.
+
+Used by the Globus persistent-agent boot path to authenticate as the
+agent via ``client_credentials`` without further user interaction.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import pathlib
+import uuid
+from datetime import datetime
+from typing import Any
+from typing import Generic
+
+from pydantic import BaseModel
+from pydantic import ConfigDict
+from pydantic import field_serializer
+from pydantic import SecretStr
+from pydantic import SerializationInfo
+
+from academy.exchange.cloud.login import get_academy_home
+from academy.identifier import AgentId
+from academy.identifier import AgentT
+
+logger = logging.getLogger(__name__)
+
+_AGENTS_SUBDIR = 'agents'
+_AGENTS_DIR_MODE = 0o700
+
+
+class PersistentAgentCredentials(BaseModel, Generic[AgentT]):
+    """Durable credentials for a Globus persistent agent."""
+
+    agent_id: AgentId[AgentT]
+    """Unique identifier for the agent."""
+
+    client_id: uuid.UUID
+    """Client ID of the agent's Globus Auth resource server."""
+
+    client_secret: SecretStr
+    """Secret used to authenticate the agent's Globus Auth client.
+
+    Stored as ``SecretStr`` so ``repr`` and accidental ``model_dump_json``
+    calls do not leak the secret. The credential file store opts into
+    unmasking via ``model_dump_json(context={'unmask': True})``; all other
+    callers see ``'**********'``.
+    """
+
+    scope_string: str
+    """Per-agent scope requested via ``client_credentials``."""
+
+    agent_type: tuple[str, ...]
+    """MRO of the agent type, matching ``Agent._agent_mro()``."""
+
+    fleet_group_ids: tuple[uuid.UUID, ...]
+    """Fleet group memberships at provision time (length 1 in v1)."""
+
+    created_at: datetime
+    """Provisioning timestamp."""
+
+    spawn_capable: bool = False
+    """Whether this agent may spawn child agents.
+
+    Default ``False``. ``True`` grants project-admin authority and is
+    not safe for production until sub-project isolation lands in v1.1
+    (see threat model T1).
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    @field_serializer('client_secret', when_used='json')
+    def _serialize_client_secret(
+        self,
+        secret: SecretStr,
+        info: SerializationInfo,
+    ) -> str:
+        if info.context is not None and info.context.get('unmask'):
+            return secret.get_secret_value()
+        return str(secret)
+
+
+class AgentCredentialFileStore:
+    """JSON-per-agent credential store with 0600 perms and atomic writes.
+
+    Args:
+        directory: Storage directory. Defaults to ``$ACADEMY_HOME/agents``.
+    """
+
+    def __init__(
+        self,
+        directory: pathlib.Path | None = None,
+    ) -> None:
+        if directory is None:
+            directory = get_academy_home() / _AGENTS_SUBDIR
+        self._dir = pathlib.Path(directory)
+        self._dir.mkdir(parents=True, exist_ok=True)
+        self._dir.chmod(_AGENTS_DIR_MODE)
+        # Clean up any orphaned tmp files from a previous crashed save.
+        # A stale ``<uid>.json.tmp`` would otherwise hold the agent's
+        # secret on disk.
+        for stale in self._dir.glob('*.json.tmp'):
+            stale.unlink()
+
+    def _path(self, agent_id: AgentId[Any]) -> pathlib.Path:
+        return self._dir / f'{agent_id.uid}.json'
+
+    def save(self, creds: PersistentAgentCredentials[Any]) -> None:
+        """Atomically write credentials to ``<agent_id.uid>.json``.
+
+        Uses the ``open(0600) + fsync(fd) + replace + fsync(dir)`` pattern
+        so a crash at any point leaves the prior file intact, never a
+        partial write.
+        """
+        if creds.spawn_capable:
+            logger.warning(
+                'Persisting spawn-capable credentials for %s; not safe '
+                'until sub-project grouping lands.',
+                creds.agent_id,
+                extra={'academy.agent_id': creds.agent_id},
+            )
+        payload = creds.model_dump_json(context={'unmask': True})
+        path = self._path(creds.agent_id)
+        tmp = path.with_suffix('.json.tmp')
+        fd = os.open(tmp, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+        try:
+            os.write(fd, payload.encode('utf-8'))
+            os.fsync(fd)
+        finally:
+            os.close(fd)
+        os.replace(tmp, path)
+        dir_fd = os.open(self._dir, os.O_RDONLY)
+        try:
+            os.fsync(dir_fd)
+        finally:
+            os.close(dir_fd)
+
+    def load(
+        self,
+        agent_id: AgentId[Any],
+    ) -> PersistentAgentCredentials[Any]:
+        """Load credentials for an agent.
+
+        Raises:
+            FileNotFoundError: if no credentials are stored for the agent.
+        """
+        return PersistentAgentCredentials.model_validate_json(
+            self._path(agent_id).read_text(encoding='utf-8'),
+        )
+
+    def list_agents(self) -> list[AgentId[Any]]:
+        """List identifiers for all agents with credentials on disk.
+
+        Returns ``AgentId`` instances with ``name=None``. Call
+        ``load(agent_id)`` if the display name is needed; this method
+        deliberately avoids reading every file just to enumerate IDs.
+        """
+        return [
+            AgentId(uid=uuid.UUID(p.stem))
+            for p in sorted(self._dir.glob('*.json'))
+        ]
+
+    def delete(self, agent_id: AgentId[Any]) -> None:
+        """Remove credentials for an agent.
+
+        Raises:
+            FileNotFoundError: if no credentials are stored for the agent.
+        """
+        self._path(agent_id).unlink()

--- a/academy/exchange/cloud/globus.py
+++ b/academy/exchange/cloud/globus.py
@@ -10,6 +10,7 @@ import threading
 import time
 import uuid
 from collections.abc import AsyncGenerator
+from collections.abc import Callable
 from concurrent.futures import ThreadPoolExecutor
 from datetime import datetime
 from datetime import timedelta
@@ -35,6 +36,8 @@ from globus_sdk import GlobusApp
 from globus_sdk import GlobusHTTPResponse
 from globus_sdk import Scope
 from globus_sdk.authorizers import GlobusAuthorizer
+from globus_sdk.authorizers import RenewingAuthorizer
+from globus_sdk.authorizers.renewing import EXPIRES_ADJUST_SECONDS
 from globus_sdk.exc import GlobusAPIError
 from globus_sdk.gare import GlobusAuthorizationParameters
 from globus_sdk.scopes import AuthScopes
@@ -46,6 +49,7 @@ from academy.exception import BadEntityIdError
 from academy.exception import MailboxTerminatedError
 from academy.exception import UnauthorizedError
 from academy.exchange.cloud.app import StatusCode
+from academy.exchange.cloud.credentials import PersistentAgentCredentials
 from academy.exchange.cloud.login import get_globus_app
 from academy.exchange.cloud.scopes import AcademyExchangeScopes
 from academy.exchange.cloud.scopes import get_academy_exchange_scope_id
@@ -868,3 +872,101 @@ class GlobusExchangeFactory(ExchangeFactory[GlobusExchangeTransport]):
                 name=name,
                 connection_info=self.info,
             )
+
+
+class _PersistentAgentAuthorizer(
+    RenewingAuthorizer[globus_sdk.OAuthClientCredentialsResponse],
+):
+    """Authorize against the exchange via ``client_credentials``.
+
+    Mints a chained token for the exchange resource server through the
+    agent's per-agent scope.
+
+    Adds thread-safe renewal on top of ``globus_sdk``'s
+    ``RenewingAuthorizer``. The parent class checks expiry without a
+    lock, so N concurrent callers all see the same expired token and
+    each fire a redundant grant. This subclass locks the
+    check-and-renew so only the first call mints; the rest find a
+    valid token and skip.
+    """
+
+    def __init__(
+        self,
+        confidential_client: globus_sdk.ConfidentialAppAuthClient,
+        scope: str,
+        target_resource_server: str,
+        on_refresh: Callable[
+            [globus_sdk.OAuthClientCredentialsResponse],
+            Any,
+        ]
+        | None = None,
+    ) -> None:
+        self._client = confidential_client
+        self._scope = scope
+        self._target_rs = target_resource_server
+        self._renew_lock = threading.Lock()
+        super().__init__(on_refresh=on_refresh)
+
+    def _needs_new_token(self) -> bool:
+        return (
+            self.access_token is None
+            or self.expires_at is None
+            or time.time() > self.expires_at - EXPIRES_ADJUST_SECONDS
+        )
+
+    def ensure_valid_token(self) -> None:
+        if self._needs_new_token():
+            with self._renew_lock:
+                # The inner re-check guards the race where another
+                # thread renewed while we waited for the lock.
+                # Single-threaded CI tests cannot hit the False branch
+                # of this check; that concurrency property is verified
+                # by spikes/globus_client/spike_authorizer_concurrent_grant.py.
+                if self._needs_new_token():  # pragma: no branch
+                    self._get_new_access_token()
+
+    def _get_token_response(
+        self,
+    ) -> globus_sdk.OAuthClientCredentialsResponse:
+        return self._client.oauth2_client_credentials_tokens(
+            requested_scopes=self._scope,
+        )
+
+    def _extract_token_data(
+        self,
+        res: globus_sdk.OAuthClientCredentialsResponse,
+    ) -> dict[str, Any]:
+        return res.by_resource_server[self._target_rs]
+
+
+async def create_persistent_agent_transport(  # pragma: no cover
+    creds: PersistentAgentCredentials[Any],
+    *,
+    connection_info: _AcademyConnectionInfo,
+) -> GlobusExchangeTransport:
+    """Boot a Globus exchange transport from persistent credentials.
+
+    Pure composition over `_PersistentAgentAuthorizer` and
+    `GlobusExchangeTransport.new`; 
+
+    Args:
+        creds: Durable credentials for the agent.
+        connection_info: Connection settings for the hosted exchange.
+
+    Returns:
+        Authenticated transport bound to ``creds.agent_id``.
+    """
+    auth_client = globus_sdk.ConfidentialAppAuthClient(
+        client_id=str(creds.client_id),
+        client_secret=creds.client_secret.get_secret_value(),
+    )
+    authorizer = _PersistentAgentAuthorizer(
+        confidential_client=auth_client,
+        scope=creds.scope_string,
+        target_resource_server=AcademyExchangeScopes.resource_server,
+    )
+    return await GlobusExchangeTransport.new(
+        authorizer=authorizer,
+        mailbox_id=creds.agent_id,
+        connection_info=connection_info,
+    )

--- a/academy/exchange/cloud/login.py
+++ b/academy/exchange/cloud/login.py
@@ -50,6 +50,21 @@ class _CustomLoginFlowManager(CommandLineLoginFlowManager):
         return auth_code.strip()
 
 
+def get_academy_home() -> pathlib.Path:
+    """Resolve the Academy data directory.
+
+    Resolves the Academy data directory (``ACADEMY_HOME``) if
+    set, otherwise ``~/local/share/academy``.
+    Assumes callers are responsible for creating the directory
+    as needed.
+
+    Returns:
+        Path to the Academy data directory.
+    """
+    default = os.path.join(os.path.expanduser('~/local/share'), _APP_NAME)
+    return pathlib.Path(os.environ.get('ACADEMY_HOME', default=default))
+
+
 def get_token_storage(
     filepath: str | pathlib.Path | None = None,
     *,
@@ -67,12 +82,7 @@ def get_token_storage(
         Token storage.
     """
     if filepath is None:
-        default = os.path.join(
-            os.path.expanduser('~/local/share'),
-            _APP_NAME,
-        )
-        basepath = os.environ.get('ACADEMY_HOME', default=default)
-        filepath = os.path.join(basepath, _TOKENS_FILE)
+        filepath = get_academy_home() / _TOKENS_FILE
 
     filepath = pathlib.Path(filepath)
     filepath.parent.mkdir(parents=True, exist_ok=True)

--- a/tests/unit/exchange/cloud/authorizer_test.py
+++ b/tests/unit/exchange/cloud/authorizer_test.py
@@ -1,0 +1,93 @@
+from __future__ import annotations
+
+import time
+from typing import Any
+from unittest import mock
+
+import globus_sdk
+
+from academy.exchange.cloud.globus import _PersistentAgentAuthorizer
+
+
+def _fake_response(*, target_rs: str, token: str) -> Any:
+    """Single-RS stand-in for OAuthClientCredentialsResponse.
+
+    ``RenewingAuthorizer`` reads ``by_resource_server[target_rs]`` and
+    treats the value as a dict with ``access_token`` and
+    ``expires_at_seconds``.
+    """
+    response = mock.MagicMock(spec=globus_sdk.OAuthClientCredentialsResponse)
+    response.by_resource_server = {
+        target_rs: {
+            'access_token': token,
+            'expires_at_seconds': int(time.time()) + 3600,
+        },
+    }
+    return response
+
+
+def _fake_chained_response(*, target_rs: str, target_token: str) -> Any:
+    """Two-RS stand-in (target + sibling) for chained-token tests."""
+    now = int(time.time())
+    response = mock.MagicMock(spec=globus_sdk.OAuthClientCredentialsResponse)
+    response.by_resource_server = {
+        target_rs: {
+            'access_token': target_token,
+            'expires_at_seconds': now + 3600,
+        },
+        'sibling_rs': {
+            'access_token': 'sibling-token',
+            'expires_at_seconds': now + 3600,
+        },
+    }
+    return response
+
+
+def test_authorizer_caches_token_within_validity() -> None:
+    client = mock.MagicMock(spec=globus_sdk.ConfidentialAppAuthClient)
+    client.oauth2_client_credentials_tokens.return_value = _fake_response(
+        target_rs='exchange_rs',
+        token='t',
+    )
+    authorizer = _PersistentAgentAuthorizer(
+        confidential_client=client,
+        scope='launch',
+        target_resource_server='exchange_rs',
+    )
+    authorizer.get_authorization_header()
+    authorizer.get_authorization_header()
+    assert client.oauth2_client_credentials_tokens.call_count == 1
+
+
+def test_authorizer_renews_after_expiry() -> None:
+    client = mock.MagicMock(spec=globus_sdk.ConfidentialAppAuthClient)
+    client.oauth2_client_credentials_tokens.return_value = _fake_response(
+        target_rs='exchange_rs',
+        token='t',
+    )
+    authorizer = _PersistentAgentAuthorizer(
+        confidential_client=client,
+        scope='launch',
+        target_resource_server='exchange_rs',
+    )
+    # Force expiry; next call must trigger renewal.
+    authorizer.access_token = None
+    authorizer.expires_at = 0
+    authorizer.get_authorization_header()
+    assert client.oauth2_client_credentials_tokens.call_count == 2  # noqa: PLR2004
+
+
+def test_authorizer_picks_target_rs_from_chained_response() -> None:
+    client = mock.MagicMock(spec=globus_sdk.ConfidentialAppAuthClient)
+    client.oauth2_client_credentials_tokens.return_value = (
+        _fake_chained_response(
+            target_rs='exchange_rs',
+            target_token='target-token',
+        )
+    )
+    authorizer = _PersistentAgentAuthorizer(
+        confidential_client=client,
+        scope='launch',
+        target_resource_server='exchange_rs',
+    )
+    assert authorizer.access_token == 'target-token'

--- a/tests/unit/exchange/cloud/credentials_test.py
+++ b/tests/unit/exchange/cloud/credentials_test.py
@@ -1,0 +1,139 @@
+from __future__ import annotations
+
+import pathlib
+import pickle
+import uuid
+from datetime import datetime
+from typing import Any
+from unittest import mock
+
+import pytest
+from pydantic import SecretStr
+from pydantic import ValidationError
+
+from academy.exchange.cloud.credentials import AgentCredentialFileStore
+from academy.exchange.cloud.credentials import PersistentAgentCredentials
+from academy.identifier import AgentId
+
+
+def _make_creds(
+    *,
+    name: str = 'test',
+    client_secret: str = 'secret',
+    spawn_capable: bool = False,
+) -> PersistentAgentCredentials[Any]:
+    return PersistentAgentCredentials(
+        agent_id=AgentId.new(name=name),
+        client_id=uuid.uuid4(),
+        client_secret=SecretStr(client_secret),
+        scope_string='launch',
+        agent_type=('module.Cls', 'module.Base'),
+        fleet_group_ids=(uuid.uuid4(),),
+        created_at=datetime.now(),
+        spawn_capable=spawn_capable,
+    )
+
+
+def test_credentials_pickle_roundtrip() -> None:
+    creds = _make_creds()
+    assert pickle.loads(pickle.dumps(creds)) == creds
+
+
+def test_credentials_is_frozen() -> None:
+    creds = _make_creds()
+    with pytest.raises(ValidationError):
+        creds.client_secret = SecretStr('mutated')  # type: ignore[misc]
+
+
+def test_credentials_secret_does_not_leak() -> None:
+    creds = _make_creds(client_secret='qwerty')
+    assert 'qwerty' not in repr(creds)
+    assert 'qwerty' not in creds.model_dump_json()
+
+
+def test_credentials_spawn_capable_defaults_false() -> None:
+    # Constructed directly (not via _make_creds) so the model's default
+    # is exercised, not the helper's.
+    creds: PersistentAgentCredentials[Any] = PersistentAgentCredentials(
+        agent_id=AgentId.new(),
+        client_id=uuid.uuid4(),
+        client_secret=SecretStr('x'),
+        scope_string='launch',
+        agent_type=('A',),
+        fleet_group_ids=(uuid.uuid4(),),
+        created_at=datetime.now(),
+    )
+    assert creds.spawn_capable is False
+
+
+def test_store_save_load(tmp_path: pathlib.Path) -> None:
+    store = AgentCredentialFileStore(tmp_path)
+    creds = _make_creds()
+    store.save(creds)
+    assert store.load(creds.agent_id) == creds
+
+
+def test_store_save_load_with_spawn_capable(tmp_path: pathlib.Path) -> None:
+    store = AgentCredentialFileStore(tmp_path)
+    creds = _make_creds(spawn_capable=True)
+    store.save(creds)
+    assert store.load(creds.agent_id).spawn_capable is True
+
+
+def test_store_uses_default_dir_under_academy_home(
+    tmp_path: pathlib.Path,
+) -> None:
+    with mock.patch(
+        'academy.exchange.cloud.credentials.get_academy_home',
+        return_value=tmp_path,
+    ):
+        AgentCredentialFileStore()
+    assert (tmp_path / 'agents').is_dir()
+
+
+def test_store_save_uses_0600(tmp_path: pathlib.Path) -> None:
+    store = AgentCredentialFileStore(tmp_path)
+    creds = _make_creds()
+    store.save(creds)
+    path = tmp_path / f'{creds.agent_id.uid}.json'
+    assert path.stat().st_mode & 0o777 == 0o600  # noqa: PLR2004
+
+
+def test_store_dir_perms_are_0o700(tmp_path: pathlib.Path) -> None:
+    target = tmp_path / 'agents'
+    AgentCredentialFileStore(target)
+    assert target.stat().st_mode & 0o777 == 0o700  # noqa: PLR2004
+
+
+def test_store_cleans_orphaned_tmp_files(tmp_path: pathlib.Path) -> None:
+    # A stale .json.tmp from a crashed save would otherwise hold the
+    # agent's secret on disk indefinitely.
+    orphan = tmp_path / f'{uuid.uuid4()}.json.tmp'
+    orphan.write_text('{"stale": true}')
+    AgentCredentialFileStore(tmp_path)
+    assert not orphan.exists()
+
+
+def test_store_list_agents(tmp_path: pathlib.Path) -> None:
+    store = AgentCredentialFileStore(tmp_path)
+    a = _make_creds(name='a')
+    b = _make_creds(name='b')
+    store.save(a)
+    store.save(b)
+    listed = store.list_agents()
+    assert {aid.uid for aid in listed} == {a.agent_id.uid, b.agent_id.uid}
+
+
+def test_store_delete(tmp_path: pathlib.Path) -> None:
+    store = AgentCredentialFileStore(tmp_path)
+    creds = _make_creds()
+    store.save(creds)
+    store.delete(creds.agent_id)
+    with pytest.raises(FileNotFoundError):
+        store.load(creds.agent_id)
+
+
+def test_store_delete_missing(tmp_path: pathlib.Path) -> None:
+    store = AgentCredentialFileStore(tmp_path)
+    with pytest.raises(FileNotFoundError):
+        store.delete(AgentId.new())

--- a/tests/unit/exchange/cloud/login_test.py
+++ b/tests/unit/exchange/cloud/login_test.py
@@ -15,6 +15,7 @@ from globus_sdk.token_storage import MemoryTokenStorage
 
 from academy.exchange.cloud.login import ACADEMY_GLOBUS_CLIENT_ID_ENV_NAME
 from academy.exchange.cloud.login import ACADEMY_GLOBUS_CLIENT_SECRET_ENV_NAME
+from academy.exchange.cloud.login import get_academy_home
 from academy.exchange.cloud.login import get_auth_headers
 from academy.exchange.cloud.login import get_client_app
 from academy.exchange.cloud.login import get_client_credentials_from_env
@@ -35,6 +36,19 @@ def mock_env_credentials() -> Generator[tuple[str, str], None, None]:
     }
     with mock.patch.dict(os.environ, env):
         yield client_uuid, client_secret
+
+
+def test_get_academy_home(tmp_path: pathlib.Path):
+    with mock.patch.dict(os.environ, {}, clear=True):
+        assert (
+            get_academy_home()
+            == pathlib.Path(
+                os.path.expanduser('~/local/share'),
+            )
+            / 'academy'
+        )
+    with mock.patch.dict(os.environ, {'ACADEMY_HOME': str(tmp_path)}):
+        assert get_academy_home() == tmp_path
 
 
 def test_get_token_storage(tmp_path: pathlib.Path):


### PR DESCRIPTION
## Summary

This PR is a place to discuss and decide on how we want to 1. reduce auth friction from users using hosted exchanges (Globus), and 2. enable agents to delegate auth to sub-agents. This initial PR is part of a proposal I have, but does not lock us into any particular solution. 

Launching agents on the Globus Exchange today requires users to *authenticate twice*, and agents *cant spawn sub-agents*. My proposed solution is described below to get us started:

Agents already have Globus Auth identities, and per-agent scope registration, but those identities are not used at runtime. The agent uses a user delegated token to access the exchange, so every action runs through the users auth chain. We redesign this so those existing identities are used by agents to authenticate as themselves via `client_credentials`, so the token presented to the exchange is native to the agent, not the user. After a one-time provisioning, agents boot non-interactively, persist across sessions, and can spawn other agents on demand. 

You could imagine this -- initial provisioning of some agent client:
```python
async with await Manager.from_exchange_factory(factory=factory) as m:
    creds = await m.register_persistent_agent(MyAgent)
    # creds.agent_id is durable; credentials persisted at
    # $ACADEMY_HOME/agents/<uid>.json with 0o600 perms.
```
and reuse of that client avoiding re-auth:
```python
# Booting — any future session, any process, zero prompts:
async with await Manager.from_exchange_factory(factory=factory) as m:
    creds = store.load(agent_id)  
    handle = await m.launch(
        MyAgent,
        registration=PersistentGlobusAgentRegistration(creds),
    )
```
and then an agent with sub-agent launch capabilities:
```python
class Coordinator(Agent):
    @action
    async def deploy_worker(self) -> AgentId[Worker]:
        return await self.spawn_child(Worker, name='worker-1')
        # Parent's own client_credentials grant mints child credentials.
        # No user prompt; no user session needed.
```

This functionality requires:

1. Agents authenticating themselves via `client_credentials`, instead of as the user's delegate. This removes one auth request. 
2. Agent mailboxes are shared with a _fleet Globus Group_ when provisioned for auth
3. Each agent's credentials (`client_id`, `secret`) are persisted on disk so they can boot non-interactively. This is a pre-req for sub-agent spawning + long-horizon agents. 
4. Parent agents provision children using their own `manage_projects` --> hierarchical relationships between agents are represented in the exchange. 

All four are validated end-to-end against the live Globus dev exchange by some spike scripts, so in theory this should work.  

This specific PR relates to point 3. @AK2000 already pushed a PR (#397) which persists credentials on disk for long-lived agents via the `python -m academy.run` path. This PR adds similar infrastructure: a storage convention for agent credentials, plus lookup and boot primitives. The flow `agent_id` -> `credentials_map` -> `re-launched agent` works today, but there is **no** user facing flow that exercises it yet (future PR). 

Identity mapping between agents and agent-credentials is done via UUID. `PersistentAgentCredentials.agent_id` carries the agents UUID. The store writes agents/{agent_id.uid}.json. The file path is the identity mapping. 


---

## Design decisions / thoughts

### Globus Groups as auth

Right now an agent is a thin layer on top of the user's identity. The user logs in, delegates a token, and the agent uses that token to access the exchange on the user's behalf. 

The idea is to make each agent its own [Globus Confidential Client](https://globus-sdk-python.readthedocs.io/en/stable/_modules/globus_sdk/services/auth/client/confidential_client.html), authenticating against the exchange via `client_credentials` OAuth grant. Once an agent is running under its own auth, the user's session is not required. The agent could run indefinitely, its credentials can be written to disk, and reloaded across restarts. 

We can also make an agent **spawn-capable** at its registration, which would (in this proposal) grant it the `manage_projects` capability, enabling it to mint creds for child agents. In this model a user is required to provision a parent-agent and the fleet of agents under that parent can grow without additional auth prompts. 

This all assumes that we move the auth model from per-agent scopes to fleet groups ([Globus Groups](https://www.globus.org/globus-groups-service)). Currently the exchange does this check: "does this token bear scope `agent_scope`", which requires a consent prompt per agent. With groups this becomes "is this agent a member of fleet group X?". So per-agent scopes are not required. 

The logic for this [already exists](https://github.com/academy-agents/academy/blob/056a898014a9a55d31765a036c8db5f2770fadbd/academy/exchange/cloud/authenticate.py#L196-L211), and authz check runs in the backend (look for group_memberships in the [backend](https://github.com/academy-agents/academy/blob/main/academy/exchange/cloud/backend.py#L283-L291)).  Its used for **explicit** mailbox sharing (e.g. a user chooses to share a mailbox with a group), so this proposal is to make this the default rather than opt-in, and to develop the wiring needed to manage fleet memberships.  

### Secondary wins

Relationship disambiguation on the exchange. As each agent has its own client credentials and authenticates as itself, we can resolve an agents `client_id` at the exchange. So, the exchange can now know which agent sent a message, and we can create attestation / provenance chains. You could enforce things like only a parent shutting down its child, only a fleet member invoking a fleet action, or rejecting a message whose claimed src doesn't match  the authenticated sender.

## Related Issues

- #45 — This PR's credential store is the foundation for the agent_id identity persistence that issue calls for 
- #324 — the plan set out here uses group-based authz for mailbox access, which is a step toward the narrower per-agent permission model.

## Changes
<!--- Check which of the following changes were made --->

- [ ] Breaking (backwards incompatible changes to public interfaces)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] Enhancement (non-breaking change or feature addition)
- [X] Refactor (internal code or design clean up)
- [ ] Documentation (no changes to the code)
- [X] Test (changes or additions to testing)
- [ ] Build (change to CI workflows or build processes)
- [ ] Package (changes to package metadata or dependency versions)

## Testing
<!--- Please describe the test ran to verify changes --->

New unit tests included in PR.

## Pull Request Checklist

Please confirm the PR meets the following requirements.
- [ ] Relevant tags are added based on the types of changes.
- [X] Code changes pass `pre-commit` (e.g., ruff, mypy, etc.).
- [X] Tests have been added to show the fix is effective or that the new feature works.
- [X] New and existing unit tests pass locally with the changes.
- [X] Docs have been updated and reviewed if relevant.
