### PR TITLE
Fix default Academy home directory

### DIFF
--- a/academy/home.py
+++ b/academy/home.py
@@ -10,11 +10,11 @@ def get_academy_home() -> pathlib.Path:
     """Resolve the Academy data directory.
 
     Resolves the Academy data directory from the `ACADEMY_HOME`
-    environment variable if set, otherwise `~/local/share/academy`.
+    environment variable if set, otherwise `~/.local/share/academy`.
     Callers are responsible for creating the directory as needed.
 
     Returns:
         Path to the Academy data directory.
     """
-    default = pathlib.Path.home() / 'local' / 'share' / 'academy'
+    default = pathlib.Path.home() / '.local' / 'share' / 'academy'
     return pathlib.Path(os.environ.get('ACADEMY_HOME', default))

--- a/tests/unit/home_test.py
+++ b/tests/unit/home_test.py
@@ -10,7 +10,7 @@ from academy.home import get_academy_home
 def test_get_academy_home_default(tmp_path: pathlib.Path) -> None:
     env = {'HOME': str(tmp_path)}
     with mock.patch.dict(os.environ, env, clear=True):
-        expected = tmp_path / 'local' / 'share' / 'academy'
+        expected = tmp_path / '.local' / 'share' / 'academy'
         assert get_academy_home() == expected
 
 


### PR DESCRIPTION
## Summary

Use the XDG-style `~/.local/share/academy` default instead of creating `~/local/share/academy`.

## Related Issues

- Closes #432

## Changes

- [ ] Breaking (backwards incompatible changes to public interfaces)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (non-breaking change or feature addition)
- [ ] Refactor (internal code or design clean up)
- [ ] Documentation (no changes to the code)
- [x] Test (changes or additions to testing)
- [ ] Build (change to CI workflows or build processes)
- [ ] Package (changes to package metadata or dependency versions)

## Testing

The focused unit tests, Ruff, Mypy, and codespell pass.

## Pull Request Checklist

Please confirm the PR meets the following requirements.
- [ ] Relevant tags are added based on the types of changes.
- [x] Code changes pass `pre-commit` (e.g., ruff, mypy, etc.).
- [x] Tests have been added to show the fix is effective or that the new feature works.
- [x] New and existing unit tests pass locally with the changes.
- [x] Docs have been updated and reviewed if relevant.
