### PR TITLE
Academy home helper for shared data directory

### DIFF
--- a/academy/exchange/cloud/login.py
+++ b/academy/exchange/cloud/login.py
@@ -19,6 +19,7 @@ from globus_sdk.login_flows import CommandLineLoginFlowManager
 
 from academy.exchange.cloud.scopes import AcademyExchangeScopes
 from academy.exchange.cloud.token_store import SafeSQLiteTokenStorage
+from academy.home import get_academy_home
 
 # Registered `Academy-Client Application` by alokvk2@uchicago.edu
 # For the sdk
@@ -59,7 +60,8 @@ def get_token_storage(
 
     Args:
         filepath: Name of the database file. If not provided, defaults to a
-            file in the Academy home directory specified by ACADEMY_HOME.
+            file in the Academy home directory resolved by
+            [`get_academy_home()`][academy.home.get_academy_home].
         namespace: Optional namespace to use within the database for
             partitioning token data.
 
@@ -67,12 +69,7 @@ def get_token_storage(
         Token storage.
     """
     if filepath is None:
-        default = os.path.join(
-            os.path.expanduser('~/local/share'),
-            _APP_NAME,
-        )
-        basepath = os.environ.get('ACADEMY_HOME', default=default)
-        filepath = os.path.join(basepath, _TOKENS_FILE)
+        filepath = get_academy_home() / _TOKENS_FILE
 
     filepath = pathlib.Path(filepath)
     filepath.parent.mkdir(parents=True, exist_ok=True)

--- a/academy/home.py
+++ b/academy/home.py
@@ -1,0 +1,20 @@
+"""Academy home directory resolution."""
+
+from __future__ import annotations
+
+import os
+import pathlib
+
+
+def get_academy_home() -> pathlib.Path:
+    """Resolve the Academy data directory.
+
+    Resolves the Academy data directory from the `ACADEMY_HOME`
+    environment variable if set, otherwise `~/local/share/academy`.
+    Callers are responsible for creating the directory as needed.
+
+    Returns:
+        Path to the Academy data directory.
+    """
+    default = pathlib.Path.home() / 'local' / 'share' / 'academy'
+    return pathlib.Path(os.environ.get('ACADEMY_HOME', default))

--- a/academy/logging/configs/jsonpool.py
+++ b/academy/logging/configs/jsonpool.py
@@ -1,10 +1,10 @@
 from __future__ import annotations
 
 import logging
-import pathlib
 import uuid
 from collections.abc import Callable
 
+from academy.home import get_academy_home
 from academy.logging.configs.base import LogConfig
 from academy.logging.helpers import JSONHandler
 
@@ -18,7 +18,8 @@ class JSONPoolLogging(LogConfig):
     human readability.
 
     Logs written by this configuration are stored in JSON format under
-    `~/local/share/academy/logs/`
+    `logs/` in the Academy home directory resolved by
+    [`get_academy_home()`][academy.home.get_academy_home].
 
     Under that directory, logs are first separated into directories by
     the (distributed) identity of the log configuration: logs configured
@@ -45,15 +46,7 @@ class JSONPoolLogging(LogConfig):
         # Home resolution is deferred until init_logging time because the path
         # can be different on every invocation as the config object is moved
         # between execution hosts.
-        path = (
-            pathlib.Path.home()
-            / 'local'
-            / 'share'
-            / 'academy'
-            / 'logs'
-            / self.uuid
-            / instance_id
-        )
+        path = get_academy_home() / 'logs' / self.uuid / instance_id
         path.parent.mkdir(parents=True, exist_ok=True)
 
         json_handler = JSONHandler(path.with_suffix('.jsonlog'))

--- a/tests/unit/home_test.py
+++ b/tests/unit/home_test.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+import os
+import pathlib
+from unittest import mock
+
+from academy.home import get_academy_home
+
+
+def test_get_academy_home_default(tmp_path: pathlib.Path) -> None:
+    env = {'HOME': str(tmp_path)}
+    with mock.patch.dict(os.environ, env, clear=True):
+        expected = tmp_path / 'local' / 'share' / 'academy'
+        assert get_academy_home() == expected
+
+
+def test_get_academy_home_env_override(tmp_path: pathlib.Path) -> None:
+    env = {'ACADEMY_HOME': str(tmp_path)}
+    with mock.patch.dict(os.environ, env):
+        assert get_academy_home() == tmp_path

--- a/tests/unit/logging_test.py
+++ b/tests/unit/logging_test.py
@@ -8,6 +8,7 @@ from unittest import mock
 
 import pytest
 
+from academy.home import get_academy_home
 from academy.logging.configs.base import LogConfig
 from academy.logging.configs.console import ConsoleLogging
 from academy.logging.configs.file import FileLogging
@@ -175,14 +176,7 @@ def test_logging_with_jsonpool() -> None:
         logger = logging.getLogger()
         logger.info('Test logging')
 
-        path = (
-            pathlib.Path.home()
-            / 'local'
-            / 'share'
-            / 'academy'
-            / 'logs'
-            / lc.uuid
-        )
+        path = get_academy_home() / 'logs' / lc.uuid
 
         files = list(path.iterdir())
         assert len(files) == 1, (


### PR DESCRIPTION
While brainstorming and developing out auth for the Globus exchange, a small path helper was included in https://github.com/academy-agents/academy/pull/416. This change pulls that helper out as a more general method for use across different modules, including logging and token storage.

## Changes

- [ ] Breaking (backwards incompatible changes to public interfaces)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] Enhancement (non-breaking change or feature addition)
- [X] Refactor (internal code or design clean up)
- [ ] Documentation (no changes to the code)
- [X] Test (changes or additions to testing)
- [ ] Build (change to CI workflows or build processes)
- [ ] Package (changes to package metadata or dependency versions)


## Pull Request Checklist

Please confirm the PR meets the following requirements.
- [X] Relevant tags are added based on the types of changes.
- [X] Code changes pass `pre-commit` (e.g., ruff, mypy, etc.).
- [X] Tests have been added to show the fix is effective or that the new feature works.
- [X] New and existing unit tests pass locally with the changes.
- [X] Docs have been updated and reviewed if relevant.
